### PR TITLE
Add a loader when posting a News (#208)

### DIFF
--- a/webapp/src/main/webapp/css/news.less
+++ b/webapp/src/main/webapp/css/news.less
@@ -525,9 +525,6 @@ i.uiIconBack:hover {
         justify-content: space-between;
       }
     }
-    #newsPost {
-      padding: 5px 12px;
-    }
     .draftSavingStatus {
       position: absolute;
       right: 24px;
@@ -609,7 +606,11 @@ i.uiIconBack:hover {
         }
 
         #newsPost {
-          padding: 10px 20px;
+          padding: 2px 12px;
+          color: #FFFFFF !important;
+          font-size: 15px;
+          letter-spacing: normal;
+          background-color: var(--allPagesSecondarySkinColor, #476a9c) !important;
         }
 
         #newsUpdateAndPost {
@@ -618,10 +619,6 @@ i.uiIconBack:hover {
           }
         }
       }
-    }
-
-    #newsPost {
-      padding: 5px 12px;
     }
 
     .draftSavingStatus {

--- a/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
+++ b/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
@@ -1,6 +1,5 @@
 <template>
   <div id="newsActivityComposer" class="newsComposer">
-
     <div class="newsComposerActions">
       <div class="newsFormButtons">
         <div class="newsFormLeftActions">
@@ -20,8 +19,11 @@
           <div class="newsDrafts">
             <exo-news-draft :space-id="spaceId" @draftSelected="onSelectDraft"/>
           </div>
-          <button id="newsPost" :disabled="postDisabled" class="btn btn-primary" @click="postNews"> {{ $t("news.composer.post") }}
-          </button>
+          <div class="VuetifyApp">
+            <v-app>
+              <v-btn id="newsPost" :loading="postingNews" :disabled="postDisabled || postingNews" elevation="0" class="btn btn-primary" @click="postNews">{{ $t("news.composer.post") }}</v-btn>
+            </v-app>
+          </div>
         </div>
         <div v-if="editMode" class="newsFormRightActions">
           <button id="newsEdit" :disabled="updateDisabled" class="btn btn-primary" @click.prevent="updateNews"> {{ $t("news.edit.update") }}
@@ -411,7 +413,6 @@ export default {
       }
 
       newsServices.saveNews(news).then((createdNews) => {
-        this.postingNews = false;
         let createdNewsActivity = null;
         if(createdNews.activities) {
           const createdNewsActivities = createdNews.activities.split(';')[0].split(':');


### PR DESCRIPTION
When the Post button is click to create a News, there is currently no indication that the News is being posted.

This changes displays a loader during the posting process.