### PR TITLE
Maint-26335: Fix latest news template never displays summary

### DIFF
--- a/webapp/src/main/webapp/WEB-INF/conf/news/application-templates/content-list-viewer/list/LatestNews.gtmpl
+++ b/webapp/src/main/webapp/WEB-INF/conf/news/application-templates/content-list-viewer/list/LatestNews.gtmpl
@@ -56,7 +56,7 @@
       Map<String, String> newsInfo = new HashMap();
       newsInfo.put("id", news.id);
       newsInfo.put("title", news.title);
-      if (!StringUtils.isEmpty(news.summary)){
+      if (StringUtils.isNotEmpty(news.summary)){
       newsInfo.put("body", news.summary);
       }else {
       newsInfo.put("body", news.body);

--- a/webapp/src/main/webapp/WEB-INF/conf/news/application-templates/content-list-viewer/list/LatestNews.gtmpl
+++ b/webapp/src/main/webapp/WEB-INF/conf/news/application-templates/content-list-viewer/list/LatestNews.gtmpl
@@ -16,6 +16,7 @@
   import java.util.*;
   import org.exoplatform.news.model.News;
   import org.htmlcleaner.HtmlCleaner;
+  import org.apache.commons.lang.StringUtils;
 
   SpaceService spaceService = CommonsUtils.getService(SpaceService.class);
   NewsService newsService = CommonsUtils.getService(NewsService.class);
@@ -55,7 +56,11 @@
       Map<String, String> newsInfo = new HashMap();
       newsInfo.put("id", news.id);
       newsInfo.put("title", news.title);
+      if (!StringUtils.isEmpty(news.summary)){
+      newsInfo.put("body", news.summary);
+      }else {
       newsInfo.put("body", news.body);
+      }
       newsInfo.put("illustrationURL", news.illustrationURL);
       newsInfo.put("url", news.url);
       newsInfos.add(newsInfo);


### PR DESCRIPTION
In latest News CLV, the displayed text under the title is always the content of the article.
The expected behaviour is that when the article contains a summary, the summary text is displayed in the CLV, if not we display the content.