### PR TITLE
MAINT-26434: Add intranet.properties to the list of translated files

### DIFF
--- a/translations.properties
+++ b/translations.properties
@@ -21,3 +21,4 @@
 baseDir=add-ons/news/
 
 News.properties=services/src/main/resources/locale/portlet/news/News_en.properties
+portal/intranet.properties=webapp/src/main/resources/locale/navigation/portal/intranet_en.properties


### PR DESCRIPTION
This fix is needed for eXo platform 5.3.x, to internationalize the navigation of News. The file is added to the global navigations in 6.0.x