### PR TITLE
when the news contains a single quote in the title the details are not displayed when the news is shared

### DIFF
--- a/webapp/src/main/webapp/WEB-INF/conf/news/nodetypes-templates/news/views/view1.gtmpl
+++ b/webapp/src/main/webapp/WEB-INF/conf/news/nodetypes-templates/news/views/view1.gtmpl
@@ -125,7 +125,7 @@
       activityId: '${activityId}',
       newsId: '${news.id}',
       news: {
-        title: '${newsTitle}',
+        title: "${newsTitle}",
         summary: `${newsSummary}`,
         pinned: ${news.pinned},
         body: `${newsBody}`,

--- a/webapp/src/main/webapp/groovy/news/webui/activity/UINewsFullActivity.gtmpl
+++ b/webapp/src/main/webapp/groovy/news/webui/activity/UINewsFullActivity.gtmpl
@@ -126,7 +126,7 @@
     labels: $labels,
     nodeNewsId: '${news.id}',
     news: {
-      title: '${newsTitle}',
+      title: "${newsTitle}",
       summary: `${newsSummary}`,
       body: `${newsBody}`,
       pinned: ${news.pinned},

--- a/webapp/src/main/webapp/groovy/news/webui/activity/UISharedNewsFullActivity.gtmpl
+++ b/webapp/src/main/webapp/groovy/news/webui/activity/UISharedNewsFullActivity.gtmpl
@@ -142,7 +142,7 @@ if (activity && news) {
     labels: $labels,
     nodeNewsId: '${news.id}',
      news: {
-       title: '${newsTitle}',
+       title: "${newsTitle}",
        summary: `${newsSummary}`,
        body: `${newsBody}`,
        pinned: ${news.pinned},


### PR DESCRIPTION
(cherry picked from commit 65ba40df6aa667ba49d4cdc5d8074fb623b1d68f)