### PR TITLE
Archived label is not well displayed correctly in news details page on mobile (#253)

### DIFF
--- a/webapp/src/main/webapp/css/news.less
+++ b/webapp/src/main/webapp/css/news.less
@@ -3463,6 +3463,9 @@ p.caption-title:after {
 }
 
 @media (max-width: 520px) {
+  .newsArchived{
+    padding: 21px;
+  }
   .caption-description {
     display: none;
   }


### PR DESCRIPTION
(cherry picked from commit d3dad48e675833a7d432c678ad906066ffc819bc)