### PR TITLE
MAINT-27665: Fix the inability to edit news.

### DIFF
--- a/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
+++ b/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
@@ -261,11 +261,6 @@ export default {
     }
   },
   created() {
-    if(this.newsId) {
-      this.initNewsComposerData(this.newsId);
-    } else {
-      this.initDone = true;
-    }
     newsServices.getSpaceById(this.spaceId).then(space => {
       this.currentSpace = space;
       this.displayFormTitle();
@@ -286,6 +281,12 @@ export default {
           if(message) {
             editor.setData(message);
             localStorage.removeItem('exo-activity-composer-message');
+          }
+        }).then(() => {
+          if(this.newsId) {
+            this.initNewsComposerData(this.newsId);
+          } else {
+            this.initDone = true;
           }
         });
       }

--- a/webapp/src/main/webapp/news-details/components/ExoNewsActivityEditComposer.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsActivityEditComposer.vue
@@ -18,6 +18,10 @@ export default {
       type: String,
       required: true
     },
+    spaceId: {
+      type: Number,
+      required: true
+    },
     activityId: {
       type: String,
       required: false,
@@ -31,7 +35,7 @@ export default {
   },
   computed: {
     editLink: function() {
-      return `${eXo.env.portal.context}/${eXo.env.portal.portalName}/news/editor?newsId=${this.newsId}&activityId=${this.activityId}`;
+      return `${eXo.env.portal.context}/${eXo.env.portal.portalName}/news/editor?spaceId=${this.spaceId}&newsId=${this.newsId}&activityId=${this.activityId}`;
     }
   }
 };

--- a/webapp/src/main/webapp/news-details/components/ExoNewsDetails.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsDetails.vue
@@ -19,7 +19,7 @@
             <exo-news-share-activity v-if="showShareButton" :news="news"></exo-news-share-activity>
           </div>
           <div class="newsDetailsIcons">
-            <exo-news-activity-edit-composer v-if="showEditButton" :news-id="newsId" :activity-id="activityId"></exo-news-activity-edit-composer>
+            <exo-news-activity-edit-composer v-if="showEditButton" :news-id="newsId" :space-id="spaceId" :activity-id="activityId"></exo-news-activity-edit-composer>
             <exo-news-pin-activity v-if="showPinInput" :news-id="newsId" :news-pinned="news.pinned" :news-archived="news.archived" :news-title="news.title"></exo-news-pin-activity>
           </div>
           <div class="news-top-information">
@@ -128,6 +128,7 @@ export default {
   },
   data() {
     return {
+      spaceId: null,
       showUpdateInfo: this.news.updatedDate  !== 'null' ,
       BYTES_IN_MB: 1048576,
       spaceDisplayName: this.news.spaceDisplayName,
@@ -137,6 +138,11 @@ export default {
     linkifiedSummary : function() {
       return newsServices.linkifyText(newsServices.escapeHTML(this.news.summary));
     }
+  },
+  created() {
+    newsServices.getNewsById(this.newsId).then(news => {
+      this.spaceId = news.spaceId;
+    });
   },
   mounted() {
     this.updateViewsCount();

--- a/webapp/src/main/webapp/news/components/NewsApp.vue
+++ b/webapp/src/main/webapp/news/components/NewsApp.vue
@@ -91,7 +91,7 @@
             </a>
             <div class="newsActions">
               <exo-news-archive v-if="news.canArchive" :news-id="news.newsId" :news-archived="news.archived" :news-title="news.title" :pinned="news.pinned" @refresh-news-list="fetchNews(false)"></exo-news-archive>
-              <exo-news-activity-edit-composer v-if="news.canEdit" :news-id="news.newsId" :activity-id="news.activityId" open-target="_blank"></exo-news-activity-edit-composer>
+              <exo-news-activity-edit-composer v-if="news.canEdit" :news-id="news.newsId" :space-id="news.spaceId" :activity-id="news.activityId" open-target="_blank"></exo-news-activity-edit-composer>
               <exo-news-share-activity :news="news" @newsShared="reloadNews(news.newsId)"></exo-news-share-activity>
             </div>
             <!-- The following bloc is needed in order to display the pin confirmation popup when acceding to news details from news app -->
@@ -261,6 +261,7 @@ export default {
           activities: item.activities,
           spaceAvatarUrl: item.spaceAvatarUrl,
           hiddenSpace: item.hiddenSpace,
+          spaceId: item.spaceId,
         });
       });
       if(append) {


### PR DESCRIPTION
The issue is: when clicking on edit News button after the load of the page a message is displayed as if the user does not have the permissions.
In previous fixes we added the function canUserCreateNews() which is related to security and which needs the pace id to check whether the user has the permissions to add/edit news or not. But for the edit the space id property isn't considered so i made sure to reconsider this property in order to fix this issue.