### PR TITLE
MAINT-27951_MAINT-27924: Open internal links in the same browser tab and the external ones in a news browser tab

### DIFF
--- a/webapp/src/main/webapp/groovy/news/webui/activity/UISharedNewsFullActivity.gtmpl
+++ b/webapp/src/main/webapp/groovy/news/webui/activity/UISharedNewsFullActivity.gtmpl
@@ -190,23 +190,23 @@ if (activity && news) {
       <div class="newsSpaceAndOwner">
         <div class="newsOwner">
           <div class="avatarCircle avatarUser">
-            <a href="$sharingUrl" target="_blank">
+            <a href="$sharingUrl">
               <img src="$sharerAvatar" class="avatar">
             </a>
           </div>
             <div class="userInfo">
-              <a href="$sharingUrl" target="_blank"> ${posterFullName} </a>
+              <a href="$sharingUrl"> ${posterFullName} </a>
             </div>
             <div class="createIn">
                 <span class="uiIconArrowRightMini uiIconLightGray"></span>
             </div>
               <div class="avatarSpace">
-                <a href="$urlSpaceShared" target="_blank">
+                <a href="$urlSpaceShared">
                   <img src="$ownerSpaceAvatar" class="avatar">
                 </a>
               </div>
                 <div class="spaceInfo">
-                  <a href="$urlSpaceShared" target="_blank"> ${spaceSharedName} </a>
+                  <a href="$urlSpaceShared"> ${spaceSharedName} </a>
                 </div>
              </div>
           </div>

--- a/webapp/src/main/webapp/news-details/components/ExoNewsDetails.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsDetails.vue
@@ -35,17 +35,17 @@
             <div :class="[showUpdateInfo ? 'news-update-details-header' : 'news-details-header']" class="news-header-content">
               <div :class="[ showUpdateInfo ? 'newsUpdateInfo' : '']">
                 <div class="activityAvatar avatarCircle">
-                  <a :href="news.authorProfileURL" target="_blank">
+                  <a :href="news.authorProfileURL">
                     <img :src="news.profileAvatarURL" class="avatar">
                   </a>
                 </div>
               </div>
               <div id="informationNews" class="newsInformation">
                 <div class="newsAuthor">
-                  <a :href="news.authorProfileURL" class="newsInformationValue newsAuthorName news-details-information" target="_blank"> {{ news.authorFullName }} </a>
+                  <a :href="news.authorProfileURL" class="newsInformationValue newsAuthorName news-details-information"> {{ news.authorFullName }} </a>
                   <span v-if="!news.hiddenSpace" class="newsInformationLabel"> {{ $t('news.activity.in') }} </span>
                   <div v-if="!news.hiddenSpace" class="newsSpace">
-                    <a :href="news.spaceUrl" class="newsInformationLabel news-details-information" target="_blank">{{ news.spaceDisplayName }}</a>
+                    <a :href="news.spaceUrl" class="newsInformationLabel news-details-information">{{ news.spaceDisplayName }}</a>
                   </div>
                   <span class="newsInformationValue newsPostedDate news-details-information">- {{ news.postedDate }}</span>
                 </div>
@@ -157,10 +157,13 @@ export default {
       };
       socialProfile.initUserProfilePopup('newsDetails', labels);
     });
-    const linkContentElements = document.querySelector('#newsDetails #newsBody a');
-    if (linkContentElements) {
-      linkContentElements.setAttribute('target', '_blank');
-    }
+    const linkContentElements = document.querySelectorAll('#newsDetails a');
+    linkContentElements.forEach(function(linkContentElement) {
+      if (linkContentElement && !linkContentElement.href.includes(`${eXo.env.portal.context}/${eXo.env.portal.portalName}`)) {
+        linkContentElement.setAttribute('target', '_blank');
+      }
+    });
+    
     if(this.showPinInput) {
       document.querySelector('#pinNewsActivity').style.display = '';
     }

--- a/webapp/src/main/webapp/news-details/components/ExoNewsShareActivity.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsShareActivity.vue
@@ -20,7 +20,7 @@
       </div>
       <div class="content">
         <div class="newsPreview">
-          <a :href="news.url" target="_blank">
+          <a :href="news.url">
             <img :src="newsIllustrationURL" class="newsItemIllustration"/>
           </a>
           <div class="newsItemContent">
@@ -28,7 +28,7 @@
               <h3>
                 <div class="previewNewsTitle">
                   <div>
-                    <a :href="news.url" target="_blank">{{ news.title }}
+                    <a :href="news.url">{{ news.title }}
                     </a>
                   </div>
                 </div>
@@ -36,14 +36,14 @@
             </div>
             <div class="newsInfo">
               <p class="newsOwner">
-                <a :href="news.authorProfileURL" target="_blank">
+                <a :href="news.authorProfileURL">
                   <img :src="news.profileAvatarURL">
                   <span>{{ news.authorFullName }}</span>
                 </a>
               </p>
               <i class="uiIconArrowNext"></i>
               <p class="newsSpace">
-                <a :href="news.spaceUrl" class="newsSpaceName" target="_blank">
+                <a :href="news.spaceUrl" class="newsSpaceName">
                   <img :src="news.spaceAvatarUrl">
                   <span>{{ news.spaceDisplayName }}</span>
                 </a>

--- a/webapp/src/main/webapp/news/components/NewsApp.vue
+++ b/webapp/src/main/webapp/news/components/NewsApp.vue
@@ -64,13 +64,13 @@
           </div>
           <div class="newsInfo">
             <div class="newsOwner">
-              <a :href="news.authorProfileURL" target="_blank">
+              <a :href="news.authorProfileURL">
                 <img :src="news.profileAvatarURL">
                 <span>{{ news.authorFullName }}</span>
               </a>
               <i v-if="!news.hiddenSpace" class="uiIconArrowNext"></i>
               <span v-if="!news.hiddenSpace" class="newsSpace">
-                <a :href="news.spaceUrl" class="newsSpaceName" target="_blank">
+                <a :href="news.spaceUrl" class="newsSpaceName">
                   <img :src="news.spaceAvatarUrl">
                   <span>{{ news.spaceDisplayName }}</span>
                 </a>

--- a/webapp/src/main/webapp/news/components/NewsSpacesSharedIn.vue
+++ b/webapp/src/main/webapp/news/components/NewsSpacesSharedIn.vue
@@ -22,7 +22,7 @@
               <img :src="act.spaceAvatar" :alt="act.spaceAvatar" class="avatarMini">
               {{ act.spaceDisplayName }}
             </span>
-            <a :href="act.activityUrl" type="button" class="btn" target="_blank">{{ $t('news.app.viewArticle') }}</a>
+            <a :href="act.activityUrl" type="button" class="btn">{{ $t('news.app.viewArticle') }}</a>
             <br>
           </div>
         </div>


### PR DESCRIPTION
- Internal links inside or outside the news body should be opened in the same browser tab
- External links inside the news body should be opened in a new browser tab