### PR TITLE
MAINT-27977: Remove platform/administrators permission from newly created space news folder

### DIFF
--- a/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
@@ -836,7 +836,6 @@ public class NewsServiceImpl implements NewsService {
         spaceNewsRootNode.addMixin("exo:privilegeable");
       }
       Map<String, String[]> permissions = new HashMap<>();
-      permissions.put("*:/platform/administrators", PermissionType.ALL);
       permissions.put("*:" + space.getGroupId(), PermissionType.ALL);
       ((ExtendedNode) spaceNewsRootNode).setPermissions(permissions);
 


### PR DESCRIPTION
Don't allow administrators to see posted news posted only if they are members of the related spaces or if the news are pinned