### PR TITLE
MAINT-27977: Remove platform/administrators permission from old created space news folder

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
   <modules>
     <module>services</module>
     <module>webapp</module>
+    <module>upgrade-plugin</module>
     <module>packaging</module>
   </modules>
 

--- a/upgrade-plugin/pom.xml
+++ b/upgrade-plugin/pom.xml
@@ -14,15 +14,11 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.exoplatform.addons.upgrade</groupId>
-    <artifactId>upgrade</artifactId>
-    <version>5.3.x-SNAPSHOT</version>
-<parent>
     <artifactId>news</artifactId>
     <groupId>org.exoplatform.addons.news</groupId>
     <version>1.1.x-SNAPSHOT</version>
   </parent>
-
+  
   <artifactId>news-upgrade-plugin</artifactId>
   <packaging>jar</packaging>
   <name>eXo Add-on :: NEWS Add-on Upgrade Plugin</name>

--- a/upgrade-plugin/pom.xml
+++ b/upgrade-plugin/pom.xml
@@ -1,0 +1,72 @@
+<!-- Copyright (C) 2009 eXo Platform SAS. This is free software; you can 
+  redistribute it and/or modify it under the terms of the GNU Lesser General 
+  Public License as published by the Free Software Foundation; either version 
+  2.1 of the License, or (at your option) any later version. This software 
+  is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; 
+  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
+  PURPOSE. See the GNU Lesser General Public License for more details. You 
+  should have received a copy of the GNU Lesser General Public License along 
+  with this software; if not, write to the Free Software Foundation, Inc., 
+  51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA, or see the FSF site: 
+  http://www.fsf.org. -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.exoplatform.addons.upgrade</groupId>
+    <artifactId>upgrade</artifactId>
+    <version>5.3.x-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>data-upgrade-news</artifactId>
+  <packaging>jar</packaging>
+  <name>eXo Add-on:: Data Upgrade Add-on - NEWS</name>
+
+  <properties>
+    <exo.test.coverage.ratio>0.77</exo.test.coverage.ratio>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.exoplatform.jcr</groupId>
+      <artifactId>exo.jcr.component.ext</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.exoplatform.commons</groupId>
+      <artifactId>commons-component-upgrade</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.exoplatform.ecms</groupId>
+      <artifactId>ecms-core-services</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/upgrade-plugin/pom.xml
+++ b/upgrade-plugin/pom.xml
@@ -17,11 +17,15 @@
     <groupId>org.exoplatform.addons.upgrade</groupId>
     <artifactId>upgrade</artifactId>
     <version>5.3.x-SNAPSHOT</version>
+<parent>
+    <artifactId>news</artifactId>
+    <groupId>org.exoplatform.addons.news</groupId>
+    <version>1.1.x-SNAPSHOT</version>
   </parent>
 
-  <artifactId>data-upgrade-news</artifactId>
+  <artifactId>news-upgrade-plugin</artifactId>
   <packaging>jar</packaging>
-  <name>eXo Add-on:: Data Upgrade Add-on - NEWS</name>
+  <name>eXo Add-on :: NEWS Add-on Upgrade Plugin</name>
 
   <properties>
     <exo.test.coverage.ratio>0.77</exo.test.coverage.ratio>

--- a/upgrade-plugin/src/main/java/org/exoplatform/news/upgrade/jcr/NewsJcrNodePermissionsUpgradePlugin.java
+++ b/upgrade-plugin/src/main/java/org/exoplatform/news/upgrade/jcr/NewsJcrNodePermissionsUpgradePlugin.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2003-2020 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.exoplatform.news.upgrade.jcr;
+
+import javax.jcr.Node;
+import javax.jcr.NodeIterator;
+import javax.jcr.Session;
+
+import org.exoplatform.commons.upgrade.UpgradeProductPlugin;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.services.cms.BasePath;
+import org.exoplatform.services.jcr.RepositoryService;
+import org.exoplatform.services.jcr.core.ExtendedNode;
+import org.exoplatform.services.jcr.ext.app.SessionProviderService;
+import org.exoplatform.services.jcr.ext.common.SessionProvider;
+import org.exoplatform.services.jcr.ext.hierarchy.NodeHierarchyCreator;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+
+/**
+ * Created by The eXo Platform SAS Author : Ayoub Zayati Sept 14, 2020 This
+ * plugin will be executed in order to remove administrators permission from
+ * each space news folder
+ */
+public class NewsJcrNodePermissionsUpgradePlugin extends UpgradeProductPlugin {
+
+  private static final Log       log                     = ExoLogger.getLogger(NewsJcrNodePermissionsUpgradePlugin.class.getName());
+
+  private NodeHierarchyCreator   nodeHierarchyCreator;
+
+  private RepositoryService      repositoryService;
+
+  private SessionProviderService sessionProviderService;
+
+  private int                    newsJcrNodesUpdatedCount;
+
+  public static final String     NEWS_NODES_FOLDER       = "News";
+
+  public static final String     ADMINISTRATORS_IDENTITY = "*:/platform/administrators";
+
+  public NewsJcrNodePermissionsUpgradePlugin(InitParams initParams,
+                                             NodeHierarchyCreator nodeHierarchyCreator,
+                                             RepositoryService repositoryService,
+                                             SessionProviderService sessionProviderService) {
+    super(initParams);
+    this.nodeHierarchyCreator = nodeHierarchyCreator;
+    this.repositoryService = repositoryService;
+    this.sessionProviderService = sessionProviderService;
+  }
+
+  @Override
+  public void processUpgrade(String oldVersion, String newVersion) {
+    long startupTime = System.currentTimeMillis();
+    log.info("Start upgrade of news jcr nodes");
+
+    SessionProvider sessionProvider = null;
+    try {
+      sessionProvider = sessionProviderService.getSystemSessionProvider(null);
+      Session session = sessionProvider.getSession(
+                                                   repositoryService.getCurrentRepository()
+                                                                    .getConfiguration()
+                                                                    .getDefaultWorkspaceName(),
+                                                   repositoryService.getCurrentRepository());
+
+      String spacesNodePath = nodeHierarchyCreator.getJcrPath(BasePath.CMS_GROUPS_PATH) + "/spaces";
+      Node spacesRootNode = (Node) session.getItem(spacesNodePath);
+      NodeIterator iter = spacesRootNode.getNodes();
+      while (iter.hasNext()) {
+        Node spaceNode = iter.nextNode();
+        if (spaceNode.hasNode(NEWS_NODES_FOLDER)) {
+          Node spaceNewsRootNode = spaceNode.getNode(NEWS_NODES_FOLDER);
+          ((ExtendedNode) spaceNewsRootNode).removePermission(ADMINISTRATORS_IDENTITY);
+          spaceNewsRootNode.save();
+          newsJcrNodesUpdatedCount ++;
+        }
+      }
+      log.info("End upgrade of '{}' news jcr nodes. It took {} ms",
+               newsJcrNodesUpdatedCount,
+               (System.currentTimeMillis() - startupTime));
+    } catch (Exception e) {
+      if (log.isErrorEnabled()) {
+        log.error("An unexpected error occurs when migrating news jcr node permissions:", e);
+      }
+    } finally {
+      if (sessionProvider != null) {
+        sessionProvider.close();
+      }
+    }
+  }
+  
+  /**
+   * @return the newsJcrNodesUpdatedCount
+   */
+  public int getNewsJcrNodesUpdatedCount() {
+    return newsJcrNodesUpdatedCount;
+  }
+
+}

--- a/upgrade-plugin/src/main/resources/conf/portal/configuration.xml
+++ b/upgrade-plugin/src/main/resources/conf/portal/configuration.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright (C) 2003-2011 eXo Platform SAS. This program is free software: 
+  you can redistribute it and/or modify it under the terms of the GNU Affero 
+  General Public License as published by the Free Software Foundation, either 
+  version 3 of the License, or (at your option) any later version. This program 
+  is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; 
+  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
+  PURPOSE. See the GNU Affero General Public License for more details. You 
+  should have received a copy of the GNU Affero General Public License along 
+  with this program. If not, see <http://www.gnu.org/licenses/>. -->
+
+<configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd http://www.exoplatform.org/xml/ns/kernel_1_2.xsd"
+  xmlns="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd">
+
+  <external-component-plugins>
+    <target-component>org.exoplatform.commons.upgrade.UpgradeProductService</target-component>
+    <component-plugin profiles="news">
+      <name>NewsJcrNodePermissionsUpgradePlugin</name>
+      <set-method>addUpgradePlugin</set-method>
+      <type>org.exoplatform.news.upgrade.jcr.NewsJcrNodePermissionsUpgradePlugin</type>
+      <description>Remove administrators permission from each space news folder</description>
+      <init-params>
+        <value-param>
+          <name>product.group.id</name>
+          <description>The groupId of the product</description>
+          <value>org.exoplatform.ecms</value>
+        </value-param>
+        <value-param>
+          <name>plugin.execution.order</name>
+          <description>The plugin execution order</description>
+          <value>1</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.execute.once</name>
+          <description>Execute this upgrade plugin only once</description>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.async.execution</name>
+          <description>The plugin will be executed in an asynchronous mode</description>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.target.version</name>
+          <description>Target version of the plugin</description>
+          <value>6.0.0</value>
+        </value-param>
+      </init-params>
+    </component-plugin>
+  </external-component-plugins>
+</configuration>
+

--- a/upgrade-plugin/src/main/resources/conf/portal/configuration.xml
+++ b/upgrade-plugin/src/main/resources/conf/portal/configuration.xml
@@ -44,7 +44,7 @@
         <value-param>
           <name>plugin.upgrade.target.version</name>
           <description>Target version of the plugin</description>
-          <value>6.0.0</value>
+          <value>5.3.5</value>
         </value-param>
       </init-params>
     </component-plugin>

--- a/upgrade-plugin/src/main/resources/conf/portal/configuration.xml
+++ b/upgrade-plugin/src/main/resources/conf/portal/configuration.xml
@@ -44,7 +44,7 @@
         <value-param>
           <name>plugin.upgrade.target.version</name>
           <description>Target version of the plugin</description>
-          <value>5.3.5</value>
+          <value>5.3.6</value>
         </value-param>
       </init-params>
     </component-plugin>

--- a/upgrade-plugin/src/main/resources/conf/portal/configuration.xml
+++ b/upgrade-plugin/src/main/resources/conf/portal/configuration.xml
@@ -15,7 +15,7 @@
 
   <external-component-plugins>
     <target-component>org.exoplatform.commons.upgrade.UpgradeProductService</target-component>
-    <component-plugin profiles="news">
+    <component-plugin>
       <name>NewsJcrNodePermissionsUpgradePlugin</name>
       <set-method>addUpgradePlugin</set-method>
       <type>org.exoplatform.news.upgrade.jcr.NewsJcrNodePermissionsUpgradePlugin</type>

--- a/upgrade-plugin/src/test/java/org/exoplatform/news/upgrade/jcr/NewsJcrNodePermissionsUpgradePluginTest.java
+++ b/upgrade-plugin/src/test/java/org/exoplatform/news/upgrade/jcr/NewsJcrNodePermissionsUpgradePluginTest.java
@@ -1,0 +1,89 @@
+package org.exoplatform.news.upgrade.jcr;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.*;
+
+import javax.jcr.Node;
+import javax.jcr.NodeIterator;
+import javax.jcr.Session;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.container.xml.ValueParam;
+import org.exoplatform.services.cms.BasePath;
+import org.exoplatform.services.jcr.RepositoryService;
+import org.exoplatform.services.jcr.access.PermissionType;
+import org.exoplatform.services.jcr.config.RepositoryEntry;
+import org.exoplatform.services.jcr.core.ExtendedNode;
+import org.exoplatform.services.jcr.core.ManageableRepository;
+import org.exoplatform.services.jcr.ext.app.SessionProviderService;
+import org.exoplatform.services.jcr.ext.common.SessionProvider;
+import org.exoplatform.services.jcr.ext.hierarchy.NodeHierarchyCreator;
+
+@RunWith(PowerMockRunner.class)
+public class NewsJcrNodePermissionsUpgradePluginTest {
+
+  @Mock
+  NodeHierarchyCreator   nodeHierarchyCreator;
+  
+  @Mock
+  RepositoryService      repositoryService;
+  
+  @Mock
+  SessionProviderService sessionProviderService;
+
+  @Mock
+  ManageableRepository   repository;
+
+  @Mock
+  RepositoryEntry        repositoryEntry;
+
+  @Mock
+  SessionProvider        sessionProvider;
+  
+  @Mock
+  Session                session;
+
+  @Mock
+  NodeIterator           nodeIterator;
+
+  @Test
+  public void testNewsJcrNodeMigration() throws Exception {
+    InitParams initParams = new InitParams();
+
+    ValueParam valueParam = new ValueParam();
+    valueParam.setName("product.group.id");
+    valueParam.setValue("org.exoplatform.addons.news");
+    initParams.addParameter(valueParam);
+
+    when(sessionProviderService.getSystemSessionProvider(any())).thenReturn(sessionProvider);
+    when(repositoryService.getCurrentRepository()).thenReturn(repository);
+    when(repository.getConfiguration()).thenReturn(repositoryEntry);
+    when(repositoryEntry.getDefaultWorkspaceName()).thenReturn("collaboration");
+    when(sessionProvider.getSession(any(), any())).thenReturn(session);
+    when(nodeHierarchyCreator.getJcrPath(anyString())).thenReturn(BasePath.CMS_GROUPS_PATH);
+    Node spacesRootNode = mock(Node.class);
+    when((Node)session.getItem(anyString())).thenReturn(spacesRootNode);
+    when(spacesRootNode.getNodes()).thenReturn(nodeIterator);
+    when(nodeIterator.hasNext()).thenReturn(true, true, false);
+    Node spaceNode = mock(Node.class);
+    when(nodeIterator.nextNode()).thenReturn(spaceNode);
+    when(spaceNode.hasNode(NewsJcrNodePermissionsUpgradePlugin.NEWS_NODES_FOLDER)).thenReturn(true);
+    ExtendedNode spaceNewsExtendedRootNode = mock(ExtendedNode.class);
+    when(spaceNode.getNode(NewsJcrNodePermissionsUpgradePlugin.NEWS_NODES_FOLDER)).thenReturn(spaceNewsExtendedRootNode);
+    spaceNewsExtendedRootNode.setPermission(NewsJcrNodePermissionsUpgradePlugin.ADMINISTRATORS_IDENTITY, PermissionType.ALL);
+    NewsJcrNodePermissionsUpgradePlugin newsJcrNodePermissionsUpgradePlugin = new NewsJcrNodePermissionsUpgradePlugin(initParams,
+                                                                                                                      nodeHierarchyCreator,
+                                                                                                                      repositoryService,
+                                                                                                                      sessionProviderService);
+    newsJcrNodePermissionsUpgradePlugin.processUpgrade(null, null);
+    verify(spaceNewsExtendedRootNode, times(2)).save();
+    assertEquals(2, newsJcrNodePermissionsUpgradePlugin.getNewsJcrNodesUpdatedCount());
+  }
+}


### PR DESCRIPTION
This Backport in needed to apply [patch](https://github.com/exoplatform/news/pull/42) on eXo 5.3.x