### PR TITLE
Task-39856 : XSS issue in news content

### DIFF
--- a/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
@@ -21,6 +21,7 @@ import org.exoplatform.commons.api.search.data.SearchResult;
 import org.exoplatform.commons.notification.impl.NotificationContextImpl;
 import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.commons.utils.HTMLEntityEncoder;
+import org.exoplatform.commons.utils.HTMLSanitizer;
 import org.exoplatform.container.PortalContainer;
 import org.exoplatform.ecm.jcr.model.VersionNode;
 import org.exoplatform.ecm.utils.text.Text;
@@ -658,7 +659,7 @@ public class NewsServiceImpl implements NewsService {
 
     news.setTitle(getStringProperty(node, "exo:title"));
     news.setSummary(getStringProperty(node, "exo:summary"));
-    news.setBody(formatMention(getStringProperty(node, "exo:body")));
+    news.setBody(formatMention(HTMLSanitizer.sanitize(getStringProperty(node, "exo:body"))));
     news.setAuthor(getStringProperty(node, "exo:author"));
     news.setCanArchive(canArchiveNews(news.getAuthor()));
     news.setCreationDate(getDateProperty(node, "exo:dateCreated"));

--- a/services/src/test/java/org/exoplatform/news/NewsServiceImplTest.java
+++ b/services/src/test/java/org/exoplatform/news/NewsServiceImplTest.java
@@ -2975,4 +2975,43 @@ public class NewsServiceImplTest {
     //Then
     assertEquals("test mention user in news <a href=\"http://exoplatfom.com/profile/john\">john john</a> ", article);
   }
+  
+  
+  @Test
+  public void testHTMLSanitization() throws Exception {
+    NewsServiceImpl newsService = new NewsServiceImpl(repositoryService,
+                                                      sessionProviderService,
+                                                      nodeHierarchyCreator,
+                                                      dataDistributionManager,
+                                                      spaceService,
+                                                      activityManager,
+                                                      identityManager,
+                                                      uploadService,
+                                                      imageProcessor,
+                                                      linkManager,
+                                                      publicationServiceImpl,
+                                                      publicationManagerImpl,
+                                                      wcmPublicationServiceImpl,
+                                                      newsSearchConnector,
+                                                      newsAttachmentsService);
+  
+    Node newsNode = mock(Node.class);
+    when(newsNode.hasProperty(anyString())).thenReturn(true);
+    when(newsNode.hasProperty(eq("jcr:frozenUuid"))).thenReturn(false);
+    when(newsNode.hasProperty(eq("exo:dateCreated"))).thenReturn(false);
+    when(newsNode.hasProperty(eq("exo:dateModified"))).thenReturn(false);
+    when(newsNode.hasProperty(eq("exo:activities"))).thenReturn(false);
+  
+    Property property = mock(Property.class);
+    when(property.getString()).thenReturn("propertyValue");
+  
+    Property propertyBody = mock(Property.class);
+    when(propertyBody.getString()).thenReturn("body <img='#' onerror=alert('test')/>");
+    when(newsNode.getProperty(anyString())).thenReturn(property);
+    when(newsNode.getProperty(eq("exo:body"))).thenReturn(propertyBody);
+    
+    
+    assertFalse(newsService.convertNodeToNews(newsNode).getBody().contains("<img"));
+    
+  }
 }


### PR DESCRIPTION
Before this fix a stored XSS issue can occur in new content.
This fix sanitize the html content before displaying it.