### PR TITLE
MAINT-40063 : fix news formatMention when no text after @ char (#63)

### DIFF
--- a/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
@@ -1205,11 +1205,15 @@ public class NewsServiceImpl implements NewsService {
       if (next.length() == 0) {
         continue;
       } else if (next.contains("@")) {
-        String username = next.split("@")[1];
-        org.exoplatform.social.core.identity.model.Identity identity = loadUser(username);
-        if (identity != null) {
-          next = next.split("@")[0] + "<a href=\"" + CommonsUtils.getCurrentDomain() + identity.getProfile().getUrl() + "\">"
-                  + encoder.encodeHTML(identity.getProfile().getFullName()) + "</a>";
+        String username = "";
+        String[] splitTable = next.split("@");
+        if (splitTable.length > 1) {
+          username = splitTable[1];
+          org.exoplatform.social.core.identity.model.Identity identity = loadUser(username);
+          if (identity != null) {
+            next = splitTable[0] + "<a href=\"" + CommonsUtils.getCurrentDomain() + identity.getProfile().getUrl() + "\">"
+                    + encoder.encodeHTML(identity.getProfile().getFullName()) + "</a>";
+          }
         }
       }
       sb.append(next);

--- a/services/src/test/java/org/exoplatform/news/NewsServiceImplTest.java
+++ b/services/src/test/java/org/exoplatform/news/NewsServiceImplTest.java
@@ -2975,8 +2975,39 @@ public class NewsServiceImplTest {
     //Then
     assertEquals("test mention user in news <a href=\"http://exoplatfom.com/profile/john\">john john</a> ", article);
   }
-  
-  
+  @Test
+  public void testWrongFormatMention() throws Exception {
+    //Given
+    NewsServiceImpl newsServiceImpl = new NewsServiceImpl(repositoryService,
+            sessionProviderService,
+            nodeHierarchyCreator,
+            dataDistributionManager,
+            spaceService,
+            activityManager,
+            identityManager,
+            uploadService,
+            imageProcessor,
+            linkManager,
+            publicationServiceImpl,
+            publicationManagerImpl,
+            wcmPublicationServiceImpl,
+            newsSearchConnector,
+            newsAttachmentsService);
+    Identity posterIdentity = new Identity(OrganizationIdentityProvider.NAME, "john");
+    Profile profile = posterIdentity.getProfile();
+    profile.setUrl("/profile/john");
+    profile.setProperty("fullName", "john john");
+    when(identityManager.getOrCreateIdentity(eq(OrganizationIdentityProvider.NAME),
+            eq("john"),
+            anyBoolean())).thenReturn(posterIdentity);
+    PowerMockito.mockStatic(CommonsUtils.class);
+    PowerMockito.when(CommonsUtils.getCurrentDomain()).thenReturn("http://exoplatfom.com");
+
+    //When
+    String article = newsServiceImpl.formatMention("test mention user in news @ john");
+    //Then
+    assertEquals("test mention user in news @ john ", article);
+  }
   @Test
   public void testHTMLSanitization() throws Exception {
     NewsServiceImpl newsService = new NewsServiceImpl(repositoryService,


### PR DESCRIPTION
* MAINT-40063:fix news formatMention when no text after @ char

* Update services/src/main/java/org/exoplatform/news/NewsServiceImpl.java

Co-authored-by: Ali HAMDI <ahamdi@exoplatform.com>

Co-authored-by: Ali HAMDI <ahamdi@exoplatform.com>
(cherry picked from commit 137af86eb67bb9a40e051b4f841797d130f4d751)