### PR TITLE
TASK-40065: Image inserted in news body are now displayed in the details view

### DIFF
--- a/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
@@ -15,6 +15,7 @@ import javax.jcr.query.Query;
 import javax.jcr.query.QueryManager;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.exoplatform.commons.api.notification.NotificationContext;
 import org.exoplatform.commons.api.notification.model.PluginKey;
@@ -22,7 +23,6 @@ import org.exoplatform.commons.api.search.data.SearchContext;
 import org.exoplatform.commons.api.search.data.SearchResult;
 import org.exoplatform.commons.notification.impl.NotificationContextImpl;
 import org.exoplatform.commons.utils.CommonsUtils;
-import org.exoplatform.commons.utils.HTMLEntityEncoder;
 import org.exoplatform.commons.utils.HTMLSanitizer;
 import org.exoplatform.container.PortalContainer;
 import org.exoplatform.ecm.jcr.model.VersionNode;
@@ -688,6 +688,7 @@ public class NewsServiceImpl implements NewsService {
     news.setSummary(getStringProperty(node, "exo:summary"));
     String body = getStringProperty(node, "exo:body");
     String sanitizedBody = HTMLSanitizer.sanitize(body);
+    sanitizedBody = StringEscapeUtils.unescapeHtml(sanitizedBody);
     sanitizedBody = sanitizedBody.replaceAll(HTML_AT_SYMBOL_ESCAPED_PATTERN, HTML_AT_SYMBOL_PATTERN);
     news.setBody(substituteUsernames(portalOwner, sanitizedBody));
     news.setAuthor(getStringProperty(node, "exo:author"));

--- a/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
@@ -351,18 +351,17 @@ public class NewsServiceImpl implements NewsService {
 
         if ("published".equals(news.getPublicationState())) {
           publicationService.changeState(newsNode, "published", new HashMap<>());
-        }
-
-        //if it's an "update news" case
-        if (StringUtils.isNotEmpty(news.getId()) && news.getCreationDate() != null) {
-          News newMentionedNews = news;
-          if (!previousMentions.isEmpty()) {
-            //clear old mentions from news body before sending a custom object to notification context.
-            previousMentions.forEach(username -> {
-              newMentionedNews.setBody(newMentionedNews.getBody().replaceAll("@"+username, ""));
-            });
+          //if it's an "update news" case
+          if (StringUtils.isNotEmpty(news.getId()) && news.getCreationDate() != null) {
+            News newMentionedNews = news;
+            if (!previousMentions.isEmpty()) {
+              //clear old mentions from news body before sending a custom object to notification context.
+              previousMentions.forEach(username -> {
+                newMentionedNews.setBody(newMentionedNews.getBody().replaceAll("@"+username, ""));
+              });
+            }
+            sendNotification(newMentionedNews, NotificationConstants.NOTIFICATION_CONTEXT.MENTION_IN_NEWS);
           }
-          sendNotification(newMentionedNews, NotificationConstants.NOTIFICATION_CONTEXT.MENTION_IN_NEWS);
         }
       }
 

--- a/services/src/main/java/org/exoplatform/news/NewsUtils.java
+++ b/services/src/main/java/org/exoplatform/news/NewsUtils.java
@@ -18,33 +18,6 @@ import java.util.regex.Matcher;
 
 public class NewsUtils {
   /**
-   * Processes Mentioners who has been mentioned via the news body.
-   *
-   * @param body
-   * @return set of mentioned users
-   */
-  public static Set<String> processMentions(String body) {
-    if (StringUtils.isEmpty(body)) {
-      return Collections.emptySet();
-    }
-
-    Set<String> mentions = new HashSet<>();
-    Matcher matcher = MentionInNewsNotificationPlugin.MENTION_PATTERN.matcher(body);
-    while (matcher.find()) {
-      String remoteId = matcher.group().substring(1);
-      if (mentions.contains(remoteId)) {
-        continue;
-      }
-      Identity identity = loadUser(remoteId);
-      // if not the right mention then ignore
-      if (identity != null) {
-        mentions.add(identity.getRemoteId());
-      }
-    }
-    return mentions;
-  }
-
-  /**
    * Load the user identity
    *
    * @param username

--- a/services/src/test/java/org/exoplatform/news/NewsServiceImplTest.java
+++ b/services/src/test/java/org/exoplatform/news/NewsServiceImplTest.java
@@ -2913,14 +2913,24 @@ public class NewsServiceImplTest {
     when(imageProcessor.processImages(anyString(), any(), anyString())).thenAnswer(i -> i.getArguments()[0]);
     Workspace workSpace = mock(Workspace.class);
     when(session.getWorkspace()).thenReturn(workSpace);
+    Identity johnIdentity = new Identity(OrganizationIdentityProvider.NAME, "john");
+    Profile profile = johnIdentity.getProfile();
+    profile.setUrl("/profile/john");
+    profile.setProperty("fullName", "john john");
+    Set<String> mentionedIds = new HashSet(Collections.singleton("john"));
+    when(identityManager.getOrCreateIdentity(eq(OrganizationIdentityProvider.NAME), eq("john"))).thenReturn(johnIdentity);
+    PowerMockito.mockStatic(CommonsUtils.class);
+    when(CommonsUtils.getService(IdentityManager.class)).thenReturn(identityManager);
+
     News news = new News();
-    news.setTitle("update title");
-    news.setSummary("Updated summary");
-    news.setBody("Updated body");
+    news.setTitle("title");
+    news.setSummary("summary");
+    news.setBody("body <img alt=\"\" class=\"pull-left\" data-plugin-name=\"selectImage\" referrerpolicy=\"no-referrer\" src=\"/portal/rest/composer/image/thumbnail?uploadId=88b5af9\">");
     news.setUploadId(null);
     news.setViewsCount((long) 10);
     // when
-    newsService.updateNews(news);
+    news.setBody("Updated body @john <img alt=\"\" class=\"pull-left\" data-plugin-name=\"selectImage\" referrerpolicy=\"no-referrer\" src=\"/portal/rest/composer/image/thumbnail?uploadId=88b5af9\">");
+    News updatedNews = newsService.updateNews(news);
     // then
     verify(workSpace, times(1)).move(any(), any());
     verify(newsNode, times(1)).save();
@@ -3058,6 +3068,8 @@ public class NewsServiceImplTest {
     news.setCreationDate(new Date());
     news.setUploadId(null);
     news.setViewsCount((long) 10);
+    news.setPublicationState("published");
+    news.setPublicationDate(Calendar.getInstance().getTime());
 
     // when
     newsService.updateNews(news);

--- a/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
+++ b/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
@@ -495,11 +495,12 @@ export default {
 
       this.news.body = newsServices.linkifyHTML(this.news.body, 'newsContent');
       this.news.body = this.replaceImagesURLs(this.news.body);
+      const newsBody = this.replaceImagesURLs(this.getBody());
       const news = {
         id: this.news.id,
         title: this.news.title,
         summary: this.news.summary,
-        body: this.getBody() ? this.getBody() : this.news.body,
+        body: this.getBody() ? newsBody : this.news.body,
         author: eXo.env.portal.userName,
         attachments: this.news.attachments,
         pinned: this.news.pinned,
@@ -683,11 +684,12 @@ export default {
     },
     doUpdateNews: function () {
       this.news.body = newsServices.linkifyHTML(this.news.body, 'newsContent');
+      const newsBody = this.replaceImagesURLs(this.getBody());
       const updatedNews = {
         id: this.news.id,
         title: this.news.title,
         summary: this.news.summary != null ? this.news.summary : '',
-        body: this.getBody() ? this.getBody() : this.news.body,
+        body: this.getBody() ? newsBody : this.news.body,
         attachments: this.news.attachments,
         pinned: this.news.pinned,
         publicationState: 'published'


### PR DESCRIPTION
Problem: the source of the image in the sanitized body was different from the real source.
How it was solved: by applying the unescapeHtml method to recover the original source image.