### PR TITLE
40065 : Image lost after posting news

### DIFF
--- a/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
@@ -15,6 +15,7 @@ import javax.jcr.query.Query;
 import javax.jcr.query.QueryManager;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.exoplatform.commons.api.notification.NotificationContext;
 import org.exoplatform.commons.api.notification.model.PluginKey;
@@ -22,7 +23,6 @@ import org.exoplatform.commons.api.search.data.SearchContext;
 import org.exoplatform.commons.api.search.data.SearchResult;
 import org.exoplatform.commons.notification.impl.NotificationContextImpl;
 import org.exoplatform.commons.utils.CommonsUtils;
-import org.exoplatform.commons.utils.HTMLEntityEncoder;
 import org.exoplatform.commons.utils.HTMLSanitizer;
 import org.exoplatform.container.PortalContainer;
 import org.exoplatform.ecm.jcr.model.VersionNode;
@@ -688,6 +688,7 @@ public class NewsServiceImpl implements NewsService {
     news.setSummary(getStringProperty(node, "exo:summary"));
     String body = getStringProperty(node, "exo:body");
     String sanitizedBody = HTMLSanitizer.sanitize(body);
+    sanitizedBody = StringEscapeUtils.unescapeHtml(sanitizedBody);
     sanitizedBody = sanitizedBody.replaceAll(HTML_AT_SYMBOL_ESCAPED_PATTERN, HTML_AT_SYMBOL_PATTERN);
     news.setBody(substituteUsernames(portalOwner, sanitizedBody));
     news.setAuthor(getStringProperty(node, "exo:author"));

--- a/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
@@ -351,18 +351,17 @@ public class NewsServiceImpl implements NewsService {
 
         if ("published".equals(news.getPublicationState())) {
           publicationService.changeState(newsNode, "published", new HashMap<>());
-        }
-
-        //if it's an "update news" case
-        if (StringUtils.isNotEmpty(news.getId()) && news.getCreationDate() != null) {
-          News newMentionedNews = news;
-          if (!previousMentions.isEmpty()) {
-            //clear old mentions from news body before sending a custom object to notification context.
-            previousMentions.forEach(username -> {
-              newMentionedNews.setBody(newMentionedNews.getBody().replaceAll("@"+username, ""));
-            });
+          //if it's an "update news" case
+          if (StringUtils.isNotEmpty(news.getId()) && news.getCreationDate() != null) {
+            News newMentionedNews = news;
+            if (!previousMentions.isEmpty()) {
+              //clear old mentions from news body before sending a custom object to notification context.
+              previousMentions.forEach(username -> {
+                newMentionedNews.setBody(newMentionedNews.getBody().replaceAll("@"+username, ""));
+              });
+            }
+            sendNotification(newMentionedNews, NotificationConstants.NOTIFICATION_CONTEXT.MENTION_IN_NEWS);
           }
-          sendNotification(newMentionedNews, NotificationConstants.NOTIFICATION_CONTEXT.MENTION_IN_NEWS);
         }
       }
 

--- a/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
@@ -1118,18 +1118,7 @@ public class NewsServiceImpl implements NewsService {
       ctx.getNotificationExecutor().with(ctx.makeCommand(PluginKey.key(PostNewsNotificationPlugin.ID))).execute(ctx);
       Matcher matcher = MentionInNewsNotificationPlugin.MENTION_PATTERN.matcher(contentBody);
       if(matcher.find()) {
-        Set<String> mentionedIds = NewsUtils.processMentions(contentBody);
-        NotificationContext mentionNotificationCtx = NotificationContextImpl.cloneInstance()
-                .append(MentionInNewsNotificationPlugin.CONTEXT, NotificationConstants.NOTIFICATION_CONTEXT.MENTION_IN_NEWS)
-                .append(MentionInNewsNotificationPlugin.CURRENT_USER, currentUser)
-                .append(MentionInNewsNotificationPlugin.CONTENT_AUTHOR, contentAuthor)
-                .append(MentionInNewsNotificationPlugin.CONTENT_SPACE_ID, contentSpaceId)
-                .append(MentionInNewsNotificationPlugin.CONTENT_TITLE, contentTitle)
-                .append(MentionInNewsNotificationPlugin.CONTENT_SPACE, contentSpaceName)
-                .append(MentionInNewsNotificationPlugin.ILLUSTRATION_URL, illustrationURL)
-                .append(MentionInNewsNotificationPlugin.ACTIVITY_LINK, activityLink)
-                .append(MentionInNewsNotificationPlugin.MENTIONED_IDS, mentionedIds);
-        mentionNotificationCtx.getNotificationExecutor().with(mentionNotificationCtx.makeCommand(PluginKey.key(MentionInNewsNotificationPlugin.ID))).execute(mentionNotificationCtx);
+        sendMentionInNewsNotification(contentAuthor, currentUser, contentTitle, contentBody, contentSpaceId, illustrationURL, activityLink, contentSpaceName);
       }
     } else if (context.equals(NotificationConstants.NOTIFICATION_CONTEXT.MENTION_IN_NEWS)) {
       sendMentionInNewsNotification(contentAuthor, currentUser, contentTitle, contentBody, contentSpaceId, illustrationURL, activityLink, contentSpaceName);

--- a/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
@@ -1115,9 +1115,20 @@ public class NewsServiceImpl implements NewsService {
                                                      .append(PostNewsNotificationPlugin.ACTIVITY_LINK, activityLink);
     if (context.equals(NotificationConstants.NOTIFICATION_CONTEXT.POST_NEWS)) {
       ctx.getNotificationExecutor().with(ctx.makeCommand(PluginKey.key(PostNewsNotificationPlugin.ID))).execute(ctx);
-      Set<String> mentionedIds = NewsUtils.processMentions(contentBody);
-      if (mentionedIds != null && !mentionedIds.isEmpty()) {
-        sendMentionInNewsNotification(contentAuthor, currentUser, contentTitle, contentBody, contentSpaceId, illustrationURL, activityLink, contentSpaceName);
+      Matcher matcher = MentionInNewsNotificationPlugin.MENTION_PATTERN.matcher(contentBody);
+      if(matcher.find()) {
+        Set<String> mentionedIds = NewsUtils.processMentions(contentBody);
+        NotificationContext mentionNotificationCtx = NotificationContextImpl.cloneInstance()
+                .append(MentionInNewsNotificationPlugin.CONTEXT, NotificationConstants.NOTIFICATION_CONTEXT.MENTION_IN_NEWS)
+                .append(MentionInNewsNotificationPlugin.CURRENT_USER, currentUser)
+                .append(MentionInNewsNotificationPlugin.CONTENT_AUTHOR, contentAuthor)
+                .append(MentionInNewsNotificationPlugin.CONTENT_SPACE_ID, contentSpaceId)
+                .append(MentionInNewsNotificationPlugin.CONTENT_TITLE, contentTitle)
+                .append(MentionInNewsNotificationPlugin.CONTENT_SPACE, contentSpaceName)
+                .append(MentionInNewsNotificationPlugin.ILLUSTRATION_URL, illustrationURL)
+                .append(MentionInNewsNotificationPlugin.ACTIVITY_LINK, activityLink)
+                .append(MentionInNewsNotificationPlugin.MENTIONED_IDS, mentionedIds);
+        mentionNotificationCtx.getNotificationExecutor().with(mentionNotificationCtx.makeCommand(PluginKey.key(MentionInNewsNotificationPlugin.ID))).execute(mentionNotificationCtx);
       }
     } else if (context.equals(NotificationConstants.NOTIFICATION_CONTEXT.MENTION_IN_NEWS)) {
       sendMentionInNewsNotification(contentAuthor, currentUser, contentTitle, contentBody, contentSpaceId, illustrationURL, activityLink, contentSpaceName);

--- a/services/src/main/java/org/exoplatform/news/NewsUtils.java
+++ b/services/src/main/java/org/exoplatform/news/NewsUtils.java
@@ -17,31 +17,43 @@ import java.util.StringTokenizer;
 import java.util.regex.Matcher;
 
 public class NewsUtils {
-  /**
-   * Processes Mentioners who has been mentioned via the news body.
-   *
-   * @param body
-   * @return set of mentioned users
-   */
-  public static Set<String> processMentions(String body) {
-    if (StringUtils.isEmpty(body)) {
-      return Collections.emptySet();
-    }
 
-    Set<String> mentions = new HashSet<>();
-    Matcher matcher = MentionInNewsNotificationPlugin.MENTION_PATTERN.matcher(body);
-    while (matcher.find()) {
-      String remoteId = matcher.group().substring(1);
-      if (mentions.contains(remoteId)) {
-        continue;
-      }
-      Identity identity = loadUser(remoteId);
-      // if not the right mention then ignore
-      if (identity != null) {
-        mentions.add(identity.getRemoteId());
-      }
+  /**
+   * Formats the body of the news to add profile link when mentioned
+   *
+   * @param news
+   * @return News with formatted body
+   */
+  public static News formatNews(News news) {
+    if (news == null || StringUtils.isBlank(news.getBody())) {
+      return news;
     }
-    return mentions;
+    HTMLEntityEncoder encoder = HTMLEntityEncoder.getInstance();
+    StringBuilder sb = new StringBuilder();
+    StringTokenizer tokenizer = new StringTokenizer(news.getBody());
+    while (tokenizer.hasMoreElements()) {
+      String next = (String) tokenizer.nextElement();
+      if (next.length() == 0) {
+        continue;
+      } else if (next.contains("@")) {
+        String[] splitTable = next.split("@");
+        if (splitTable.length > 1) {
+          org.exoplatform.social.core.identity.model.Identity identity = loadUser(splitTable[1]);
+          if (identity != null) {
+            next = splitTable[0] + "<a href=\"" + identity.getProfile().getUrl() + "\">"
+                    + encoder.encodeHTML(identity.getProfile().getFullName()) + "</a>";
+          }
+        }
+      }
+      sb.append(next);
+      sb.append(' ');
+    }
+    try {
+      news.setBody(HTMLSanitizer.sanitize(sb.toString().trim()));
+    } catch (Exception e) {
+      // Do nothing
+    }
+    return news;
   }
 
   /**
@@ -56,5 +68,36 @@ public class NewsUtils {
       return null;
     }
     return identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, username);
+  }
+
+  /**
+   * Processes Mentioners who has been mentioned via the news body.
+   *
+   * @param body
+   * @return set of mentioned users
+   */
+  public static Set<String> processMentions(String body) {
+    Set<String> mentions = new HashSet<>();
+    mentions.addAll(parseMention(body));
+
+    return mentions;
+  }
+
+  private static Set<String> parseMention(String str) {
+    if (str == null || str.length() == 0) {
+      return Collections.emptySet();
+    }
+
+    Set<String> mentions = new HashSet<>();
+    Matcher matcher = MentionInNewsNotificationPlugin.MENTION_PATTERN.matcher(str);
+    while (matcher.find()) {
+      String remoteId = matcher.group().substring(1);
+      Identity identity = loadUser(remoteId);
+      // if not the right mention then ignore
+      if (identity != null && !mentions.contains(identity.getRemoteId())) {
+        mentions.add(identity.getRemoteId());
+      }
+    }
+    return mentions;
   }
 }

--- a/services/src/main/java/org/exoplatform/news/NewsUtils.java
+++ b/services/src/main/java/org/exoplatform/news/NewsUtils.java
@@ -19,44 +19,6 @@ import java.util.regex.Matcher;
 public class NewsUtils {
 
   /**
-   * Formats the body of the news to add profile link when mentioned
-   *
-   * @param news
-   * @return News with formatted body
-   */
-  public static News formatNews(News news) {
-    if (news == null || StringUtils.isBlank(news.getBody())) {
-      return news;
-    }
-    HTMLEntityEncoder encoder = HTMLEntityEncoder.getInstance();
-    StringBuilder sb = new StringBuilder();
-    StringTokenizer tokenizer = new StringTokenizer(news.getBody());
-    while (tokenizer.hasMoreElements()) {
-      String next = (String) tokenizer.nextElement();
-      if (next.length() == 0) {
-        continue;
-      } else if (next.contains("@")) {
-        String[] splitTable = next.split("@");
-        if (splitTable.length > 1) {
-          org.exoplatform.social.core.identity.model.Identity identity = loadUser(splitTable[1]);
-          if (identity != null) {
-            next = splitTable[0] + "<a href=\"" + identity.getProfile().getUrl() + "\">"
-                    + encoder.encodeHTML(identity.getProfile().getFullName()) + "</a>";
-          }
-        }
-      }
-      sb.append(next);
-      sb.append(' ');
-    }
-    try {
-      news.setBody(HTMLSanitizer.sanitize(sb.toString().trim()));
-    } catch (Exception e) {
-      // Do nothing
-    }
-    return news;
-  }
-
-  /**
    * Load the user identity
    *
    * @param username

--- a/services/src/test/java/org/exoplatform/news/NewsServiceImplTest.java
+++ b/services/src/test/java/org/exoplatform/news/NewsServiceImplTest.java
@@ -2913,14 +2913,24 @@ public class NewsServiceImplTest {
     when(imageProcessor.processImages(anyString(), any(), anyString())).thenAnswer(i -> i.getArguments()[0]);
     Workspace workSpace = mock(Workspace.class);
     when(session.getWorkspace()).thenReturn(workSpace);
+    Identity johnIdentity = new Identity(OrganizationIdentityProvider.NAME, "john");
+    Profile profile = johnIdentity.getProfile();
+    profile.setUrl("/profile/john");
+    profile.setProperty("fullName", "john john");
+    Set<String> mentionedIds = new HashSet(Collections.singleton("john"));
+    when(identityManager.getOrCreateIdentity(eq(OrganizationIdentityProvider.NAME), eq("john"))).thenReturn(johnIdentity);
+    PowerMockito.mockStatic(CommonsUtils.class);
+    when(CommonsUtils.getService(IdentityManager.class)).thenReturn(identityManager);
+
     News news = new News();
-    news.setTitle("update title");
-    news.setSummary("Updated summary");
-    news.setBody("Updated body");
+    news.setTitle("title");
+    news.setSummary("summary");
+    news.setBody("body <img alt=\"\" class=\"pull-left\" data-plugin-name=\"selectImage\" referrerpolicy=\"no-referrer\" src=\"/portal/rest/composer/image/thumbnail?uploadId=88b5af9\">");
     news.setUploadId(null);
     news.setViewsCount((long) 10);
     // when
-    newsService.updateNews(news);
+    news.setBody("Updated body @john <img alt=\"\" class=\"pull-left\" data-plugin-name=\"selectImage\" referrerpolicy=\"no-referrer\" src=\"/portal/rest/composer/image/thumbnail?uploadId=88b5af9\">");
+    News updatedNews = newsService.updateNews(news);
     // then
     verify(workSpace, times(1)).move(any(), any());
     verify(newsNode, times(1)).save();
@@ -3058,6 +3068,8 @@ public class NewsServiceImplTest {
     news.setCreationDate(new Date());
     news.setUploadId(null);
     news.setViewsCount((long) 10);
+    news.setPublicationState("published");
+    news.setPublicationDate(Calendar.getInstance().getTime());
 
     // when
     newsService.updateNews(news);

--- a/webapp/src/main/webapp/WEB-INF/conf/news/app-center-configuration.xml
+++ b/webapp/src/main/webapp/WEB-INF/conf/news/app-center-configuration.xml
@@ -35,6 +35,10 @@
           <name>override</name>
           <value>${exo.app-center.news.override:false}</value>
         </value-param>
+        <value-param>
+          <name>override-mode</name>
+          <value>${exo.app-center.news.override-mode:merge}</value>
+        </value-param>
         <object-param>
           <name>application</name>
           <description>description</description>

--- a/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
+++ b/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
@@ -495,11 +495,12 @@ export default {
 
       this.news.body = newsServices.linkifyHTML(this.news.body, 'newsContent');
       this.news.body = this.replaceImagesURLs(this.news.body);
+      const newsBody = this.replaceImagesURLs(this.getBody());
       const news = {
         id: this.news.id,
         title: this.news.title,
         summary: this.news.summary,
-        body: this.getBody() ? this.getBody() : this.news.body,
+        body: this.getBody() ? newsBody : this.news.body,
         author: eXo.env.portal.userName,
         attachments: this.news.attachments,
         pinned: this.news.pinned,
@@ -683,11 +684,12 @@ export default {
     },
     doUpdateNews: function () {
       this.news.body = newsServices.linkifyHTML(this.news.body, 'newsContent');
+      const newsBody = this.replaceImagesURLs(this.getBody());
       const updatedNews = {
         id: this.news.id,
         title: this.news.title,
         summary: this.news.summary != null ? this.news.summary : '',
-        body: this.getBody() ? this.getBody() : this.news.body,
+        body: this.getBody() ? newsBody : this.news.body,
         attachments: this.news.attachments,
         pinned: this.news.pinned,
         publicationState: 'published'


### PR DESCRIPTION
Mentioning users and sanitization are done before saving news which does not work as expected. Both operation should not be applied to data before saving, but it should be done before rendering the content of the news.