### PR TITLE
40065 : Image lost after posting news (#92)

### DIFF
--- a/services/src/main/java/org/exoplatform/news/NewsUtils.java
+++ b/services/src/main/java/org/exoplatform/news/NewsUtils.java
@@ -17,32 +17,6 @@ import java.util.StringTokenizer;
 import java.util.regex.Matcher;
 
 public class NewsUtils {
-  /**
-   * Processes Mentioners who has been mentioned via the news body.
-   *
-   * @param body
-   * @return set of mentioned users
-   */
-  public static Set<String> processMentions(String body) {
-    if (StringUtils.isEmpty(body)) {
-      return Collections.emptySet();
-    }
-
-    Set<String> mentions = new HashSet<>();
-    Matcher matcher = MentionInNewsNotificationPlugin.MENTION_PATTERN.matcher(body);
-    while (matcher.find()) {
-      String remoteId = matcher.group().substring(1);
-      if (mentions.contains(remoteId)) {
-        continue;
-      }
-      Identity identity = loadUser(remoteId);
-      // if not the right mention then ignore
-      if (identity != null) {
-        mentions.add(identity.getRemoteId());
-      }
-    }
-    return mentions;
-  }
 
   /**
    * Load the user identity
@@ -56,5 +30,36 @@ public class NewsUtils {
       return null;
     }
     return identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, username);
+  }
+
+  /**
+   * Processes Mentioners who has been mentioned via the news body.
+   *
+   * @param body
+   * @return set of mentioned users
+   */
+  public static Set<String> processMentions(String body) {
+    Set<String> mentions = new HashSet<>();
+    mentions.addAll(parseMention(body));
+
+    return mentions;
+  }
+
+  private static Set<String> parseMention(String str) {
+    if (str == null || str.length() == 0) {
+      return Collections.emptySet();
+    }
+
+    Set<String> mentions = new HashSet<>();
+    Matcher matcher = MentionInNewsNotificationPlugin.MENTION_PATTERN.matcher(str);
+    while (matcher.find()) {
+      String remoteId = matcher.group().substring(1);
+      Identity identity = loadUser(remoteId);
+      // if not the right mention then ignore
+      if (identity != null && !mentions.contains(identity.getRemoteId())) {
+        mentions.add(identity.getRemoteId());
+      }
+    }
+    return mentions;
   }
 }

--- a/services/src/test/java/org/exoplatform/news/NewsServiceImplTest.java
+++ b/services/src/test/java/org/exoplatform/news/NewsServiceImplTest.java
@@ -2913,14 +2913,24 @@ public class NewsServiceImplTest {
     when(imageProcessor.processImages(anyString(), any(), anyString())).thenAnswer(i -> i.getArguments()[0]);
     Workspace workSpace = mock(Workspace.class);
     when(session.getWorkspace()).thenReturn(workSpace);
+    Identity johnIdentity = new Identity(OrganizationIdentityProvider.NAME, "john");
+    Profile profile = johnIdentity.getProfile();
+    profile.setUrl("/profile/john");
+    profile.setProperty("fullName", "john john");
+    Set<String> mentionedIds = new HashSet(Collections.singleton("john"));
+    when(identityManager.getOrCreateIdentity(eq(OrganizationIdentityProvider.NAME), eq("john"))).thenReturn(johnIdentity);
+    PowerMockito.mockStatic(CommonsUtils.class);
+    when(CommonsUtils.getService(IdentityManager.class)).thenReturn(identityManager);
+
     News news = new News();
-    news.setTitle("update title");
-    news.setSummary("Updated summary");
-    news.setBody("Updated body");
+    news.setTitle("title");
+    news.setSummary("summary");
+    news.setBody("body <img alt=\"\" class=\"pull-left\" data-plugin-name=\"selectImage\" referrerpolicy=\"no-referrer\" src=\"/portal/rest/composer/image/thumbnail?uploadId=88b5af9\">");
     news.setUploadId(null);
     news.setViewsCount((long) 10);
     // when
-    newsService.updateNews(news);
+    news.setBody("Updated body @john <img alt=\"\" class=\"pull-left\" data-plugin-name=\"selectImage\" referrerpolicy=\"no-referrer\" src=\"/portal/rest/composer/image/thumbnail?uploadId=88b5af9\">");
+    News updatedNews = newsService.updateNews(news);
     // then
     verify(workSpace, times(1)).move(any(), any());
     verify(newsNode, times(1)).save();
@@ -3058,6 +3068,8 @@ public class NewsServiceImplTest {
     news.setCreationDate(new Date());
     news.setUploadId(null);
     news.setViewsCount((long) 10);
+    news.setPublicationState("published");
+    news.setPublicationDate(Calendar.getInstance().getTime());
 
     // when
     newsService.updateNews(news);

--- a/webapp/src/main/webapp/WEB-INF/conf/news/app-center-configuration.xml
+++ b/webapp/src/main/webapp/WEB-INF/conf/news/app-center-configuration.xml
@@ -35,6 +35,10 @@
           <name>override</name>
           <value>${exo.app-center.news.override:false}</value>
         </value-param>
+        <value-param>
+          <name>override-mode</name>
+          <value>${exo.app-center.news.override-mode:merge}</value>
+        </value-param>
         <object-param>
           <name>application</name>
           <description>description</description>

--- a/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
+++ b/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
@@ -495,11 +495,12 @@ export default {
 
       this.news.body = newsServices.linkifyHTML(this.news.body, 'newsContent');
       this.news.body = this.replaceImagesURLs(this.news.body);
+      const newsBody = this.replaceImagesURLs(this.getBody());
       const news = {
         id: this.news.id,
         title: this.news.title,
         summary: this.news.summary,
-        body: this.getBody() ? this.getBody() : this.news.body,
+        body: this.getBody() ? newsBody : this.news.body,
         author: eXo.env.portal.userName,
         attachments: this.news.attachments,
         pinned: this.news.pinned,
@@ -683,11 +684,12 @@ export default {
     },
     doUpdateNews: function () {
       this.news.body = newsServices.linkifyHTML(this.news.body, 'newsContent');
+      const newsBody = this.replaceImagesURLs(this.getBody());
       const updatedNews = {
         id: this.news.id,
         title: this.news.title,
         summary: this.news.summary != null ? this.news.summary : '',
-        body: this.getBody() ? this.getBody() : this.news.body,
+        body: this.getBody() ? newsBody : this.news.body,
         attachments: this.news.attachments,
         pinned: this.news.pinned,
         publicationState: 'published'


### PR DESCRIPTION
Mentioning users and sanitization are done before saving news which does not work as expected. Both operation should not be applied to data before saving, but it should be done before rendering the content of the news.