### PR TITLE
Task-42704: Enable post article on redactional space (space with redactors) when super manager or space manager

### DIFF
--- a/services/src/main/java/org/exoplatform/news/rest/NewsRestResourcesV1.java
+++ b/services/src/main/java/org/exoplatform/news/rest/NewsRestResourcesV1.java
@@ -750,7 +750,7 @@ public class NewsRestResourcesV1 implements ResourceContainer {
       if (StringUtils.isBlank(authenticatedUser) || !spaceService.isMember(space, authenticatedUser)) {
         return Response.status(Response.Status.UNAUTHORIZED).build();
       }
-      return Response.ok(String.valueOf(SpaceUtils.isRedactor(authenticatedUser, space.getGroupId()))).build();
+      return Response.ok(String.valueOf(SpaceUtils.isRedactor(authenticatedUser, space.getGroupId()) || SpaceUtils.isSpaceManagerOrSuperManager(authenticatedUser, space.getGroupId()))).build();
     } catch (Exception e) {
       LOG.error("Error when checking if the authenticated user can create a news", e);
       return Response.serverError().build();


### PR DESCRIPTION
**Current behavior:** When adding at least a redactor for a space, the space manager or a super user or a space admin can no more post article.
**New Behavior:**  When adding at least a redactor for a space, the space manager or a super user or a space admin can post article.