### PR TITLE
Task-42687: Implement remove news article from news details

### DIFF
--- a/services/src/main/java/org/exoplatform/news/NewsService.java
+++ b/services/src/main/java/org/exoplatform/news/NewsService.java
@@ -47,4 +47,7 @@ public interface NewsService {
   void archiveNews(String newsId) throws Exception;
 
   void unarchiveNews(String newsId) throws Exception;
+
+  public boolean canDeleteNews(String posterId, String spaceId);
+
 }

--- a/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
@@ -1258,7 +1258,8 @@ public class NewsServiceImpl implements NewsService {
     }
     String authenticatedUser = currentIdentity.getUserId();
     Space currentSpace = spaceService.getSpaceById(spaceId);
-    return userACL.isSuperUser() || spaceService.isSuperManager(authenticatedUser) || spaceService.isManager(currentSpace, authenticatedUser);
+    return authenticatedUser.equals(posterId) || userACL.isSuperUser() || spaceService.isSuperManager(authenticatedUser)
+        || spaceService.isManager(currentSpace, authenticatedUser);
   }
 
   protected String substituteUsernames(String portalOwner, String message) {

--- a/services/src/main/java/org/exoplatform/news/model/News.java
+++ b/services/src/main/java/org/exoplatform/news/model/News.java
@@ -62,6 +62,8 @@ public class News {
   private String authorAvatarUrl;
 
   private Boolean canEdit;
+  
+  private Boolean canDelete;
 
   private Set<Space> sharedInSpacesList;
 
@@ -96,7 +98,7 @@ public class News {
   public String getBody() {
     return body;
   }
-
+  
   public void setBody(String body) {
     this.body = body;
   }
@@ -315,5 +317,13 @@ public class News {
 
   public void setAuthorAvatarUrl(String authorAvatarUrl) {
     this.authorAvatarUrl = authorAvatarUrl;
+  }
+
+  public Boolean getCanDelete() {
+    return canDelete;
+  }
+
+  public void setCanDelete(Boolean canDelete) {
+    this.canDelete = canDelete;
   }
 }

--- a/services/src/main/java/org/exoplatform/news/model/News.java
+++ b/services/src/main/java/org/exoplatform/news/model/News.java
@@ -319,7 +319,7 @@ public class News {
     this.authorAvatarUrl = authorAvatarUrl;
   }
 
-  public Boolean getCanDelete() {
+  public Boolean isCanDelete() {
     return canDelete;
   }
 

--- a/services/src/main/java/org/exoplatform/news/rest/NewsRestResourcesV1.java
+++ b/services/src/main/java/org/exoplatform/news/rest/NewsRestResourcesV1.java
@@ -742,7 +742,7 @@ public class NewsRestResourcesV1 implements ResourceContainer, Startable {
 
       String authenticatedUser = request.getRemoteUser();
 
-      if (StringUtils.isBlank(news.getAuthor()) || !authenticatedUser.equals(news.getAuthor())) {
+      if (!news.isCanDelete()) {
         return Response.status(Response.Status.UNAUTHORIZED).build();
       }
       boolean isDeletedNews = false;

--- a/services/src/main/java/org/exoplatform/news/rest/NewsRestResourcesV1.java
+++ b/services/src/main/java/org/exoplatform/news/rest/NewsRestResourcesV1.java
@@ -2,10 +2,10 @@ package org.exoplatform.news.rest;
 
 import java.io.InputStream;
 import java.net.URI;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import javax.annotation.security.RolesAllowed;
 import javax.servlet.http.HttpServletRequest;
@@ -26,6 +26,10 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
 import org.apache.commons.lang3.StringUtils;
+import org.exoplatform.common.http.HTTPStatus;
+import org.exoplatform.container.ExoContainerContext;
+import org.exoplatform.container.PortalContainer;
+import org.exoplatform.container.component.RequestLifeCycle;
 import org.exoplatform.news.NewsAttachmentsService;
 import org.exoplatform.news.NewsService;
 import org.exoplatform.news.filter.NewsFilter;
@@ -49,10 +53,11 @@ import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import io.swagger.jaxrs.PATCH;
+import org.picocontainer.Startable;
 
 @Path("v1/news")
 @Api(tags = "v1/news", value = "v1/news", description = "Managing news")
-public class NewsRestResourcesV1 implements ResourceContainer {
+public class NewsRestResourcesV1 implements ResourceContainer, Startable {
 
   private static final Log       LOG                             = ExoLogger.getLogger(NewsRestResourcesV1.class);
 
@@ -74,6 +79,12 @@ public class NewsRestResourcesV1 implements ResourceContainer {
 
   private IdentityManager        identityManager;
 
+  private ScheduledExecutorService scheduledExecutor;
+
+  private PortalContainer        container;
+
+  private Map<String, String>    newsToDeleteQueue = new HashMap<>();
+
   private enum FilterType {
     PINNED, MYPOSTED, ARCHIVED, ALL
   }
@@ -81,13 +92,28 @@ public class NewsRestResourcesV1 implements ResourceContainer {
   public NewsRestResourcesV1(NewsService newsService,
                              NewsAttachmentsService newsAttachmentsService,
                              SpaceService spaceService,
-                             IdentityManager identityManager) {
+                             IdentityManager identityManager,
+                             PortalContainer container) {
 
     this.newsService = newsService;
     this.newsAttachmentsService = newsAttachmentsService;
     this.spaceService = spaceService;
     this.identityManager = identityManager;
+    this.container = container;
   }
+
+  @Override
+  public void start() {
+    scheduledExecutor = Executors.newScheduledThreadPool(1);
+  }
+
+  @Override
+  public void stop() {
+    if (scheduledExecutor != null) {
+      scheduledExecutor.shutdown();
+    }
+  }
+
 
   @POST
   @Consumes(MediaType.APPLICATION_JSON)
@@ -690,7 +716,7 @@ public class NewsRestResourcesV1 implements ResourceContainer {
 
   @DELETE
   @Path("{id}")
-  @Consumes(MediaType.APPLICATION_JSON)
+  @Produces(MediaType.APPLICATION_JSON)
   @RolesAllowed("users")
   @ApiOperation(value = "Delete news", httpMethod = "DELETE", response = Response.class, notes = "This deletes the news", consumes = "application/json")
   @ApiResponses(value = { @ApiResponse(code = 200, message = "News deleted"),
@@ -698,7 +724,12 @@ public class NewsRestResourcesV1 implements ResourceContainer {
       @ApiResponse(code = 401, message = "User not authorized to delete the news"),
       @ApiResponse(code = 500, message = "Internal server error") })
   public Response deleteNews(@Context HttpServletRequest request,
-                             @ApiParam(value = "News id", required = true) @PathParam("id") String id) {
+                             @ApiParam(value = "News id", required = true)
+                             @PathParam("id") String id,
+                             @ApiParam(value = "Time to effectively delete news", required = false)
+                             @QueryParam(
+                               "delay"
+                             ) long delay) {
     try {
       if (StringUtils.isBlank(id)) {
         return Response.status(Response.Status.BAD_REQUEST).build();
@@ -714,13 +745,73 @@ public class NewsRestResourcesV1 implements ResourceContainer {
       if (StringUtils.isBlank(news.getAuthor()) || !authenticatedUser.equals(news.getAuthor())) {
         return Response.status(Response.Status.UNAUTHORIZED).build();
       }
-
-      newsService.deleteNews(id);
-
+      if (delay > 0) {
+        newsToDeleteQueue.put(id, authenticatedUser);
+        scheduledExecutor.schedule(() -> {
+          if (newsToDeleteQueue.containsKey(id)) {
+            ExoContainerContext.setCurrentContainer(container);
+            RequestLifeCycle.begin(container);
+            try {
+              newsToDeleteQueue.remove(id);
+              newsService.deleteNews(id);
+            } catch (IllegalAccessException e) {
+              LOG.error("User '{}' attempts to delete a non authorized news", authenticatedUser, e);
+            } catch (Exception e) {
+              LOG.warn("Error deleting an news", e);
+            } finally {
+              RequestLifeCycle.end();
+            }
+          }
+        }, delay, TimeUnit.SECONDS);
+      } else {
+        newsToDeleteQueue.remove(id);
+        newsService.deleteNews(id);
+      }
       return Response.ok().build();
     } catch (Exception e) {
       LOG.error("Error when deleting the news with id " + id, e);
       return Response.serverError().build();
+    }
+  }
+
+  @Path("{newsId}/undoDelete")
+  @POST
+  @RolesAllowed("users")
+  @ApiOperation(
+      value = "Undo deleting news if not yet effectively deleted.",
+      httpMethod = "POST",
+      response = Response.class
+  )
+  @ApiResponses(
+      value = {
+          @ApiResponse(code = HTTPStatus.NO_CONTENT, message = "Request fulfilled"),
+          @ApiResponse(code = HTTPStatus.BAD_REQUEST, message = "Invalid query input"),
+          @ApiResponse(code = HTTPStatus.FORBIDDEN, message = "Forbidden operation"),
+          @ApiResponse(code = HTTPStatus.UNAUTHORIZED, message = "Unauthorized operation"),
+          @ApiResponse(code = HTTPStatus.INTERNAL_ERROR, message = "Internal server error"), }
+  )
+  public Response undoDeleteNews(
+                                  @Context HttpServletRequest request,
+                                  @ApiParam(value = "News technical identifier", required = true)
+                                  @PathParam(
+                                    "newsId"
+                                  ) String newsId) {
+    if (StringUtils.isBlank(newsId)) {
+      return Response.status(Response.Status.BAD_REQUEST).entity("News identifier must be a positive integer").build();
+    }
+    if (newsToDeleteQueue.containsKey(newsId)) {
+      String authenticatedUser = request.getRemoteUser();
+      String originalModifierUser = newsToDeleteQueue.get(newsId);
+      if (!originalModifierUser.equals(authenticatedUser)) {
+        LOG.warn("User {} attempts to cancel deletion of a news deleted by user {}", authenticatedUser, originalModifierUser);
+        return Response.status(Response.Status.FORBIDDEN).build();
+      }
+      newsToDeleteQueue.remove(newsId);
+      return Response.noContent().build();
+    } else {
+      return Response.status(Response.Status.BAD_REQUEST)
+                     .entity("News id was already deleted or isn't planned to be deleted")
+                     .build();
     }
   }
 

--- a/services/src/main/java/org/exoplatform/news/rest/NewsRestResourcesV1.java
+++ b/services/src/main/java/org/exoplatform/news/rest/NewsRestResourcesV1.java
@@ -812,7 +812,7 @@ public class NewsRestResourcesV1 implements ResourceContainer, Startable {
       return Response.noContent().build();
     } else {
       return Response.status(Response.Status.BAD_REQUEST)
-                     .entity("News id was already deleted or isn't planned to be deleted")
+                     .entity("News with id {} was already deleted or isn't planned to be deleted" + id)
                      .build();
     }
   }

--- a/services/src/main/java/org/exoplatform/news/rest/NewsRestResourcesV1.java
+++ b/services/src/main/java/org/exoplatform/news/rest/NewsRestResourcesV1.java
@@ -745,10 +745,8 @@ public class NewsRestResourcesV1 implements ResourceContainer, Startable {
       if (!news.isCanDelete()) {
         return Response.status(Response.Status.UNAUTHORIZED).build();
       }
-      boolean isDeletedNews = false;
       if (delay > 0) {
         newsToDeleteQueue.put(id, authenticatedUser);
-        isDeletedNews = newsToDeleteQueue.containsKey(id);
         scheduledExecutor.schedule(() -> {
           if (newsToDeleteQueue.containsKey(id)) {
             ExoContainerContext.setCurrentContainer(container);
@@ -769,7 +767,7 @@ public class NewsRestResourcesV1 implements ResourceContainer, Startable {
         newsToDeleteQueue.remove(id);
         newsService.deleteNews(id);
       }
-      return Response.ok(String.valueOf(isDeletedNews)).build();
+      return Response.ok().build();
     } catch (Exception e) {
       LOG.error("Error when deleting the news with id " + id, e);
       return Response.serverError().build();

--- a/services/src/main/resources/locale/portlet/news/News_en.properties
+++ b/services/src/main/resources/locale/portlet/news/News_en.properties
@@ -185,3 +185,4 @@ news.permission.msg=You don't have the permission to write an article in this sp
 
 news.details.header.menu.share=Share
 news.details.header.menu.edit=Edit
+news.details.header.menu.delete=Delete

--- a/services/src/main/resources/locale/portlet/news/News_en.properties
+++ b/services/src/main/resources/locale/portlet/news/News_en.properties
@@ -187,5 +187,5 @@ news.details.header.menu.share=Share
 news.details.header.menu.edit=Edit
 news.details.header.menu.delete=Delete
 
-news.undoRemoveActivity=Undo
-news.activityDeleteSuccess=Activity deleted
+news.details.undoDelete=Undo
+news.details.deleteSuccess=News deleted

--- a/services/src/main/resources/locale/portlet/news/News_en.properties
+++ b/services/src/main/resources/locale/portlet/news/News_en.properties
@@ -186,3 +186,6 @@ news.permission.msg=You don't have the permission to write an article in this sp
 news.details.header.menu.share=Share
 news.details.header.menu.edit=Edit
 news.details.header.menu.delete=Delete
+
+news.undoRemoveActivity=Undo
+news.activityDeleteSuccess=Activity deleted

--- a/services/src/main/resources/locale/portlet/news/News_en.properties
+++ b/services/src/main/resources/locale/portlet/news/News_en.properties
@@ -189,3 +189,4 @@ news.details.header.menu.delete=Delete
 
 news.details.undoDelete=Undo
 news.details.deleteSuccess=News deleted
+news.details.deleteCanceled=News deletion canceled

--- a/services/src/test/java/org/exoplatform/news/NewsServiceImplTest.java
+++ b/services/src/test/java/org/exoplatform/news/NewsServiceImplTest.java
@@ -39,6 +39,7 @@ import org.exoplatform.news.filter.NewsFilter;
 import org.exoplatform.news.model.News;
 import org.exoplatform.news.model.SharedNews;
 import org.exoplatform.news.notification.utils.NotificationConstants;
+import org.exoplatform.portal.config.UserACL;
 import org.exoplatform.services.cms.link.LinkManager;
 import org.exoplatform.services.ecm.publication.impl.PublicationServiceImpl;
 import org.exoplatform.services.jcr.RepositoryService;
@@ -149,6 +150,9 @@ public class NewsServiceImplTest {
 
   @Mock
   NewsAttachmentsService     newsAttachmentsService;
+  
+  @Mock
+  UserACL                    userACL;
 
   @Rule
   public ExpectedException   exceptionRule = ExpectedException.none();
@@ -170,7 +174,8 @@ public class NewsServiceImplTest {
                                                   publicationManagerImpl,
                                                   wcmPublicationServiceImpl,
                                                   newsSearchConnector,
-                                                  newsAttachmentsService);
+                                                  newsAttachmentsService,
+                                                  userACL);
     Node node = mock(Node.class);
     Property property = mock(Property.class);
     when(sessionProviderService.getSystemSessionProvider(any())).thenReturn(sessionProvider);
@@ -225,7 +230,8 @@ public class NewsServiceImplTest {
                                                   publicationManagerImpl,
                                                   wcmPublicationServiceImpl,
                                                   newsSearchConnector,
-                                                  newsAttachmentsService);
+                                                  newsAttachmentsService,
+                                                  userACL);
     when(sessionProviderService.getSystemSessionProvider(any())).thenReturn(sessionProvider);
     when(sessionProviderService.getSessionProvider(any())).thenReturn(sessionProvider);
     when(repositoryService.getCurrentRepository()).thenReturn(repository);
@@ -246,20 +252,21 @@ public class NewsServiceImplTest {
   public void shouldGetLastNewsVersionWhenNewsExistsAndHasVersions() throws Exception {
     // Given
     NewsService newsService = new NewsServiceImpl(repositoryService,
-            sessionProviderService,
-            nodeHierarchyCreator,
-            dataDistributionManager,
-            spaceService,
-            activityManager,
-            identityManager,
-            uploadService,
-            imageProcessor,
-            linkManager,
-            publicationServiceImpl,
-            publicationManagerImpl,
-            wcmPublicationServiceImpl,
-            newsSearchConnector,
-            newsAttachmentsService);
+                                                  sessionProviderService,
+                                                  nodeHierarchyCreator,
+                                                  dataDistributionManager,
+                                                  spaceService,
+                                                  activityManager,
+                                                  identityManager,
+                                                  uploadService,
+                                                  imageProcessor,
+                                                  linkManager,
+                                                  publicationServiceImpl,
+                                                  publicationManagerImpl,
+                                                  wcmPublicationServiceImpl,
+                                                  newsSearchConnector,
+                                                  newsAttachmentsService,
+                                                  userACL);
     Node node = mock(Node.class);
     Property property = mock(Property.class);
     when(property.getString()).thenReturn("");
@@ -374,7 +381,8 @@ public class NewsServiceImplTest {
                                                   publicationManagerImpl,
                                                   wcmPublicationServiceImpl,
                                                   newsSearchConnector,
-                                                  newsAttachmentsService);
+                                                  newsAttachmentsService,
+                                                  userACL);
     Node newsNode = mock(Node.class);
     Node illustrationNode = mock(Node.class);
     Property property = mock(Property.class);
@@ -427,7 +435,8 @@ public class NewsServiceImplTest {
                                                   publicationManagerImpl,
                                                   wcmPublicationServiceImpl,
                                                   newsSearchConnector,
-                                                  newsAttachmentsService);
+                                                  newsAttachmentsService,
+                                                  userACL);
     Node newsNode = mock(Node.class);
     Node illustrationNode = mock(Node.class);
     Property property = mock(Property.class);
@@ -480,7 +489,8 @@ public class NewsServiceImplTest {
                                                       publicationManagerImpl,
                                                       wcmPublicationServiceImpl,
                                                       newsSearchConnector,
-                                                      newsAttachmentsService);
+                                                      newsAttachmentsService,
+                                                      userACL);
     ExtendedNode newsNode = mock(ExtendedNode.class);
     Property property = mock(Property.class);
     when(sessionProviderService.getSystemSessionProvider(any())).thenReturn(sessionProvider);
@@ -556,7 +566,8 @@ public class NewsServiceImplTest {
                                                       publicationManagerImpl,
                                                       wcmPublicationServiceImpl,
                                                       newsSearchConnector,
-                                                      newsAttachmentsService);
+                                                      newsAttachmentsService,
+                                                      userACL);
 
     NewsServiceImpl newsServiceSpy = Mockito.spy(newsService);
     ExtendedNode newsNode = mock(ExtendedNode.class);
@@ -621,7 +632,8 @@ public class NewsServiceImplTest {
                                                       publicationManagerImpl,
                                                       wcmPublicationServiceImpl,
                                                       newsSearchConnector,
-                                                      newsAttachmentsService);
+                                                      newsAttachmentsService,
+                                                      userACL);
     News news = new News();
     news.setTitle("new pinned news title");
     news.setSummary("new pinned news summary");
@@ -705,7 +717,8 @@ public class NewsServiceImplTest {
                                                       publicationManagerImpl,
                                                       wcmPublicationServiceImpl,
                                                       newsSearchConnector,
-                                                      newsAttachmentsService);
+                                                      newsAttachmentsService,
+                                                      userACL);
 
     NewsService newsServiceSpy = Mockito.spy(newsService);
     ExtendedNode newsNode = mock(ExtendedNode.class);
@@ -772,7 +785,8 @@ public class NewsServiceImplTest {
                                                       publicationManagerImpl,
                                                       wcmPublicationServiceImpl,
                                                       newsSearchConnector,
-                                                      newsAttachmentsService);
+                                                      newsAttachmentsService,
+                                                      userACL);
 
     NewsService newsServiceSpy = Mockito.spy(newsService);
     News news = new News();
@@ -818,7 +832,8 @@ public class NewsServiceImplTest {
                                                       publicationManagerImpl,
                                                       wcmPublicationServiceImpl,
                                                       newsSearchConnector,
-                                                      newsAttachmentsService);
+                                                      newsAttachmentsService,
+                                                      userACL);
 
     NewsService newsServiceSpy = Mockito.spy(newsService);
     when(sessionProviderService.getSystemSessionProvider(any())).thenReturn(sessionProvider);
@@ -853,7 +868,8 @@ public class NewsServiceImplTest {
                                                       publicationManagerImpl,
                                                       wcmPublicationServiceImpl,
                                                       newsSearchConnector,
-                                                      newsAttachmentsService);
+                                                      newsAttachmentsService,
+                                                      userACL);
 
     NewsService newsServiceSpy = Mockito.spy(newsService);
     ExtendedNode newsNode = mock(ExtendedNode.class);
@@ -912,7 +928,8 @@ public class NewsServiceImplTest {
                                                       publicationManagerImpl,
                                                       wcmPublicationServiceImpl,
                                                       newsSearchConnector,
-                                                      newsAttachmentsService);
+                                                      newsAttachmentsService,
+                                                      userACL);
 
     NewsService newsServiceSpy = Mockito.spy(newsService);
     ExtendedNode newsNode = mock(ExtendedNode.class);
@@ -971,7 +988,8 @@ public class NewsServiceImplTest {
                                                       publicationManagerImpl,
                                                       wcmPublicationServiceImpl,
                                                       newsSearchConnector,
-                                                      newsAttachmentsService);
+                                                      newsAttachmentsService,
+                                                      userACL);
 
     NewsService newsServiceSpy = Mockito.spy(newsService);
     ExtendedNode newsNode = mock(ExtendedNode.class);
@@ -1037,7 +1055,8 @@ public class NewsServiceImplTest {
                                                       publicationManagerImpl,
                                                       wcmPublicationServiceImpl,
                                                       newsSearchConnector,
-                                                      newsAttachmentsService);
+                                                      newsAttachmentsService,
+                                                      userACL);
     Node newsFolderNode = mock(Node.class);
     Node newsRootNode = mock(Node.class);
     Node applicationDataNode = mock(Node.class);
@@ -1122,7 +1141,8 @@ public class NewsServiceImplTest {
                                                       publicationManagerImpl,
                                                       wcmPublicationServiceImpl,
                                                       newsSearchConnector,
-                                                      newsAttachmentsService);
+                                                      newsAttachmentsService,
+                                                      userACL);
     Node applicationDataNode = mock(Node.class);
     Node newsNode = mock(Node.class);
     newsNode.setProperty("id", "1");
@@ -1189,7 +1209,8 @@ public class NewsServiceImplTest {
                                                       publicationManagerImpl,
                                                       wcmPublicationServiceImpl,
                                                       newsSearchConnector,
-                                                      newsAttachmentsService);
+                                                      newsAttachmentsService,
+                                                      userACL);
     Node applicationDataNode = mock(Node.class);
     Node newsNode = mock(Node.class);
     newsNode.setProperty("id", "1");
@@ -1253,7 +1274,8 @@ public class NewsServiceImplTest {
                                                       publicationManagerImpl,
                                                       wcmPublicationServiceImpl,
                                                       newsSearchConnector,
-                                                      newsAttachmentsService);
+                                                      newsAttachmentsService,
+                                                      userACL);
     Node applicationDataNode = mock(Node.class);
     Node newsNode = mock(Node.class);
     newsNode.setProperty("id", "1");
@@ -1314,7 +1336,8 @@ public class NewsServiceImplTest {
                                                       publicationManagerImpl,
                                                       wcmPublicationServiceImpl,
                                                       newsSearchConnector,
-                                                      newsAttachmentsService);
+                                                      newsAttachmentsService,
+                                                      userACL);
     when(sessionProviderService.getSessionProvider(any())).thenReturn(sessionProvider);
     when(repositoryService.getCurrentRepository()).thenReturn(repository);
     when(repository.getConfiguration()).thenReturn(repositoryEntry);
@@ -1393,7 +1416,8 @@ public class NewsServiceImplTest {
                                                       publicationManagerImpl,
                                                       wcmPublicationServiceImpl,
                                                       newsSearchConnector,
-                                                      newsAttachmentsService);
+                                                      newsAttachmentsService,
+                                                      userACL);
     when(sessionProviderService.getSessionProvider(any())).thenReturn(sessionProvider);
     when(repositoryService.getCurrentRepository()).thenReturn(repository);
     when(repository.getConfiguration()).thenReturn(repositoryEntry);
@@ -1448,7 +1472,8 @@ public class NewsServiceImplTest {
                                                       publicationManagerImpl,
                                                       wcmPublicationServiceImpl,
                                                       newsSearchConnector,
-                                                      newsAttachmentsService);
+                                                      newsAttachmentsService,
+                                                      userACL);
     News news = new News();
     news.setId("id123");
     news.setViewsCount((long) 5);
@@ -1495,7 +1520,8 @@ public class NewsServiceImplTest {
                                                       publicationManagerImpl,
                                                       wcmPublicationServiceImpl,
                                                       newsSearchConnector,
-                                                      newsAttachmentsService);
+                                                      newsAttachmentsService,
+                                                      userACL);
     News news = new News();
     news.setId("id123");
     news.setViewsCount((long) 5);
@@ -1533,7 +1559,8 @@ public class NewsServiceImplTest {
                                                       publicationManagerImpl,
                                                       wcmPublicationServiceImpl,
                                                       newsSearchConnector,
-                                                      newsAttachmentsService);
+                                                      newsAttachmentsService,
+                                                      userACL);
     News news = new News();
     news.setId("id123");
     news.setViewsCount((long) 5);
@@ -1577,7 +1604,8 @@ public class NewsServiceImplTest {
                                                       publicationManagerImpl,
                                                       wcmPublicationServiceImpl,
                                                       newsSearchConnector,
-                                                      newsAttachmentsService);
+                                                      newsAttachmentsService,
+                                                      userACL);
     News news = new News();
     news.setId("id123");
     news.setViewsCount((long) 5);
@@ -1624,7 +1652,8 @@ public class NewsServiceImplTest {
                                                       publicationManagerImpl,
                                                       wcmPublicationServiceImpl,
                                                       newsSearchConnector,
-                                                      newsAttachmentsService);
+                                                      newsAttachmentsService,
+                                                      userACL);
     News news = new News();
     news.setId("id123");
     Node newsNode = mock(Node.class);
@@ -1663,7 +1692,8 @@ public class NewsServiceImplTest {
                                                       publicationManagerImpl,
                                                       wcmPublicationServiceImpl,
                                                       newsSearchConnector,
-                                                      newsAttachmentsService);
+                                                      newsAttachmentsService,
+                                                      userACL);
 
     Space currentSpace = mock(Space.class);
     org.exoplatform.services.security.Identity currentIdentity = new org.exoplatform.services.security.Identity("user");
@@ -1706,7 +1736,8 @@ public class NewsServiceImplTest {
                                                       publicationManagerImpl,
                                                       wcmPublicationServiceImpl,
                                                       newsSearchConnector,
-                                                      newsAttachmentsService);
+                                                      newsAttachmentsService,
+                                                      userACL);
 
     Space currentSpace = mock(Space.class);
     org.exoplatform.services.security.Identity currentIdentity = new org.exoplatform.services.security.Identity("user");
@@ -1749,7 +1780,8 @@ public class NewsServiceImplTest {
                                                       publicationManagerImpl,
                                                       wcmPublicationServiceImpl,
                                                       newsSearchConnector,
-                                                      newsAttachmentsService);
+                                                      newsAttachmentsService,
+                                                      userACL);
 
     Space currentSpace = mock(Space.class);
     org.exoplatform.services.security.Identity currentIdentity = new org.exoplatform.services.security.Identity("user");
@@ -1792,7 +1824,8 @@ public class NewsServiceImplTest {
                                                       publicationManagerImpl,
                                                       wcmPublicationServiceImpl,
                                                       newsSearchConnector,
-                                                      newsAttachmentsService);
+                                                      newsAttachmentsService,
+                                                      userACL);
 
     Space currentSpace = mock(Space.class);
     org.exoplatform.services.security.Identity currentIdentity = new org.exoplatform.services.security.Identity("user");
@@ -1835,7 +1868,8 @@ public class NewsServiceImplTest {
                                                       publicationManagerImpl,
                                                       wcmPublicationServiceImpl,
                                                       newsSearchConnector,
-                                                      newsAttachmentsService);
+                                                      newsAttachmentsService,
+                                                      userACL);
 
     Space currentSpace = mock(Space.class);
     org.exoplatform.services.security.Identity currentIdentity = new org.exoplatform.services.security.Identity("user");
@@ -1878,7 +1912,8 @@ public class NewsServiceImplTest {
                                                       publicationManagerImpl,
                                                       wcmPublicationServiceImpl,
                                                       newsSearchConnector,
-                                                      newsAttachmentsService);
+                                                      newsAttachmentsService,
+                                                      userACL);
 
     org.exoplatform.services.security.Identity currentIdentity = new org.exoplatform.services.security.Identity("user");
     MembershipEntry membershipentry = new MembershipEntry("/platform/web-contributors", "member");
@@ -1915,7 +1950,8 @@ public class NewsServiceImplTest {
                                                       publicationManagerImpl,
                                                       wcmPublicationServiceImpl,
                                                       newsSearchConnector,
-                                                      newsAttachmentsService);
+                                                      newsAttachmentsService,
+                                                      userACL);
 
     setCurrentIdentity();
 
@@ -1946,7 +1982,8 @@ public class NewsServiceImplTest {
                                                       publicationManagerImpl,
                                                       wcmPublicationServiceImpl,
                                                       newsSearchConnector,
-                                                      newsAttachmentsService);
+                                                      newsAttachmentsService,
+                                                      userACL);
     News news = new News();
     news.setAuthor("root");
     news.setSpaceId("1");
@@ -1997,7 +2034,8 @@ public class NewsServiceImplTest {
                                                       publicationManagerImpl,
                                                       wcmPublicationServiceImpl,
                                                       newsSearchConnector,
-                                                      newsAttachmentsService);
+                                                      newsAttachmentsService,
+                                                      userACL);
     News news = new News();
     news.setAuthor("root");
     news.setSpaceId("1");
@@ -2048,7 +2086,8 @@ public class NewsServiceImplTest {
                                                       publicationManagerImpl,
                                                       wcmPublicationServiceImpl,
                                                       newsSearchConnector,
-                                                      newsAttachmentsService);
+                                                      newsAttachmentsService,
+                                                      userACL);
     when(sessionProviderService.getSessionProvider(any())).thenReturn(sessionProvider);
     when(repositoryService.getCurrentRepository()).thenReturn(repository);
     when(repository.getConfiguration()).thenReturn(repositoryEntry);
@@ -2157,7 +2196,8 @@ public class NewsServiceImplTest {
                                                       publicationManagerImpl,
                                                       wcmPublicationServiceImpl,
                                                       newsSearchConnector,
-                                                      newsAttachmentsService);
+                                                      newsAttachmentsService,
+                                                      userACL);
 
     News news = new News();
     news.setTitle("unpinned");
@@ -2192,7 +2232,8 @@ public class NewsServiceImplTest {
                                                       publicationManagerImpl,
                                                       wcmPublicationServiceImpl,
                                                       newsSearchConnector,
-                                                      newsAttachmentsService);
+                                                      newsAttachmentsService,
+                                                      userACL);
 
     News news = new News();
     news.setTitle("unpinned");
@@ -2250,7 +2291,8 @@ public class NewsServiceImplTest {
                                                       publicationManagerImpl,
                                                       wcmPublicationServiceImpl,
                                                       newsSearchConnector,
-                                                      newsAttachmentsService);
+                                                      newsAttachmentsService,
+                                                      userACL);
 
     News news = new News();
     news.setTitle("title");
@@ -2355,7 +2397,8 @@ public class NewsServiceImplTest {
                                                       publicationManagerImpl,
                                                       wcmPublicationServiceImpl,
                                                       newsSearchConnector,
-                                                      newsAttachmentsService);
+                                                      newsAttachmentsService,
+                                                      userACL);
 
     News news = new News();
     news.setTitle("title");
@@ -2461,7 +2504,8 @@ public class NewsServiceImplTest {
                                                       publicationManagerImpl,
                                                       wcmPublicationServiceImpl,
                                                       newsSearchConnector,
-                                                      newsAttachmentsService);
+                                                      newsAttachmentsService,
+                                                      userACL);
 
     News news = new News();
     news.setTitle("title");
@@ -2563,7 +2607,8 @@ public class NewsServiceImplTest {
                                                       publicationManagerImpl,
                                                       wcmPublicationServiceImpl,
                                                       newsSearchConnector,
-                                                      newsAttachmentsService);
+                                                      newsAttachmentsService,
+                                                      userACL);
     when(sessionProviderService.getSessionProvider(any())).thenReturn(sessionProvider);
     when(repositoryService.getCurrentRepository()).thenReturn(repository);
     when(repository.getConfiguration()).thenReturn(repositoryEntry);
@@ -2643,7 +2688,8 @@ public class NewsServiceImplTest {
                                                       publicationManagerImpl,
                                                       wcmPublicationServiceImpl,
                                                       newsSearchConnector,
-                                                      newsAttachmentsService);
+                                                      newsAttachmentsService,
+                                                      userACL);
     when(sessionProviderService.getSessionProvider(any())).thenReturn(sessionProvider);
     when(repositoryService.getCurrentRepository()).thenReturn(repository);
     when(repository.getConfiguration()).thenReturn(repositoryEntry);
@@ -2688,7 +2734,8 @@ public class NewsServiceImplTest {
                                                       publicationManagerImpl,
                                                       wcmPublicationServiceImpl,
                                                       newsSearchConnector,
-                                                      newsAttachmentsService);
+                                                      newsAttachmentsService,
+                                                      userACL);
 
     ExtendedNode newsNode = mock(ExtendedNode.class);
 
@@ -2746,7 +2793,8 @@ public class NewsServiceImplTest {
                                                       publicationManagerImpl,
                                                       wcmPublicationServiceImpl,
                                                       newsSearchConnector,
-                                                      newsAttachmentsService);
+                                                      newsAttachmentsService,
+                                                      userACL);
 
     ExtendedNode newsNode = mock(ExtendedNode.class);
 
@@ -2796,7 +2844,8 @@ public class NewsServiceImplTest {
                                                       publicationManagerImpl,
                                                       wcmPublicationServiceImpl,
                                                       newsSearchConnector,
-                                                      newsAttachmentsService);
+                                                      newsAttachmentsService,
+                                                      userACL);
 
     ExtendedNode newsNode = mock(ExtendedNode.class);
 
@@ -2846,7 +2895,8 @@ public class NewsServiceImplTest {
                                                       publicationManagerImpl,
                                                       wcmPublicationServiceImpl,
                                                       newsSearchConnector,
-                                                      newsAttachmentsService);
+                                                      newsAttachmentsService,
+                                                      userACL);
 
     ExtendedNode newsNode = mock(ExtendedNode.class);
 
@@ -2882,20 +2932,21 @@ public class NewsServiceImplTest {
   public void shouldUpdateNewsNodePathWhenNewsNameIsUpdated() throws Exception {
     // Given
     NewsService newsService = new NewsServiceImpl(repositoryService,
-            sessionProviderService,
-            nodeHierarchyCreator,
-            dataDistributionManager,
-            spaceService,
-            activityManager,
-            identityManager,
-            uploadService,
-            imageProcessor,
-            linkManager,
-            publicationServiceImpl,
-            publicationManagerImpl,
-            wcmPublicationServiceImpl,
-            newsSearchConnector,
-            newsAttachmentsService);
+                                                  sessionProviderService,
+                                                  nodeHierarchyCreator,
+                                                  dataDistributionManager,
+                                                  spaceService,
+                                                  activityManager,
+                                                  identityManager,
+                                                  uploadService,
+                                                  imageProcessor,
+                                                  linkManager,
+                                                  publicationServiceImpl,
+                                                  publicationManagerImpl,
+                                                  wcmPublicationServiceImpl,
+                                                  newsSearchConnector,
+                                                  newsAttachmentsService,
+                                                  userACL);
 
     Node newsNode = mock(Node.class);
     Node parentNode = mock(Node.class);
@@ -2947,20 +2998,21 @@ public class NewsServiceImplTest {
   public void shouldUpdateNewsMentionedIdsWhenNewsBodyIsUpdated() throws Exception {
     // Given
     NewsService newsService = new NewsServiceImpl(repositoryService,
-            sessionProviderService,
-            nodeHierarchyCreator,
-            dataDistributionManager,
-            spaceService,
-            activityManager,
-            identityManager,
-            uploadService,
-            imageProcessor,
-            linkManager,
-            publicationServiceImpl,
-            publicationManagerImpl,
-            wcmPublicationServiceImpl,
-            newsSearchConnector,
-            newsAttachmentsService);
+                                                  sessionProviderService,
+                                                  nodeHierarchyCreator,
+                                                  dataDistributionManager,
+                                                  spaceService,
+                                                  activityManager,
+                                                  identityManager,
+                                                  uploadService,
+                                                  imageProcessor,
+                                                  linkManager,
+                                                  publicationServiceImpl,
+                                                  publicationManagerImpl,
+                                                  wcmPublicationServiceImpl,
+                                                  newsSearchConnector,
+                                                  newsAttachmentsService,
+                                                  userACL);
 
     Node newsNode = mock(Node.class);
     Node parentNode = mock(Node.class);
@@ -3105,20 +3157,21 @@ public class NewsServiceImplTest {
   public void testFormatMention() throws Exception {
     //Given
     NewsServiceImpl newsServiceImpl = new NewsServiceImpl(repositoryService,
-            sessionProviderService,
-            nodeHierarchyCreator,
-            dataDistributionManager,
-            spaceService,
-            activityManager,
-            identityManager,
-            uploadService,
-            imageProcessor,
-            linkManager,
-            publicationServiceImpl,
-            publicationManagerImpl,
-            wcmPublicationServiceImpl,
-            newsSearchConnector,
-            newsAttachmentsService);
+                                                          sessionProviderService,
+                                                          nodeHierarchyCreator,
+                                                          dataDistributionManager,
+                                                          spaceService,
+                                                          activityManager,
+                                                          identityManager,
+                                                          uploadService,
+                                                          imageProcessor,
+                                                          linkManager,
+                                                          publicationServiceImpl,
+                                                          publicationManagerImpl,
+                                                          wcmPublicationServiceImpl,
+                                                          newsSearchConnector,
+                                                          newsAttachmentsService,
+                                                          userACL);
     Identity posterIdentity = new Identity(OrganizationIdentityProvider.NAME, "john");
     Profile profile = posterIdentity.getProfile();
     profile.setUrl("/profile/john");
@@ -3137,22 +3190,23 @@ public class NewsServiceImplTest {
   }
   @Test
   public void testWrongFormatMention() throws Exception {
-    //Given
+    // Given
     NewsServiceImpl newsServiceImpl = new NewsServiceImpl(repositoryService,
-            sessionProviderService,
-            nodeHierarchyCreator,
-            dataDistributionManager,
-            spaceService,
-            activityManager,
-            identityManager,
-            uploadService,
-            imageProcessor,
-            linkManager,
-            publicationServiceImpl,
-            publicationManagerImpl,
-            wcmPublicationServiceImpl,
-            newsSearchConnector,
-            newsAttachmentsService);
+                                                          sessionProviderService,
+                                                          nodeHierarchyCreator,
+                                                          dataDistributionManager,
+                                                          spaceService,
+                                                          activityManager,
+                                                          identityManager,
+                                                          uploadService,
+                                                          imageProcessor,
+                                                          linkManager,
+                                                          publicationServiceImpl,
+                                                          publicationManagerImpl,
+                                                          wcmPublicationServiceImpl,
+                                                          newsSearchConnector,
+                                                          newsAttachmentsService,
+                                                          userACL);
     Identity posterIdentity = new Identity(OrganizationIdentityProvider.NAME, "john");
     Profile profile = posterIdentity.getProfile();
     profile.setUrl("/profile/john");
@@ -3182,7 +3236,8 @@ public class NewsServiceImplTest {
                                                       publicationManagerImpl,
                                                       wcmPublicationServiceImpl,
                                                       newsSearchConnector,
-                                                      newsAttachmentsService);
+                                                      newsAttachmentsService,
+                                                      userACL);
   
     Node newsNode = mock(Node.class);
     when(newsNode.hasProperty(anyString())).thenReturn(true);

--- a/services/src/test/java/org/exoplatform/news/NewsServiceImplTest.java
+++ b/services/src/test/java/org/exoplatform/news/NewsServiceImplTest.java
@@ -1126,6 +1126,8 @@ public class NewsServiceImplTest {
     Node applicationDataNode = mock(Node.class);
     Node newsNode = mock(Node.class);
     newsNode.setProperty("id", "1");
+    Property exoActivitiesProperty = mock(Property.class);
+    
 
     Space space1 = new Space();
     space1.setId("1");
@@ -1150,6 +1152,9 @@ public class NewsServiceImplTest {
     when(sessionProvider.getSession(any(), any())).thenReturn(session);
     when(session.getItem(anyString())).thenReturn(applicationDataNode);
     when(session.getNodeByUUID(anyString())).thenReturn(newsNode);
+    when(newsNode.hasProperty("exo:activities")).thenReturn(true);
+    when(newsNode.getProperty("exo:activities")).thenReturn(exoActivitiesProperty);
+    when(exoActivitiesProperty.getString()).thenReturn("1:1;2:2;2:3");
 
     // When
     newsService.deleteNews("1");
@@ -1158,6 +1163,7 @@ public class NewsServiceImplTest {
     verify(session, times(1)).getNodeByUUID(anyString());
     verify(session, times(1)).save();
     verify(newsNode, times(1)).remove();
+    verify(activityManager, times(3)).deleteActivity(anyString());
   }
 
   @Test

--- a/services/src/test/java/org/exoplatform/news/rest/NewsRestResourcesV1Test.java
+++ b/services/src/test/java/org/exoplatform/news/rest/NewsRestResourcesV1Test.java
@@ -20,6 +20,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.RuntimeDelegate;
 
+import org.exoplatform.container.PortalContainer;
 import org.exoplatform.news.NewsAttachmentsService;
 import org.exoplatform.news.NewsService;
 import org.exoplatform.news.filter.NewsFilter;
@@ -59,6 +60,9 @@ public class NewsRestResourcesV1Test {
   @Mock
   ActivityManager        activityManager;
 
+  @Mock
+  PortalContainer        container;
+
   @Before
   public void setup() {
     RuntimeDelegate.setInstance(new RuntimeDelegateImpl());
@@ -70,7 +74,8 @@ public class NewsRestResourcesV1Test {
     NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
                                                                       newsAttachmentsService,
                                                                       spaceService,
-                                                                      identityManager);
+                                                                      identityManager,
+                                                                      container);
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getRemoteUser()).thenReturn("john");
     News news = new News();
@@ -97,7 +102,8 @@ public class NewsRestResourcesV1Test {
     NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
                                                                       newsAttachmentsService,
                                                                       spaceService,
-                                                                      identityManager);
+                                                                      identityManager,
+                                                                      container);
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getRemoteUser()).thenReturn("john");
     News news = new News();
@@ -119,7 +125,8 @@ public class NewsRestResourcesV1Test {
     NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
                                                                       newsAttachmentsService,
                                                                       spaceService,
-                                                                      identityManager);
+                                                                      identityManager,
+                                                                      container);
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getRemoteUser()).thenReturn("john");
     News news = new News();
@@ -141,7 +148,8 @@ public class NewsRestResourcesV1Test {
     NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
                                                                       newsAttachmentsService,
                                                                       spaceService,
-                                                                      identityManager);
+                                                                      identityManager,
+                                                                      container);
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getRemoteUser()).thenReturn("john");
     when(newsService.getNewsById(anyString())).thenReturn(null);
@@ -159,7 +167,7 @@ public class NewsRestResourcesV1Test {
   @Test
   public void shouldGetNewsSpacesWhenNewsExistsAndUserIsMemberOfTheSpace() throws Exception {
     // Given
-    NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService, newsAttachmentsService, spaceService, identityManager);
+    NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService, newsAttachmentsService, spaceService, identityManager,container);
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getRemoteUser()).thenReturn("john");
     News news = new News();
@@ -199,7 +207,8 @@ public class NewsRestResourcesV1Test {
     NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
                                                                       newsAttachmentsService,
                                                                       spaceService,
-                                                                      identityManager);
+                                                                      identityManager,
+                                                                      container);
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getRemoteUser()).thenReturn("john");
     News existingNews = new News();
@@ -237,7 +246,8 @@ public class NewsRestResourcesV1Test {
     NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
                                                                       newsAttachmentsService,
                                                                       spaceService,
-                                                                      identityManager);
+                                                                      identityManager,
+                                                                      container);
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getRemoteUser()).thenReturn("john");
     News news = new News();
@@ -276,7 +286,8 @@ public class NewsRestResourcesV1Test {
     NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
                                                                       newsAttachmentsService,
                                                                       spaceService,
-                                                                      identityManager);
+                                                                      identityManager,
+                                                                      container);
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getRemoteUser()).thenReturn("john");
     News news = new News();
@@ -298,7 +309,8 @@ public class NewsRestResourcesV1Test {
     NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
                                                                       newsAttachmentsService,
                                                                       spaceService,
-                                                                      identityManager);
+                                                                      identityManager,
+                                                                      container);
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getRemoteUser()).thenReturn("john");
     when(newsService.getNewsById(anyString())).thenReturn(null);
@@ -319,7 +331,8 @@ public class NewsRestResourcesV1Test {
     NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
                                                                       newsAttachmentsService,
                                                                       spaceService,
-                                                                      identityManager);
+                                                                      identityManager,
+                                                                      container);
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getRemoteUser()).thenReturn("john");
 
@@ -365,7 +378,8 @@ public class NewsRestResourcesV1Test {
     NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
                                                                       newsAttachmentsService,
                                                                       spaceService,
-                                                                      identityManager);
+                                                                      identityManager,
+                                                                      container);
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getRemoteUser()).thenReturn("john");
 
@@ -414,7 +428,8 @@ public class NewsRestResourcesV1Test {
     NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
                                                                       newsAttachmentsService,
                                                                       spaceService,
-                                                                      identityManager);
+                                                                      identityManager,
+                                                                      container);
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getRemoteUser()).thenReturn("john");
 
@@ -464,7 +479,8 @@ public class NewsRestResourcesV1Test {
     NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
                                                                       newsAttachmentsService,
                                                                       spaceService,
-                                                                      identityManager);
+                                                                      identityManager,
+                                                                      container);
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getRemoteUser()).thenReturn("john");
 
@@ -514,7 +530,8 @@ public class NewsRestResourcesV1Test {
     NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
                                                                       newsAttachmentsService,
                                                                       spaceService,
-                                                                      identityManager);
+                                                                      identityManager,
+                                                                      container);
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getRemoteUser()).thenReturn("john");
 
@@ -564,7 +581,8 @@ public class NewsRestResourcesV1Test {
     NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
                                                                       newsAttachmentsService,
                                                                       spaceService,
-                                                                      identityManager);
+                                                                      identityManager,
+                                                                      container);
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getRemoteUser()).thenReturn("john");
 
@@ -619,7 +637,8 @@ public class NewsRestResourcesV1Test {
     NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
                                                                       newsAttachmentsService,
                                                                       spaceService,
-                                                                      identityManager);
+                                                                      identityManager,
+                                                                      container);
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getRemoteUser()).thenReturn("john");
 
@@ -665,7 +684,8 @@ public class NewsRestResourcesV1Test {
     NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
                                                                       newsAttachmentsService,
                                                                       spaceService,
-                                                                      identityManager);
+                                                                      identityManager,
+                                                                      container);
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getRemoteUser()).thenReturn("john");
 
@@ -708,7 +728,8 @@ public class NewsRestResourcesV1Test {
     NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
                                                                       newsAttachmentsService,
                                                                       spaceService,
-                                                                      identityManager);
+                                                                      identityManager,
+                                                                      container);
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getRemoteUser()).thenReturn("john");
 
@@ -730,7 +751,8 @@ public class NewsRestResourcesV1Test {
     NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
                                                                       newsAttachmentsService,
                                                                       spaceService,
-                                                                      identityManager);
+                                                                      identityManager,
+                                                                      container);
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getRemoteUser()).thenReturn("john");
 
@@ -773,7 +795,8 @@ public class NewsRestResourcesV1Test {
     NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
                                                                       newsAttachmentsService,
                                                                       spaceService,
-                                                                      identityManager);
+                                                                      identityManager,
+                                                                      container);
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getRemoteUser()).thenReturn("john");
 
@@ -822,7 +845,8 @@ public class NewsRestResourcesV1Test {
     NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
                                                                       newsAttachmentsService,
                                                                       spaceService,
-                                                                      identityManager);
+                                                                      identityManager,
+                                                                      container);
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getRemoteUser()).thenReturn("john");
 
@@ -867,7 +891,8 @@ public class NewsRestResourcesV1Test {
     NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
                                                                       newsAttachmentsService,
                                                                       spaceService,
-                                                                      identityManager);
+                                                                      identityManager,
+                                                                      container);
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getRemoteUser()).thenReturn("john");
     when(spaceService.getSpaceById(anyString())).thenReturn(new Space());
@@ -887,7 +912,8 @@ public class NewsRestResourcesV1Test {
     NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
                                                                       newsAttachmentsService,
                                                                       spaceService,
-                                                                      identityManager);
+                                                                      identityManager,
+                                                                      container);
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getRemoteUser()).thenReturn("john");
 
@@ -906,7 +932,8 @@ public class NewsRestResourcesV1Test {
     NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
                                                                       newsAttachmentsService,
                                                                       spaceService,
-                                                                      identityManager);
+                                                                      identityManager,
+                                                                      container);
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getRemoteUser()).thenReturn("john");
     when(spaceService.isMember(any(Space.class), eq("john"))).thenReturn(false);
@@ -926,7 +953,8 @@ public class NewsRestResourcesV1Test {
     NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
                                                                       newsAttachmentsService,
                                                                       spaceService,
-                                                                      identityManager);
+                                                                      identityManager,
+                                                                      container);
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getRemoteUser()).thenReturn("john");
     News news = new News();
@@ -953,7 +981,8 @@ public class NewsRestResourcesV1Test {
     NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
                                                                       newsAttachmentsService,
                                                                       spaceService,
-                                                                      identityManager);
+                                                                      identityManager,
+                                                                      container);
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getRemoteUser()).thenReturn("john");
     News news = new News();
@@ -981,7 +1010,8 @@ public class NewsRestResourcesV1Test {
     NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
                                                                       newsAttachmentsService,
                                                                       spaceService,
-                                                                      identityManager);
+                                                                      identityManager,
+                                                                      container);
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getRemoteUser()).thenReturn("john");
     News news = new News();
@@ -1007,7 +1037,8 @@ public class NewsRestResourcesV1Test {
     NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
                                                                       newsAttachmentsService,
                                                                       spaceService,
-                                                                      identityManager);
+                                                                      identityManager,
+                                                                      container);
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getRemoteUser()).thenReturn("john");
     when(newsService.getNewsById(anyString())).thenReturn(null);
@@ -1028,7 +1059,8 @@ public class NewsRestResourcesV1Test {
     NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
                                                                       newsAttachmentsService,
                                                                       spaceService,
-                                                                      identityManager);
+                                                                      identityManager,
+                                                                      container);
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getRemoteUser()).thenReturn("john");
     News news = new News();
@@ -1055,7 +1087,8 @@ public class NewsRestResourcesV1Test {
     NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
                                                                       newsAttachmentsService,
                                                                       spaceService,
-                                                                      identityManager);
+                                                                      identityManager,
+                                                                      container);
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getRemoteUser()).thenReturn("john");
     News news = new News();
@@ -1079,7 +1112,8 @@ public class NewsRestResourcesV1Test {
     NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
                                                                       newsAttachmentsService,
                                                                       spaceService,
-                                                                      identityManager);
+                                                                      identityManager,
+                                                                      container);
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getRemoteUser()).thenReturn("john");
     when(newsService.getNewsById(anyString())).thenReturn(null);
@@ -1100,7 +1134,8 @@ public class NewsRestResourcesV1Test {
     NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
                                                                       newsAttachmentsService,
                                                                       spaceService,
-                                                                      identityManager);
+                                                                      identityManager,
+                                                                      container);
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getRemoteUser()).thenReturn("john");
     when(newsService.getNewsById(anyString())).thenReturn(null);
@@ -1121,7 +1156,8 @@ public class NewsRestResourcesV1Test {
     NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
                                                                       newsAttachmentsService,
                                                                       spaceService,
-                                                                      identityManager);
+                                                                      identityManager,
+                                                                      container);
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getRemoteUser()).thenReturn("john");
     News news = new News();
@@ -1154,7 +1190,8 @@ public class NewsRestResourcesV1Test {
     NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
                                                                       newsAttachmentsService,
                                                                       spaceService,
-                                                                      identityManager);
+                                                                      identityManager,
+                                                                      container);
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getRemoteUser()).thenReturn("john");
     News news = new News();
@@ -1183,7 +1220,8 @@ public class NewsRestResourcesV1Test {
     NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
                                                                       newsAttachmentsService,
                                                                       spaceService,
-                                                                      identityManager);
+                                                                      identityManager,
+                                                                      container);
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getRemoteUser()).thenReturn("");
     News news = new News();
@@ -1211,7 +1249,8 @@ public class NewsRestResourcesV1Test {
     NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
                                                                       newsAttachmentsService,
                                                                       spaceService,
-                                                                      identityManager);
+                                                                      identityManager,
+                                                                      container);
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getRemoteUser()).thenReturn("john");
     when(newsService.getNewsDrafts(anyString(), anyString())).thenReturn(null);
@@ -1234,7 +1273,8 @@ public class NewsRestResourcesV1Test {
     NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
                                                                       newsAttachmentsService,
                                                                       spaceService,
-                                                                      identityManager);
+                                                                      identityManager,
+                                                                      container);
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getRemoteUser()).thenReturn("john");
     News news = new News();
@@ -1250,7 +1290,7 @@ public class NewsRestResourcesV1Test {
     when(spaceService.isSuperManager(eq("john"))).thenReturn(true);
 
     // When
-    Response response = newsRestResourcesV1.deleteNews(request, "1");
+    Response response = newsRestResourcesV1.deleteNews(request, "1", 0L);
 
     // Then
     assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
@@ -1263,7 +1303,8 @@ public class NewsRestResourcesV1Test {
     NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
                                                                       newsAttachmentsService,
                                                                       spaceService,
-                                                                      identityManager);
+                                                                      identityManager,
+                                                                      container);
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getRemoteUser()).thenReturn("john");
     News news = new News();
@@ -1279,7 +1320,7 @@ public class NewsRestResourcesV1Test {
     when(spaceService.isSuperManager(eq("john"))).thenReturn(true);
 
     // When
-    Response response = newsRestResourcesV1.deleteNews(request, "1");
+    Response response = newsRestResourcesV1.deleteNews(request, "1", 0L);
 
     // Then
     assertEquals(Response.Status.UNAUTHORIZED.getStatusCode(), response.getStatus());
@@ -1292,7 +1333,8 @@ public class NewsRestResourcesV1Test {
     NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
                                                                       newsAttachmentsService,
                                                                       spaceService,
-                                                                      identityManager);
+                                                                      identityManager,
+                                                                      container);
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getRemoteUser()).thenReturn("john");
     News news = new News();
@@ -1304,7 +1346,7 @@ public class NewsRestResourcesV1Test {
     when(spaceService.isSuperManager(eq("john"))).thenReturn(false);
 
     // When
-    Response response = newsRestResourcesV1.deleteNews(request, "1");
+    Response response = newsRestResourcesV1.deleteNews(request, "1", 0L);
 
     // Then
     assertEquals(Response.Status.UNAUTHORIZED.getStatusCode(), response.getStatus());
@@ -1317,7 +1359,8 @@ public class NewsRestResourcesV1Test {
     NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
                                                                       newsAttachmentsService,
                                                                       spaceService,
-                                                                      identityManager);
+                                                                      identityManager,
+                                                                      container);
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getRemoteUser()).thenReturn("john");
     when(newsService.getNewsById(anyString())).thenReturn(null);
@@ -1326,7 +1369,7 @@ public class NewsRestResourcesV1Test {
     when(spaceService.isSuperManager(eq("john"))).thenReturn(true);
 
     // When
-    Response response = newsRestResourcesV1.deleteNews(request, "1");
+    Response response = newsRestResourcesV1.deleteNews(request, "1", 0L);
 
     // Then
     assertEquals(Response.Status.NOT_FOUND.getStatusCode(), response.getStatus());
@@ -1339,7 +1382,8 @@ public class NewsRestResourcesV1Test {
     NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
                                                                       newsAttachmentsService,
                                                                       spaceService,
-                                                                      identityManager);
+                                                                      identityManager,
+                                                                      container);
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getRemoteUser()).thenReturn("john");
     when(newsService.getNewsById(anyString())).thenReturn(null);
@@ -1348,7 +1392,7 @@ public class NewsRestResourcesV1Test {
     when(spaceService.isSuperManager(eq("john"))).thenReturn(true);
 
     // When
-    Response response = newsRestResourcesV1.deleteNews(request, null);
+    Response response = newsRestResourcesV1.deleteNews(request, null, 0L);
 
     // Then
     assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
@@ -1361,7 +1405,8 @@ public class NewsRestResourcesV1Test {
     NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
                                                                       newsAttachmentsService,
                                                                       spaceService,
-                                                                      identityManager);
+                                                                      identityManager,
+                                                                      container);
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getRemoteUser()).thenReturn("john");
     News news = new News();
@@ -1384,7 +1429,8 @@ public class NewsRestResourcesV1Test {
     NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
                                                                       newsAttachmentsService,
                                                                       spaceService,
-                                                                      identityManager);
+                                                                      identityManager,
+                                                                      container);
     HttpServletRequest request = mock(HttpServletRequest.class);
     News news = new News();
     news.setId("1");
@@ -1404,7 +1450,8 @@ public class NewsRestResourcesV1Test {
     NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
                                                                       newsAttachmentsService,
                                                                       spaceService,
-                                                                      identityManager);
+                                                                      identityManager,
+                                                                      container);
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getRemoteUser()).thenReturn("john");
     News news = new News();
@@ -1432,7 +1479,8 @@ public class NewsRestResourcesV1Test {
     NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
                                                                       newsAttachmentsService,
                                                                       spaceService,
-                                                                      identityManager);
+                                                                      identityManager,
+                                                                      container);
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getRemoteUser()).thenReturn("john");
     News news = new News();
@@ -1461,7 +1509,8 @@ public class NewsRestResourcesV1Test {
     NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
                                                                       newsAttachmentsService,
                                                                       spaceService,
-                                                                      identityManager);
+                                                                      identityManager,
+                                                                      container);
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getRemoteUser()).thenReturn("john");
     News news1 = new News();
@@ -1489,7 +1538,8 @@ public class NewsRestResourcesV1Test {
     NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
                                                                       newsAttachmentsService,
                                                                       spaceService,
-                                                                      identityManager);
+                                                                      identityManager,
+                                                                      container);
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getRemoteUser()).thenReturn("john");
     NewsFilter newsFilter = new NewsFilter();
@@ -1511,7 +1561,8 @@ public class NewsRestResourcesV1Test {
     NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
                                                                       newsAttachmentsService,
                                                                       spaceService,
-                                                                      identityManager);
+                                                                      identityManager,
+                                                                      container);
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getRemoteUser()).thenReturn("john");
     News news = new News();
@@ -1539,7 +1590,8 @@ public class NewsRestResourcesV1Test {
     NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
                                                                       newsAttachmentsService,
                                                                       spaceService,
-                                                                      identityManager);
+                                                                      identityManager,
+                                                                      container);
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getRemoteUser()).thenReturn("john");
     News news = new News();
@@ -1561,7 +1613,8 @@ public class NewsRestResourcesV1Test {
     NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
                                                                       newsAttachmentsService,
                                                                       spaceService,
-                                                                      identityManager);
+                                                                      identityManager,
+                                                                      container);
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getRemoteUser()).thenReturn("john");
     News news1 = new News();
@@ -1608,7 +1661,8 @@ public class NewsRestResourcesV1Test {
     NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
                                                                       newsAttachmentsService,
                                                                       spaceService,
-                                                                      identityManager);
+                                                                      identityManager,
+                                                                      container);
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getRemoteUser()).thenReturn("john");
     when(request.getLocale()).thenReturn(new Locale("en"));
@@ -1662,7 +1716,8 @@ public class NewsRestResourcesV1Test {
     NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
                                                                       newsAttachmentsService,
                                                                       spaceService,
-                                                                      identityManager);
+                                                                      identityManager,
+                                                                      container);
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getRemoteUser()).thenReturn("john");
     when(request.getLocale()).thenReturn(new Locale("en"));
@@ -1713,7 +1768,8 @@ public class NewsRestResourcesV1Test {
     NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
                                                                       newsAttachmentsService,
                                                                       spaceService,
-                                                                      identityManager);
+                                                                      identityManager,
+                                                                      container);
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getRemoteUser()).thenReturn("john");
     when(request.getLocale()).thenReturn(new Locale("en"));
@@ -1768,7 +1824,8 @@ public class NewsRestResourcesV1Test {
     NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
                                                                       newsAttachmentsService,
                                                                       spaceService,
-                                                                      identityManager);
+                                                                      identityManager,
+                                                                      container);
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getRemoteUser()).thenReturn("john");
     when(request.getLocale()).thenReturn(new Locale("en"));
@@ -1800,7 +1857,8 @@ public class NewsRestResourcesV1Test {
     NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
                                                                       newsAttachmentsService,
                                                                       spaceService,
-                                                                      identityManager);
+                                                                      identityManager,
+                                                                      container);
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getRemoteUser()).thenReturn("john");
     when(request.getLocale()).thenReturn(new Locale("en"));
@@ -1849,7 +1907,8 @@ public class NewsRestResourcesV1Test {
     NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
                                                                       newsAttachmentsService,
                                                                       spaceService,
-                                                                      identityManager);
+                                                                      identityManager,
+                                                                      container);
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getRemoteUser()).thenReturn("john");
     when(request.getLocale()).thenReturn(new Locale("en"));
@@ -1900,7 +1959,8 @@ public class NewsRestResourcesV1Test {
     NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
                                                                       newsAttachmentsService,
                                                                       spaceService,
-                                                                      identityManager);
+                                                                      identityManager,
+                                                                      container);
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getRemoteUser()).thenReturn("john");
     when(request.getLocale()).thenReturn(new Locale("en"));

--- a/services/src/test/java/org/exoplatform/news/rest/NewsRestResourcesV1Test.java
+++ b/services/src/test/java/org/exoplatform/news/rest/NewsRestResourcesV1Test.java
@@ -1281,6 +1281,7 @@ public class NewsRestResourcesV1Test {
     news.setId("1");
     news.setAuthor("john");
     news.setSpaceId("1");
+    news.setCanDelete(true);
     when(newsService.getNewsById(anyString())).thenReturn(news);
     Space space1 = new Space();
     space1.setId("1");
@@ -1311,6 +1312,7 @@ public class NewsRestResourcesV1Test {
     news.setId("1");
     news.setAuthor("mary");
     news.setSpaceId("1");
+    news.setCanDelete(true);
     when(newsService.getNewsById(anyString())).thenReturn(news);
     Space space1 = new Space();
     space1.setId("1");
@@ -1323,8 +1325,8 @@ public class NewsRestResourcesV1Test {
     Response response = newsRestResourcesV1.deleteNews(request, "1", 0L);
 
     // Then
-    assertEquals(Response.Status.UNAUTHORIZED.getStatusCode(), response.getStatus());
-    verify(newsService, never()).deleteNews("1");
+    assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+    verify(newsService).deleteNews("1");
   }
 
   @Test
@@ -1339,6 +1341,7 @@ public class NewsRestResourcesV1Test {
     when(request.getRemoteUser()).thenReturn("john");
     News news = new News();
     news.setId("1");
+    news.setCanDelete(false);
     news.setSpaceId("1");
     when(newsService.getNewsById(anyString())).thenReturn(news);
     when(spaceService.getSpaceById(anyString())).thenReturn(new Space());

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -10,7 +10,7 @@
     "start": "webpack --config webpack.dev.js --mode development",
     "dev": "webpack-dev-server --config webpack.dev.js --mode development --hot",
     "watch": "webpack --config webpack.dev.js --progress --colors --watch -d",
-    "lint": "eslint --fix ./src/main/webapp/news-activity-composer-app/components/*.vue ./src/main/webapp/news/components/*.vue ./src/main/webapp/news-details/components/*.vue ./src/main/webapp/news-details/components/*.js ./src/main/webapp/news-details/*.js",
+    "lint": "eslint --fix ./src/main/webapp/news-activity-composer-app/components/*.vue ./src/main/webapp/news/components/*.vue ./src/main/webapp/news-details/components/*.vue ./src/main/webapp/news-details/components/*.js ./src/main/webapp/news-details/*.js ./src/main/webapp/components/**/*.vue",
     "test": "jest",
     "test-coverage": "jest --coverage",
     "build": "webpack --config webpack.prod.js --mode production"

--- a/webapp/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/webapp/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -195,6 +195,9 @@
       <module>modalComponent</module>
     </depends>
     <depends>
+      <module>snackbarComponent</module>
+    </depends>
+    <depends>
       <module>commons-editor</module>
       <as>editor</as>
     </depends>
@@ -273,6 +276,17 @@
     <script>
       <minify>false</minify>
       <path>/js/modalComponent.bundle.js</path>
+    </script>
+    <depends>
+      <module>vue</module>
+    </depends>
+  </module>
+
+  <module>
+    <name>snackbarComponent</name>
+    <script>
+      <minify>false</minify>
+      <path>/js/snackbarComponent.bundle.js</path>
     </script>
     <depends>
       <module>vue</module>

--- a/webapp/src/main/webapp/components/snackbar/ExoNewsNotificationAlert.vue
+++ b/webapp/src/main/webapp/components/snackbar/ExoNewsNotificationAlert.vue
@@ -1,0 +1,63 @@
+<template>
+  <v-alert
+      v-model="displayAlert"
+      :type="alertType"
+      border="left"
+      class="white"
+      elevation="2"
+      dismissible
+      colored-border
+      outlined>
+    <span class="text-color">
+      {{ alertMessage }}
+    </span>
+    <v-btn
+        v-if="alert.click"
+        class="primary--text"
+        text
+        @click="alert.click">
+      {{ alert.clickMessage }}
+    </v-btn>
+    <v-btn
+        slot="close"
+        slot-scope="{toggle}"
+        icon
+        small
+        light
+        @click="toggle">
+      <v-icon>close</v-icon>
+    </v-btn>
+  </v-alert>
+</template>
+
+<script>
+export default {
+  props: {
+    alert: {
+      type: Object,
+      default: null
+    },
+  },
+  data: () => ({
+    displayAlert: true,
+  }),
+  computed: {
+    alertMessage() {
+      return this.alert.message;
+    },
+    alertType() {
+      return this.alert.type;
+    },
+  },
+  watch: {
+    displayAlert() {
+      if (!this.displayAlert) {
+        this.$emit('dismissed');
+      }
+    },
+  },
+  created() {
+    window.setTimeout(() => this.displayAlert = false, 5000);
+  },
+};
+</script>

--- a/webapp/src/main/webapp/components/snackbar/ExoNewsNotificationAlert.vue
+++ b/webapp/src/main/webapp/components/snackbar/ExoNewsNotificationAlert.vue
@@ -1,30 +1,30 @@
 <template>
   <v-alert
-      v-model="displayAlert"
-      :type="alertType"
-      border="left"
-      class="white"
-      elevation="2"
-      dismissible
-      colored-border
-      outlined>
+    v-model="displayAlert"
+    :type="alertType"
+    border="left"
+    class="white"
+    elevation="2"
+    dismissible
+    colored-border
+    outlined>
     <span class="text-color">
       {{ alertMessage }}
     </span>
     <v-btn
-        v-if="alert.click"
-        class="primary--text"
-        text
-        @click="alert.click">
+      v-if="alert.click"
+      class="primary--text"
+      text
+      @click="alert.click">
       {{ alert.clickMessage }}
     </v-btn>
     <v-btn
-        slot="close"
-        slot-scope="{toggle}"
-        icon
-        small
-        light
-        @click="toggle">
+      slot="close"
+      slot-scope="{toggle}"
+      icon
+      small
+      light
+      @click="toggle">
       <v-icon>close</v-icon>
     </v-btn>
   </v-alert>
@@ -57,7 +57,7 @@ export default {
     },
   },
   created() {
-    window.setTimeout(() => this.displayAlert = false, 5000);
+    // window.setTimeout(() => this.displayAlert = false, 5000);
   },
 };
 </script>

--- a/webapp/src/main/webapp/components/snackbar/ExoNewsNotificationAlert.vue
+++ b/webapp/src/main/webapp/components/snackbar/ExoNewsNotificationAlert.vue
@@ -57,7 +57,8 @@ export default {
     },
   },
   created() {
-    // window.setTimeout(() => this.displayAlert = false, 5000);
+    const time = 5000;
+    window.setTimeout(() => this.displayAlert = false, time);
   },
 };
 </script>

--- a/webapp/src/main/webapp/components/snackbar/ExoNewsNotificationAlert.vue
+++ b/webapp/src/main/webapp/components/snackbar/ExoNewsNotificationAlert.vue
@@ -53,6 +53,7 @@ export default {
     displayAlert() {
       if (!this.displayAlert) {
         this.$emit('dismissed');
+        this.$root.$emit('undo-delete-redirection');
       }
     },
   },

--- a/webapp/src/main/webapp/components/snackbar/ExoNewsNotificationAlerts.vue
+++ b/webapp/src/main/webapp/components/snackbar/ExoNewsNotificationAlerts.vue
@@ -37,8 +37,8 @@ export default {
     this.$root.$on('news-notification-alert', alert => this.alerts.push(alert));
     this.$root.$on('news-deleted', news => {
       if (news && news.newsId) {
-        const clickMessage = this.$t('news.undoRemoveActivity');
-        const message = this.$t('news.activityDeleteSuccess');
+        const clickMessage = this.$t('news.details.undoDelete');
+        const message = this.$t('news.details.deleteSuccess');
         this.$root.$emit('news-notification-alert', {
           message,
           type: 'success',

--- a/webapp/src/main/webapp/components/snackbar/ExoNewsNotificationAlerts.vue
+++ b/webapp/src/main/webapp/components/snackbar/ExoNewsNotificationAlerts.vue
@@ -1,12 +1,60 @@
 <template>
-  <h1>test</h1>
+  <v-app>
+    <v-snackbar
+      :value="displayAlerts"
+      color="transparent"
+      elevation="0"
+      absolute
+      app
+      left>
+      <exo-news-notification-alert
+        v-for="(alert, index) in alerts"
+        :key="index"
+        :alert="alert"
+        @dismissed="deleteAlert(index)" />
+    </v-snackbar>
+  </v-app>
 </template>
 
 <script>
 export default {
+  props: {
+    name: {
+      type: String,
+      default: null
+    },
+  },
   data: () => ({
     alerts: [],
-    alert: true,
   }),
+  computed: {
+    displayAlerts() {
+      return this.alerts && this.alerts.length;
+    },
+  },
+  created() {
+    this.$root.$on('news-notification-alert', alert => this.alerts.push(alert));
+    this.$root.$on('news-deleted', news => {
+      if (news && news.newsId) {
+        const clickMessage = this.$t('news.undoRemoveActivity');
+        const message = this.$t('news.activityDeleteSuccess');
+        this.$root.$emit('news-notification-alert', {
+          message,
+          type: 'success',
+          click: () => this.undoDeleteEvent(),
+          clickMessage,
+        });
+      }
+    });
+  },
+  methods: {
+    deleteAlert(index) {
+      this.alerts.splice(index, 1);
+      this.$forceUpdate();
+    },
+    undoDeleteEvent() {
+      this.$forceUpdate();
+    }
+  },
 };
 </script>

--- a/webapp/src/main/webapp/components/snackbar/ExoNewsNotificationAlerts.vue
+++ b/webapp/src/main/webapp/components/snackbar/ExoNewsNotificationAlerts.vue
@@ -7,10 +7,10 @@
       app
       left>
       <exo-news-notification-alert
-        v-for="(alert, index) in alerts"
-        :key="index"
+        v-for="alert in alerts"
+        :key="alert.message"
         :alert="alert"
-        @dismissed="deleteAlert(index)" />
+        @dismissed="deleteAlert(alert)" />
     </v-snackbar>
   </v-app>
 </template>
@@ -49,15 +49,27 @@ export default {
     });
   },
   methods: {
-    deleteAlert(index) {
+    addAlert(alert) {
+      const time = 5000;
+      if (alert) {
+        this.alerts.push(alert);
+        window.setTimeout(() => this.deleteAlert(alert), time);
+      }
+    },
+    deleteAlert(alert) {
+      const index = this.alerts.indexOf(alert);
       this.alerts.splice(index, 1);
       this.$forceUpdate();
     },
-    undoDeleteNews(newsId) {
+    undoDeleteNews(newsId, alert) {
       return newsServices.undoDeleteNews(newsId)
         .then(() => {
           this.$root.$emit('undoDelete');
-          this.$forceUpdate();
+          this.deleteAlert(alert);
+          this.addAlert({
+            message: this.$t('news.details.deleteCanceled'),
+            type: 'success',
+          });
         });
     }
   },

--- a/webapp/src/main/webapp/components/snackbar/ExoNewsNotificationAlerts.vue
+++ b/webapp/src/main/webapp/components/snackbar/ExoNewsNotificationAlerts.vue
@@ -55,7 +55,10 @@ export default {
     },
     undoDeleteNews(newsId) {
       return newsServices.undoDeleteNews(newsId)
-        .then(() => this.$forceUpdate());
+        .then(() => {
+          this.$root.$emit('undoDelete');
+          this.$forceUpdate();
+        });
     }
   },
 };

--- a/webapp/src/main/webapp/components/snackbar/ExoNewsNotificationAlerts.vue
+++ b/webapp/src/main/webapp/components/snackbar/ExoNewsNotificationAlerts.vue
@@ -1,0 +1,12 @@
+<template>
+  <h1>test</h1>
+</template>
+
+<script>
+export default {
+  data: () => ({
+    alerts: [],
+    alert: true,
+  }),
+};
+</script>

--- a/webapp/src/main/webapp/components/snackbar/ExoNewsNotificationAlerts.vue
+++ b/webapp/src/main/webapp/components/snackbar/ExoNewsNotificationAlerts.vue
@@ -4,7 +4,6 @@
       :value="displayAlerts"
       color="transparent"
       elevation="0"
-      absolute
       app
       left>
       <exo-news-notification-alert
@@ -17,6 +16,8 @@
 </template>
 
 <script>
+import * as newsServices from '../../services/newsServices';
+
 export default {
   props: {
     name: {
@@ -41,7 +42,7 @@ export default {
         this.$root.$emit('news-notification-alert', {
           message,
           type: 'success',
-          click: () => this.undoDeleteEvent(),
+          click: () => this.undoDeleteNews(news.newsId),
           clickMessage,
         });
       }
@@ -52,8 +53,9 @@ export default {
       this.alerts.splice(index, 1);
       this.$forceUpdate();
     },
-    undoDeleteEvent() {
-      this.$forceUpdate();
+    undoDeleteNews(newsId) {
+      return newsServices.undoDeleteNews(newsId)
+        .then(() => this.$forceUpdate());
     }
   },
 };

--- a/webapp/src/main/webapp/components/snackbar/main.js
+++ b/webapp/src/main/webapp/components/snackbar/main.js
@@ -1,0 +1,5 @@
+import ExoNewsNotificationAlert from './ExoNewsNotificationAlert.vue';
+import ExoNewsNotificationAlerts from './ExoNewsNotificationAlerts.vue';
+
+Vue.component('exo-news-notification-alert', ExoNewsNotificationAlert);
+Vue.component('exo-news-notification-alerts', ExoNewsNotificationAlerts);

--- a/webapp/src/main/webapp/css/news.less
+++ b/webapp/src/main/webapp/css/news.less
@@ -40,6 +40,11 @@
   }
 }
 
+.v-alert i {
+  margin-top: auto;
+  margin-bottom: auto;
+}
+
 .activityStream.uiNewsActivity {
   .newsRibbon {
     background-image: url("@{images-path}/ribbon-news.png");

--- a/webapp/src/main/webapp/groovy/news/webui/activity/UINewsFullActivity.gtmpl
+++ b/webapp/src/main/webapp/groovy/news/webui/activity/UINewsFullActivity.gtmpl
@@ -191,8 +191,4 @@
   </div>
   </div><!--activityStream-->
   <% } // News archived %>
-  <% } else { // Activity deleted %>
-  <% uiform.begin() %>
-  <div class="activityStream deleted">$labelActivityHasBeenDeleted</div>
-  <% uiform.end() %>
-  <% } %>
+  <% }

--- a/webapp/src/main/webapp/groovy/news/webui/activity/UINewsFullActivity.gtmpl
+++ b/webapp/src/main/webapp/groovy/news/webui/activity/UINewsFullActivity.gtmpl
@@ -145,6 +145,7 @@
       newsId: '${news.id}',
       archived: ${news.archived},
       canArchive: ${news.canArchive},
+      canDelete: ${news.canDelete},
       profileAvatarURL: '${ownerAvatar}',
       spaceDisplayName: "${news.spaceDisplayName}",
       spaceUrl:'${news.spaceUrl}',
@@ -191,4 +192,4 @@
   </div>
   </div><!--activityStream-->
   <% } // News archived %>
-  <% }
+  <% } %>

--- a/webapp/src/main/webapp/groovy/news/webui/activity/UINewsStreamActivity.gtmpl
+++ b/webapp/src/main/webapp/groovy/news/webui/activity/UINewsStreamActivity.gtmpl
@@ -256,4 +256,4 @@
   </div> <!-- #boxContainer-->
   <% uiform.end() %>
 </div><!--activityStream-->
-<% }
+<% } %>

--- a/webapp/src/main/webapp/groovy/news/webui/activity/UINewsStreamActivity.gtmpl
+++ b/webapp/src/main/webapp/groovy/news/webui/activity/UINewsStreamActivity.gtmpl
@@ -256,8 +256,4 @@
   </div> <!-- #boxContainer-->
   <% uiform.end() %>
 </div><!--activityStream-->
-<% } else { %> <!-- activity deleted -->
-<% uiform.begin() %>
-<div class="activityStream deleted">$labelActivityHasBeenDeleted</div>
-<% uiform.end() %>
-<% } %>
+<% }

--- a/webapp/src/main/webapp/groovy/news/webui/activity/UISharedNewsFullActivity.gtmpl
+++ b/webapp/src/main/webapp/groovy/news/webui/activity/UISharedNewsFullActivity.gtmpl
@@ -229,8 +229,4 @@ if (activity && news) {
 </div><!--activityStream-->
 </div>
 <% } // News archived %>
-<% } else { // Activity deleted %>
-<% uiform.begin() %>
-<div class="activityStream deleted">$labelActivityHasBeenDeleted</div>
-<% uiform.end() %>
-<% } %>
+<% }

--- a/webapp/src/main/webapp/groovy/news/webui/activity/UISharedNewsFullActivity.gtmpl
+++ b/webapp/src/main/webapp/groovy/news/webui/activity/UISharedNewsFullActivity.gtmpl
@@ -160,6 +160,7 @@ if (activity && news) {
        newsId: '${news.id}',
        archived: ${news.archived},
        canArchive: ${news.canArchive},
+       canDelete: ${news.canDelete},
        profileAvatarURL: '${ownerAvatar}',
        spaceDisplayName: "${news.spaceDisplayName}",
        spaceUrl:'${news.spaceUrl}',
@@ -229,4 +230,4 @@ if (activity && news) {
 </div><!--activityStream-->
 </div>
 <% } // News archived %>
-<% }
+<% } %>

--- a/webapp/src/main/webapp/groovy/news/webui/activity/UISharedNewsStreamActivity.gtmpl
+++ b/webapp/src/main/webapp/groovy/news/webui/activity/UISharedNewsStreamActivity.gtmpl
@@ -242,8 +242,4 @@ def streamOwner = activity.getStreamOwner();
     </div> <!-- #boxContainer-->
     <% uiform.end() %>
 </div><!--activityStream-->
-<% } else { %> <!-- activity deleted -->
-<% uiform.begin() %>
-<div class="activityStream deleted">$labelActivityHasBeenDeleted</div>
-<% uiform.end() %>
-<% } %>
+<% }

--- a/webapp/src/main/webapp/groovy/news/webui/activity/UISharedNewsStreamActivity.gtmpl
+++ b/webapp/src/main/webapp/groovy/news/webui/activity/UISharedNewsStreamActivity.gtmpl
@@ -242,4 +242,4 @@ def streamOwner = activity.getStreamOwner();
     </div> <!-- #boxContainer-->
     <% uiform.end() %>
 </div><!--activityStream-->
-<% }
+<% } %>

--- a/webapp/src/main/webapp/news-details/components/ExoNewsDetails.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsDetails.vue
@@ -6,6 +6,8 @@
       :news="news"
       :show-edit-button="showEditButton"
       :show-share-button="showShareButton"
+      :show-delete-button="showDeleteButton"
+      @delete="deleteNews"
       @edit="editLink"/>
     <div v-if="news.archived && !news.canArchive">
       <div class="userNotAuthorized">
@@ -90,6 +92,7 @@
       </div>
     </div>
     <exo-news-share-activity-drawer />
+    <exo-news-notification-alerts class="d-flex"/>
   </div>
 </template>
 <script>
@@ -123,6 +126,11 @@ export default {
       default: true
     },
     showPinButton: {
+      type: Boolean,
+      required: false,
+      default: true
+    },
+    showDeleteButton: {
       type: Boolean,
       required: false,
       default: true
@@ -231,6 +239,12 @@ export default {
       const editUrl = `${eXo.env.portal.context}/${eXo.env.portal.portalName}/news/editor?spaceId=${this.spaceId}&newsId=${this.news.newsId}&activityId=${this.activityId}`;
       window.open(editUrl, '_self');
     },
+    deleteNews() {
+      this.$root.$emit('news-deleted', this.news);
+      /* newsServices.deleteNews(this.newsId)
+        .then(() => this.$root.$emit('news-deleted', this.news));
+       */
+    }
   }
 };
 </script>

--- a/webapp/src/main/webapp/news-details/components/ExoNewsDetails.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsDetails.vue
@@ -235,15 +235,19 @@ export default {
         window.open('/', '_self');
       }
     },
+    reloadNews(newsId) {
+      newsServices.getNewsById(newsId).then(newsUpdated => {
+        this.newsList.find(news => news.newsId === newsId).activities = newsUpdated.activities;
+      });
+    },
     editLink() {
       const editUrl = `${eXo.env.portal.context}/${eXo.env.portal.portalName}/news/editor?spaceId=${this.spaceId}&newsId=${this.news.newsId}&activityId=${this.activityId}`;
       window.open(editUrl, '_self');
     },
     deleteNews() {
-      this.$root.$emit('news-deleted', this.news);
-      /* newsServices.deleteNews(this.newsId)
+      const deleteDelay = 10;
+      newsServices.deleteNews(this.newsId, deleteDelay)
         .then(() => this.$root.$emit('news-deleted', this.news));
-       */
     }
   }
 };

--- a/webapp/src/main/webapp/news-details/components/ExoNewsDetails.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsDetails.vue
@@ -235,19 +235,32 @@ export default {
         window.open('/', '_self');
       }
     },
-    reloadNews(newsId) {
-      newsServices.getNewsById(newsId).then(newsUpdated => {
-        this.newsList.find(news => news.newsId === newsId).activities = newsUpdated.activities;
-      });
-    },
     editLink() {
       const editUrl = `${eXo.env.portal.context}/${eXo.env.portal.portalName}/news/editor?spaceId=${this.spaceId}&newsId=${this.news.newsId}&activityId=${this.activityId}`;
       window.open(editUrl, '_self');
     },
     deleteNews() {
-      const deleteDelay = 10;
+      const deleteDelay = 6;
+      const redirectionTime = 1000;
       newsServices.deleteNews(this.newsId, deleteDelay)
-        .then(() => this.$root.$emit('news-deleted', this.news));
+        .then(() => {
+          this.$root.$emit('news-deleted', this.news);
+          this.$root.$on('undoDelete', () => {
+            localStorage.removeItem('deletedNews');
+            const deletedNews = localStorage.getItem('deletedNews');
+            if (deletedNews != null) {
+              window.location.href = this.news.spaceUrl;
+            }
+          });
+          this.$root.$on('undo-delete-redirection', () => {
+            const deletedNews = localStorage.getItem('deletedNews');
+            if (deletedNews != null) {
+              setTimeout(() => {
+                window.location.href = this.news.spaceUrl;
+              }, redirectionTime);
+            }
+          });
+        });
     }
   }
 };

--- a/webapp/src/main/webapp/news-details/components/ExoNewsDetails.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsDetails.vue
@@ -92,7 +92,7 @@
       </div>
     </div>
     <exo-news-share-activity-drawer />
-    <exo-news-notification-alerts class="d-flex"/>
+    <exo-news-notification-alerts />
   </div>
 </template>
 <script>

--- a/webapp/src/main/webapp/news-details/components/ExoNewsDetails.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsDetails.vue
@@ -133,7 +133,7 @@ export default {
     showDeleteButton: {
       type: Boolean,
       required: false,
-      default: true
+      default: false
     },
   },
   data() {

--- a/webapp/src/main/webapp/news-details/components/ExoNewsDetailsActionMenu.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsDetailsActionMenu.vue
@@ -27,6 +27,11 @@
           {{ $t('news.details.header.menu.share') }}
         </v-list-item-title>
       </v-list-item>
+      <v-list-item v-if="showDeleteButton" @click="$emit('delete')">
+        <v-list-item-title>
+          {{ $t('news.details.header.menu.delete') }}
+        </v-list-item-title>
+      </v-list-item>
     </v-list>
   </v-menu>
 </template>
@@ -46,6 +51,11 @@ export default {
       default: true
     },
     showEditButton: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
+    showDeleteButton: {
       type: Boolean,
       required: false,
       default: false

--- a/webapp/src/main/webapp/news-details/main.js
+++ b/webapp/src/main/webapp/news-details/main.js
@@ -43,6 +43,7 @@ export function init(params) {
           showEditButton: params.showEditButton,
           showPinButton: params.showPinInput,
           showShareButton : params.showShareButton,
+          showDeleteButton : params.news.canDelete,
         };
       },
       template: `<exo-news-details

--- a/webapp/src/main/webapp/news-details/main.js
+++ b/webapp/src/main/webapp/news-details/main.js
@@ -53,7 +53,8 @@ export function init(params) {
                   :activity-id="activityId"
                   :show-edit-button="showEditButton"
                   :show-pin-button="showPinButton"
-                  :show-share-button="showShareButton" />`,
+                  :show-share-button="showShareButton" 
+                  :show-delete-button="showEditButton"/>`,
       i18n,
       vuetify
     }).$mount(appElement);

--- a/webapp/src/main/webapp/news-details/main.js
+++ b/webapp/src/main/webapp/news-details/main.js
@@ -55,7 +55,7 @@ export function init(params) {
                   :show-edit-button="showEditButton"
                   :show-pin-button="showPinButton"
                   :show-share-button="showShareButton" 
-                  :show-delete-button="showEditButton"/>`,
+                  :show-delete-button="showDeleteButton"/>`,
       i18n,
       vuetify
     }).$mount(appElement);

--- a/webapp/src/main/webapp/services/newsServices.js
+++ b/webapp/src/main/webapp/services/newsServices.js
@@ -260,8 +260,11 @@ export function canUserCreateNews(spaceId) {
   });
 }
 
-export function deleteNews(newsId) {
-  return fetch(`${newsConstants.NEWS_API}/${newsId}`, {
+export function deleteNews(newsId, delay) {
+  if (delay > 0) {
+    localStorage.setItem('deletedNews', newsId);
+  }
+  return fetch(`${newsConstants.NEWS_API}/${newsId}?delay=${delay || 0}`, {
     credentials: 'include',
     method: 'DELETE'
   }).then((resp) => {
@@ -269,6 +272,19 @@ export function deleteNews(newsId) {
       resp.json();
     } else {
       throw new Error('Error deleting news');
+    }
+  });
+}
+
+export function undoDeleteNews(newsId) {
+  return fetch(`${newsConstants.NEWS_API}/${newsId}/undoDelete`, {
+    method: 'POST',
+    credentials: 'include',
+  }).then((resp) => {
+    if (resp && resp.ok) {
+      localStorage.removeItem('deletedNews');
+    } else {
+      throw new Error('Error undoing deleting news');
     }
   });
 }

--- a/webapp/src/main/webapp/services/newsServices.js
+++ b/webapp/src/main/webapp/services/newsServices.js
@@ -259,3 +259,16 @@ export function canUserCreateNews(spaceId) {
     return resp;
   });
 }
+
+export function deleteNews(newsId) {
+  return fetch(`${newsConstants.NEWS_API}/${newsId}`, {
+    credentials: 'include',
+    method: 'DELETE'
+  }).then((resp) => {
+    if (resp && resp.ok) {
+      resp.json();
+    } else {
+      throw new Error('Error deleting news');
+    }
+  });
+}

--- a/webapp/src/main/webapp/services/newsServices.js
+++ b/webapp/src/main/webapp/services/newsServices.js
@@ -271,7 +271,7 @@ export function deleteNews(newsId, delay) {
     if (resp && resp.ok) {
       resp.json();
     } else {
-      throw new Error('Error deleting news');
+      throw new Error('Error when deleting news');
     }
   });
 }
@@ -284,7 +284,7 @@ export function undoDeleteNews(newsId) {
     if (resp && resp.ok) {
       localStorage.removeItem('deletedNews');
     } else {
-      throw new Error('Error undoing deleting news');
+      throw new Error('Error when undoing deleting news');
     }
   });
 }

--- a/webapp/webpack.common.js
+++ b/webapp/webpack.common.js
@@ -9,6 +9,7 @@ let config = {
   entry: {
     suggesterComponent :'./src/main/webapp/components/suggester/main.js',
     modalComponent :'./src/main/webapp/components/modal/main.js',
+    snackbarComponent :'./src/main/webapp/components/snackbar/main.js',
     fileDropComponent :'./src/main/webapp/components/fileDrop/main.js',
     newsActivityComposer :'./src/main/webapp/news-activity-composer-app/main.js',
     newsDetails :'./src/main/webapp/news-details/main.js',


### PR DESCRIPTION
Current behaviour:

- Only delete news article service and rest service is available
- When deleting the news article, the related activities are not removed
- It is not possible to remove a news article from news detail

New behaviour:

- When deleting the news article, the related activities are also removed
- It will be possible to remove a news article from news detail