### PR TITLE
Task-43886: Add a confirmation message when deleting an article from news details

### DIFF
--- a/webapp/src/main/webapp/services/newsServices.js
+++ b/webapp/src/main/webapp/services/newsServices.js
@@ -269,7 +269,7 @@ export function deleteNews(newsId, delay) {
     method: 'DELETE'
   }).then((resp) => {
     if (resp && resp.ok) {
-      resp.json();
+      resp.text();
     } else {
       throw new Error('Error when deleting news');
     }

--- a/webapp/src/main/webapp/services/newsServices.js
+++ b/webapp/src/main/webapp/services/newsServices.js
@@ -268,9 +268,7 @@ export function deleteNews(newsId, delay) {
     credentials: 'include',
     method: 'DELETE'
   }).then((resp) => {
-    if (resp && resp.ok) {
-      resp.text();
-    } else {
+    if (resp && !resp.ok) {
       throw new Error('Error when deleting news');
     }
   });


### PR DESCRIPTION
**Current behavior:**

- The confirmation message isn't displayed in news details when delete news.

**New behavior:**

- Before delete news in news details, a confirmation message will be displayed.