### PR TITLE
Task-44606: Update newsComposerPlugin by adding enabled method to plugin params

### DIFF
--- a/webapp/src/main/webapp/js/newsComposerPlugin.js
+++ b/webapp/src/main/webapp/js/newsComposerPlugin.js
@@ -5,7 +5,6 @@ const newsActivityComposerPlugin = {
   labelKey: 'news.composer.write',
   description: 'news.composer.write.description',
   iconClass: 'newsComposerIcon',
-  enabled: false,
   onExecute: function (attachments) {
     let url = `${eXo.env.portal.context}/${eXo.env.portal.portalName}/news/editor`;
     if (eXo.env.portal.spaceId) {
@@ -20,6 +19,11 @@ const newsActivityComposerPlugin = {
     }
 
     window.open(url, '_blank');
+  },
+  enabled: function () {
+    return  canUserCreateNews(eXo.env.portal.spaceId).then(canCreateNews => {
+      return (eXo.env.portal.spaceId !== "") && (canCreateNews === 'true');
+    });
   }
 };
 
@@ -48,16 +52,8 @@ const switchToArticleActivityComposerPlugin = {
 
 require(['SHARED/extensionRegistry'], function (extensionRegistry) {
   extensionRegistry.registerExtension('ActivityComposer', 'activity-composer-hint-action', switchToArticleActivityComposerPlugin);
+  extensionRegistry.registerExtension('ActivityComposer', 'activity-composer-action', newsActivityComposerPlugin);
   document.dispatchEvent(new CustomEvent('activity-composer-extension-updated'));
-  if (eXo.env.portal.spaceId) {
-    canUserCreateNews().then(canCreateNews => {
-      newsActivityComposerPlugin.enabled = eXo.env.portal.spaceId && (canCreateNews === 'true');
-      extensionRegistry.registerExtension('ActivityComposer', 'activity-composer-action', newsActivityComposerPlugin);
-      document.dispatchEvent(new CustomEvent('activity-composer-extension-updated'));
-    });
-  } else {
-    newsActivityComposerPlugin.enabled = false;
-  }
 });
 
 function canUserCreateNews() {

--- a/webapp/src/main/webapp/js/newsComposerPlugin.js
+++ b/webapp/src/main/webapp/js/newsComposerPlugin.js
@@ -21,8 +21,8 @@ const newsActivityComposerPlugin = {
     window.open(url, '_blank');
   },
   enabled: function () {
-    return  canUserCreateNews(eXo.env.portal.spaceId).then(canCreateNews => {
-      return (eXo.env.portal.spaceId !== "") && (canCreateNews === 'true');
+    return  eXo.env.portal.spaceId && canUserCreateNews().then(canCreateNews => {
+      return canCreateNews === 'true';
     });
   }
 };


### PR DESCRIPTION
The problem is that the newsComposerPlugin is loaded only at the first site page access and not when switching from one page to another, so the "enabled" parameter will keep the initial value.
To fix this problem, we have to call the "enabled" method each time the component loads.