### PR TITLE
Task-40301: Make the back button in news details always redirect to space AS

### DIFF
--- a/webapp/src/main/webapp/news-details/components/ExoNewsDetails.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsDetails.vue
@@ -1,6 +1,6 @@
 <template>
   <div id="newsDetails">
-    <a class="backBtn" @click="goBack()"><i class="uiIconBack"></i></a>
+    <a class="backBtn" :href="news.spaceUrl"><i class="uiIconBack"></i></a>
     <exo-news-details-action-menu
       v-if="showEditButton"
       :news="news"
@@ -242,13 +242,6 @@ export default {
         document.querySelector('.uiDocumentPreview').classList += ' collapsed';
       } else {
         setTimeout(this.hideDocPreviewComments, intervalCheck);
-      }
-    },
-    goBack() {
-      if ( history.length > 1) {
-        history.back();
-      } else {
-        window.open('/', '_self');
       }
     },
     editLink() {


### PR DESCRIPTION
**Current behavior :**

- After creating/editing a News , the news is displayed. When clicking on the go back button, the edition page is displayed and not the space activity stream. 

**Suggested behavior :**

- After creating / editing a new , the go back button should take the user to the space activity stream.