### PR TITLE
Taask-44804: Fix add/edit news rest service permissions

### DIFF
--- a/services/src/main/java/org/exoplatform/news/model/News.java
+++ b/services/src/main/java/org/exoplatform/news/model/News.java
@@ -279,7 +279,7 @@ public class News {
     this.spaceAvatarUrl = spaceAvatarUrl;
   }
 
-  public Boolean getCanEdit() {
+  public Boolean isCanEdit() {
     return canEdit;
   }
 

--- a/services/src/main/java/org/exoplatform/news/rest/NewsRestResourcesV1.java
+++ b/services/src/main/java/org/exoplatform/news/rest/NewsRestResourcesV1.java
@@ -45,6 +45,7 @@ import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.services.rest.resource.ResourceContainer;
 import org.exoplatform.services.security.ConversationState;
+import org.exoplatform.social.core.activity.model.ExoSocialActivity;
 import org.exoplatform.social.core.identity.model.Identity;
 import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;
 import org.exoplatform.social.core.manager.IdentityManager;
@@ -60,6 +61,7 @@ import io.swagger.annotations.ApiResponses;
 import io.swagger.jaxrs.PATCH;
 
 import org.exoplatform.social.rest.api.EntityBuilder;
+import org.exoplatform.social.webui.Utils;
 
 import org.picocontainer.Startable;
 
@@ -423,11 +425,7 @@ public class NewsRestResourcesV1 implements ResourceContainer, Startable {
         return Response.status(Response.Status.NOT_FOUND).build();
       }
 
-      String authenticatedUser = request.getRemoteUser();
-
-      Space space = spaceService.getSpaceById(news.getSpaceId());
-      if (space == null
-          || (!spaceService.isMember(space, authenticatedUser) && !spaceService.isSuperManager(authenticatedUser))) {
+      if (!news.isCanEdit()) {
         return Response.status(Response.Status.UNAUTHORIZED).build();
       }
 
@@ -610,7 +608,6 @@ public class NewsRestResourcesV1 implements ResourceContainer, Startable {
       if (news == null) {
         return Response.status(Response.Status.NOT_FOUND).build();
       }
-      String authenticatedUser = request.getRemoteUser();
       Space space = spaceService.getSpaceById(news.getSpaceId());
       if (space == null) {
         return Response.status(Response.Status.UNAUTHORIZED).build();
@@ -653,7 +650,7 @@ public class NewsRestResourcesV1 implements ResourceContainer, Startable {
       boolean isUpdatedIllustration =
                                     (updatedNews.getUploadId() != null) && !updatedNews.getUploadId().equals(news.getUploadId());
       if (isUpdatedTitle || isUpdatedSummary || isUpdatedBody || isUpdatedIllustration) {
-        if (!spaceService.isMember(space, authenticatedUser) && !spaceService.isSuperManager(authenticatedUser)) {
+        if (!news.isCanEdit()) {
           return Response.status(Response.Status.UNAUTHORIZED).build();
         }
         if (isUpdatedTitle) {

--- a/services/src/test/java/org/exoplatform/news/rest/NewsRestResourcesV1Test.java
+++ b/services/src/test/java/org/exoplatform/news/rest/NewsRestResourcesV1Test.java
@@ -62,7 +62,7 @@ public class NewsRestResourcesV1Test {
 
   @Mock
   PortalContainer        container;
-
+  
   @Before
   public void setup() {
     RuntimeDelegate.setInstance(new RuntimeDelegateImpl());
@@ -1235,6 +1235,7 @@ public class NewsRestResourcesV1Test {
     newsDrafts.add(news2);
     when(newsService.getNewsDrafts(anyString(), anyString())).thenReturn(newsDrafts);
     when(spaceService.getSpaceById(anyString())).thenReturn(new Space());
+    when(spaceService.isMember(any(Space.class), any())).thenReturn(true);
 
     // When
     Response response = newsRestResourcesV1.getNews(request, "mike", "1", "draft", "", null, 0, 10, false);
@@ -1524,6 +1525,8 @@ public class NewsRestResourcesV1Test {
     allNews.add(news2);
     allNews.add(news3);
     when(newsService.getNews(any())).thenReturn(allNews);
+    when(spaceService.isMember(any(Space.class), any())).thenReturn(true);
+    when(spaceService.getSpaceById(anyString())).thenReturn(new Space());
 
     // When
     Response response = newsRestResourcesV1.getNews(request, "john", null, "published", "", null, 0, 10, false);
@@ -1546,6 +1549,8 @@ public class NewsRestResourcesV1Test {
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getRemoteUser()).thenReturn("john");
     NewsFilter newsFilter = new NewsFilter();
+    when(spaceService.isMember(any(Space.class), any())).thenReturn(true);
+    when(spaceService.getSpaceById(anyString())).thenReturn(new Space());
     when(newsService.getNews(newsFilter)).thenReturn(null);
 
     // When
@@ -1636,6 +1641,8 @@ public class NewsRestResourcesV1Test {
     allNews.add(news1);
     allNews.add(news2);
     allNews.add(news3);
+    when(spaceService.isMember(any(Space.class), any())).thenReturn(true);
+    when(spaceService.getSpaceById(anyString())).thenReturn(new Space());
     when(newsService.getNews(any())).thenReturn(allNews);
     when(newsService.getNewsCount(any())).thenReturn(allNews.size());
 
@@ -1691,7 +1698,8 @@ public class NewsRestResourcesV1Test {
     allNews.add(news2);
     allNews.add(news3);
     when(newsService.searchNews(any(), any())).thenReturn(allNews);
-    when(spaceService.isMember(anyString(), any())).thenReturn(true);
+    when(spaceService.isMember(any(Space.class), any())).thenReturn(true);
+    when(spaceService.getSpaceById(anyString())).thenReturn(new Space());
 
     // When
     Response response = newsRestResourcesV1.getNews(request, "john", spacesIds, "published", "", text, 0, 5, false);
@@ -1746,8 +1754,8 @@ public class NewsRestResourcesV1Test {
     allNews.add(news2);
     allNews.add(news3);
     when(newsService.searchNews(any(), any())).thenReturn(allNews);
-    when(spaceService.isMember(anyString(), any())).thenReturn(true);
-
+    when(spaceService.isMember(any(Space.class), any())).thenReturn(true);
+    when(spaceService.getSpaceById(anyString())).thenReturn(new Space());
     // When
     Response response = newsRestResourcesV1.getNews(request, "john", spaceId, "published", "", text, 0, 10, false);
 
@@ -1801,7 +1809,8 @@ public class NewsRestResourcesV1Test {
     allNews.add(news2);
     allNews.add(news3);
     when(newsService.searchNews(any(), any())).thenReturn(allNews);
-    when(spaceService.isMember(anyString(), any())).thenReturn(true);
+    when(spaceService.isMember(any(Space.class), any())).thenReturn(true);
+    when(spaceService.getSpaceById(anyString())).thenReturn(new Space());
 
     // When
     Response response = newsRestResourcesV1.getNews(request, "john", spacesIds, "published", "pinned", text, 0, 10, false);
@@ -1845,7 +1854,8 @@ public class NewsRestResourcesV1Test {
     allNews.add(news2);
     allNews.add(news3);
     when(newsService.getNews(any())).thenReturn(allNews);
-    when(spaceService.isMember(anyString(), any())).thenReturn(false);
+    when(spaceService.isMember(any(Space.class), any())).thenReturn(false);
+    when(spaceService.getSpaceById(anyString())).thenReturn(new Space());
 
     // When
     Response response = newsRestResourcesV1.getNews(request, "john", spacesIds, "published", "pinned", text, 0, 10, false);
@@ -1887,7 +1897,8 @@ public class NewsRestResourcesV1Test {
     allNews.add(news2);
     allNews.add(news3);
     when(newsService.getNews(any())).thenReturn(allNews);
-    when(spaceService.isMember(anyString(), any())).thenReturn(true);
+    when(spaceService.isMember(any(Space.class), any())).thenReturn(true);
+    when(spaceService.getSpaceById(anyString())).thenReturn(new Space());
 
     // When
     Response response = newsRestResourcesV1.getNews(request, "john", null, "published", filter, null, 0, 10, false);
@@ -1938,7 +1949,8 @@ public class NewsRestResourcesV1Test {
     allNews.add(news2);
     allNews.add(news3);
     when(newsService.getNews(any())).thenReturn(allNews);
-    when(spaceService.isMember(anyString(), any())).thenReturn(true);
+    when(spaceService.isMember(any(Space.class), any())).thenReturn(true);
+    when(spaceService.getSpaceById(anyString())).thenReturn(new Space());
 
     // When
     Response response = newsRestResourcesV1.getNews(request, "john", spacesIds, "published", filter, null, 0, 10, false);
@@ -1990,7 +2002,8 @@ public class NewsRestResourcesV1Test {
     allNews.add(news2);
     allNews.add(news3);
     when(newsService.searchNews(any(), any())).thenReturn(allNews);
-    when(spaceService.isMember(anyString(), any())).thenReturn(true);
+    when(spaceService.isMember(any(Space.class), any())).thenReturn(true);
+    when(spaceService.getSpaceById(anyString())).thenReturn(new Space());
 
     // When
     Response response = newsRestResourcesV1.getNews(request, "john", spacesIds, "published", filter, text, 0, 10, false);

--- a/services/src/test/java/org/exoplatform/news/rest/NewsRestResourcesV1Test.java
+++ b/services/src/test/java/org/exoplatform/news/rest/NewsRestResourcesV1Test.java
@@ -202,7 +202,7 @@ public class NewsRestResourcesV1Test {
 
 
   @Test
-  public void shouldGetOKWhenUpdatingNewsAndNewsExistsAndUserIsMemberOfTheSpace() throws Exception {
+  public void shouldGetOKWhenUpdatingNewsAndNewsExistsAndUserIsAuthorized() throws Exception {
     // Given
     NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
                                                                       newsAttachmentsService,
@@ -216,6 +216,7 @@ public class NewsRestResourcesV1Test {
     existingNews.setSummary("Summary");
     existingNews.setBody("Body");
     existingNews.setPublicationState("draft");
+    existingNews.setCanEdit(true);
     when(newsService.getNewsById(anyString())).thenReturn(existingNews);
     News updatedNews = new News();
     updatedNews.setTitle("Updated Title");
@@ -223,9 +224,6 @@ public class NewsRestResourcesV1Test {
     updatedNews.setBody("Updated Body");
     updatedNews.setPublicationState("published");
     when(newsService.updateNews(any())).then(returnsFirstArg());
-    when(spaceService.getSpaceById(anyString())).thenReturn(new Space());
-    when(spaceService.isMember(any(Space.class), eq("john"))).thenReturn(true);
-    when(spaceService.isSuperManager(eq("john"))).thenReturn(false);
 
     // When
     Response response = newsRestResourcesV1.updateNews(request, "1", updatedNews);
@@ -291,10 +289,8 @@ public class NewsRestResourcesV1Test {
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getRemoteUser()).thenReturn("john");
     News news = new News();
+    news.setCanEdit(false);
     when(newsService.getNewsById(anyString())).thenReturn(news);
-    when(spaceService.getSpaceById(anyString())).thenReturn(new Space());
-    when(spaceService.isMember(any(Space.class), eq("john"))).thenReturn(false);
-    when(spaceService.isSuperManager(eq("john"))).thenReturn(false);
 
     // When
     Response response = newsRestResourcesV1.updateNews(request, "1", new News());
@@ -314,9 +310,6 @@ public class NewsRestResourcesV1Test {
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getRemoteUser()).thenReturn("john");
     when(newsService.getNewsById(anyString())).thenReturn(null);
-    when(spaceService.getSpaceById(anyString())).thenReturn(new Space());
-    when(spaceService.isMember(any(Space.class), eq("john"))).thenReturn(false);
-    when(spaceService.isSuperManager(eq("john"))).thenReturn(false);
 
     // When
     Response response = newsRestResourcesV1.updateNews(request, "1", new News());
@@ -347,7 +340,8 @@ public class NewsRestResourcesV1Test {
     oldnews.setPinned(false);
     oldnews.setId("id123");
     oldnews.setSpaceId("space");
-
+    oldnews.setCanEdit(true);
+    
     News updatedNews = new News();
     updatedNews.setPinned(true);
 
@@ -361,9 +355,6 @@ public class NewsRestResourcesV1Test {
     Mockito.doNothing().when(newsService).pinNews("id123");
     when(newsService.getNewsById("id123")).thenReturn(oldnews);
     when(spaceService.getSpaceById(anyString())).thenReturn(space);
-    when(space.getGroupId()).thenReturn("space");
-    when(spaceService.isMember(any(Space.class), eq("john"))).thenReturn(true);
-    when(spaceService.isSuperManager(eq("john"))).thenReturn(true);
 
     // When
     Response response = newsRestResourcesV1.patchNews(request, "id123", updatedNews);
@@ -373,7 +364,7 @@ public class NewsRestResourcesV1Test {
   }
 
   @Test
-  public void shouldGetOKWhenArchiveNewsAndNewsExistsAndUserIsPublisher() throws Exception {
+  public void shouldGetOKWhenArchiveNewsAndNewsExistsAndUserIsAuthorized() throws Exception {
     // Given
     NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
                                                                       newsAttachmentsService,
@@ -395,6 +386,7 @@ public class NewsRestResourcesV1Test {
     oldnews.setArchived(false);
     oldnews.setId("id123");
     oldnews.setSpaceId("space");
+    oldnews.setCanEdit(true);
 
     News updatedNews = new News();
     updatedNews.setArchived(true);
@@ -409,9 +401,6 @@ public class NewsRestResourcesV1Test {
     Mockito.doNothing().when(newsService).pinNews("id123");
     when(newsService.getNewsById("id123")).thenReturn(oldnews);
     when(spaceService.getSpaceById(anyString())).thenReturn(space);
-    when(space.getGroupId()).thenReturn("space");
-    when(spaceService.isMember(any(Space.class), eq("john"))).thenReturn(true);
-    when(spaceService.isSuperManager(eq("john"))).thenReturn(true);
 
     // When
     Response response = newsRestResourcesV1.patchNews(request, "id123", updatedNews);
@@ -423,58 +412,7 @@ public class NewsRestResourcesV1Test {
   }
 
   @Test
-  public void shouldGetOKWhenArchiveNewsAndNewsExistsAndUserIsNewsAuthor() throws Exception {
-    // Given
-    NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
-                                                                      newsAttachmentsService,
-                                                                      spaceService,
-                                                                      identityManager,
-                                                                      container);
-    HttpServletRequest request = mock(HttpServletRequest.class);
-    when(request.getRemoteUser()).thenReturn("john");
-
-    News oldnews = new News();
-    oldnews.setTitle("unarchived");
-    oldnews.setSummary("unarchived summary");
-    oldnews.setBody("unarchived body");
-    oldnews.setUploadId(null);
-    String sDate1 = "22/08/2019";
-    Date date1 = new SimpleDateFormat("dd/MM/yyyy").parse(sDate1);
-    oldnews.setCreationDate(date1);
-    oldnews.setPinned(false);
-    oldnews.setArchived(false);
-    oldnews.setId("id123");
-    oldnews.setSpaceId("space");
-    oldnews.setAuthor("john");
-
-    News updatedNews = new News();
-    updatedNews.setArchived(true);
-
-    Identity currentIdentity = new Identity("john");
-    ConversationState.setCurrent(new ConversationState(currentIdentity));
-    List<MembershipEntry> memberships = new LinkedList<MembershipEntry>();
-    memberships.add(new MembershipEntry("/platform/web-contributors", "redactor"));
-    currentIdentity.setMemberships(memberships);
-    Space space = mock(Space.class);
-
-    Mockito.doNothing().when(newsService).pinNews("id123");
-    when(newsService.getNewsById("id123")).thenReturn(oldnews);
-    when(spaceService.getSpaceById(anyString())).thenReturn(space);
-    when(space.getGroupId()).thenReturn("space");
-    when(spaceService.isMember(any(Space.class), eq("john"))).thenReturn(true);
-    when(spaceService.isSuperManager(eq("john"))).thenReturn(true);
-
-    // When
-    Response response = newsRestResourcesV1.patchNews(request, "id123", updatedNews);
-
-    // Then
-    verify(newsService, times(1)).archiveNews("id123");
-    verify(newsService, times(0)).updateNews(oldnews);
-    assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
-  }
-
-  @Test
-  public void shouldGetOKWhenUnarchiveNewsAndNewsExistsAndUserIsNewsAuthor() throws Exception {
+  public void shouldGetOKWhenUnarchiveNewsAndNewsExistsAndUserIsAuthorized() throws Exception {
     // Given
     NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
                                                                       newsAttachmentsService,
@@ -497,10 +435,11 @@ public class NewsRestResourcesV1Test {
     oldnews.setId("id123");
     oldnews.setSpaceId("space");
     oldnews.setAuthor("john");
-
+    oldnews.setCanEdit(true);
+    
     News updatedNews = new News();
     updatedNews.setArchived(false);
-
+    
     Identity currentIdentity = new Identity("john");
     ConversationState.setCurrent(new ConversationState(currentIdentity));
     List<MembershipEntry> memberships = new LinkedList<MembershipEntry>();
@@ -511,9 +450,6 @@ public class NewsRestResourcesV1Test {
     Mockito.doNothing().when(newsService).pinNews("id123");
     when(newsService.getNewsById("id123")).thenReturn(oldnews);
     when(spaceService.getSpaceById(anyString())).thenReturn(space);
-    when(space.getGroupId()).thenReturn("space");
-    when(spaceService.isMember(any(Space.class), eq("john"))).thenReturn(true);
-    when(spaceService.isSuperManager(eq("john"))).thenReturn(true);
 
     // When
     Response response = newsRestResourcesV1.patchNews(request, "id123", updatedNews);
@@ -525,7 +461,7 @@ public class NewsRestResourcesV1Test {
   }
 
   @Test
-  public void shouldGetUnauthorizedWhenArchiveNewsAndNewsExistsAndUserIsNotPublisherAndNotNewsAuthor() throws Exception {
+  public void shouldGetUnauthorizedWhenArchiveNewsAndNewsExistsAndUserIsNotAuthorized() throws Exception {
     // Given
     NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
                                                                       newsAttachmentsService,
@@ -548,10 +484,11 @@ public class NewsRestResourcesV1Test {
     oldnews.setId("id123");
     oldnews.setSpaceId("space");
     oldnews.setAuthor("test");
-
+    oldnews.setCanEdit(false);
+    
     News updatedNews = new News();
     updatedNews.setArchived(true);
-
+    
     Identity currentIdentity = new Identity("john");
     ConversationState.setCurrent(new ConversationState(currentIdentity));
     List<MembershipEntry> memberships = new LinkedList<MembershipEntry>();
@@ -562,9 +499,6 @@ public class NewsRestResourcesV1Test {
     Mockito.doNothing().when(newsService).pinNews("id123");
     when(newsService.getNewsById("id123")).thenReturn(oldnews);
     when(spaceService.getSpaceById(anyString())).thenReturn(space);
-    when(space.getGroupId()).thenReturn("space");
-    when(spaceService.isMember(any(Space.class), eq("john"))).thenReturn(true);
-    when(spaceService.isSuperManager(eq("john"))).thenReturn(true);
 
     // When
     Response response = newsRestResourcesV1.patchNews(request, "id123", updatedNews);
@@ -576,7 +510,7 @@ public class NewsRestResourcesV1Test {
   }
 
   @Test
-  public void shouldGetOKWhenUpdatingAndPinNewsAndNewsExistsAndAndUserIsPublisher() throws Exception {
+  public void shouldGetOKWhenUpdatingAndPinNewsAndNewsExistsAndAndUserIsAuthorized() throws Exception {
     // Given
     NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
                                                                       newsAttachmentsService,
@@ -597,6 +531,7 @@ public class NewsRestResourcesV1Test {
     existingNews.setPinned(false);
     existingNews.setId("id123");
     existingNews.setSpaceId("space");
+    existingNews.setCanEdit(true);
 
     News updatedNews = new News();
     updatedNews.setPinned(true);
@@ -609,14 +544,9 @@ public class NewsRestResourcesV1Test {
     List<MembershipEntry> memberships = new LinkedList<MembershipEntry>();
     memberships.add(new MembershipEntry("/platform/web-contributors", "publisher"));
     currentIdentity.setMemberships(memberships);
-    Space space = mock(Space.class);
 
     when(newsService.getNewsById("id123")).thenReturn(existingNews);
     when(newsService.updateNews(any())).then(returnsFirstArg());
-    when(spaceService.getSpaceById(anyString())).thenReturn(space);
-    when(space.getGroupId()).thenReturn("space");
-    when(spaceService.isMember(any(Space.class), eq("john"))).thenReturn(true);
-    when(spaceService.isSuperManager(eq("john"))).thenReturn(false);
 
     // When
     Response response = newsRestResourcesV1.updateNews(request, "id123", updatedNews);
@@ -632,7 +562,7 @@ public class NewsRestResourcesV1Test {
   }
 
   @Test
-  public void shouldGetOKWhenUpdatingAndUnpinNewsAndNewsExistsAndAndUserIsPublisher() throws Exception {
+  public void shouldGetOKWhenUpdatingAndUnpinNewsAndNewsExistsAndAndUserIsAuthorized() throws Exception {
     // Given
     NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
                                                                       newsAttachmentsService,
@@ -653,6 +583,7 @@ public class NewsRestResourcesV1Test {
     oldnews.setPinned(true);
     oldnews.setId("id123");
     oldnews.setSpaceId("space");
+    oldnews.setCanEdit(true);
 
     News updatedNews = new News();
     updatedNews.setPinned(false);
@@ -663,14 +594,10 @@ public class NewsRestResourcesV1Test {
     List<MembershipEntry> memberships = new LinkedList<MembershipEntry>();
     memberships.add(new MembershipEntry("/platform/web-contributors", "publisher"));
     currentIdentity.setMemberships(memberships);
-    Space space = mock(Space.class);
 
     Mockito.doNothing().when(newsService).unpinNews("id123");
     when(newsService.getNewsById("id123")).thenReturn(oldnews);
-    when(spaceService.getSpaceById(anyString())).thenReturn(space);
-    when(space.getGroupId()).thenReturn("space");
-    when(spaceService.isMember(any(Space.class), eq("john"))).thenReturn(true);
-    when(spaceService.isSuperManager(eq("john"))).thenReturn(false);
+    
     // When
     Response response = newsRestResourcesV1.updateNews(request, "id123", updatedNews);
 
@@ -700,6 +627,7 @@ public class NewsRestResourcesV1Test {
     oldnews.setPinned(false);
     oldnews.setId("id123");
     oldnews.setSpaceId("space");
+    oldnews.setCanEdit(true);
 
     News updatedNews = new News();
     updatedNews.setPinned(true);
@@ -707,14 +635,10 @@ public class NewsRestResourcesV1Test {
 
     Identity currentIdentity = new Identity("john");
     ConversationState.setCurrent(new ConversationState(currentIdentity));
-    Space space = mock(Space.class);
 
     Mockito.doNothing().when(newsService).pinNews("id123");
     when(newsService.getNewsById("id123")).thenReturn(oldnews);
-    when(spaceService.getSpaceById(anyString())).thenReturn(space);
-    when(space.getGroupId()).thenReturn("space");
-    when(spaceService.isMember(any(Space.class), eq("john"))).thenReturn(true);
-    when(spaceService.isSuperManager(eq("john"))).thenReturn(false);
+
     // When
     Response response = newsRestResourcesV1.updateNews(request, "id123", updatedNews);
 
@@ -767,7 +691,8 @@ public class NewsRestResourcesV1Test {
     oldnews.setPinned(false);
     oldnews.setId("id123");
     oldnews.setSpaceId("space");
-
+    oldnews.setCanEdit(false);
+    
     News updatedNews = new News();
     updatedNews.setPinned(true);
 
@@ -778,9 +703,6 @@ public class NewsRestResourcesV1Test {
     Mockito.doNothing().when(newsService).pinNews("id123");
     when(newsService.getNewsById("id123")).thenReturn(oldnews);
     when(spaceService.getSpaceById(anyString())).thenReturn(space);
-    when(space.getGroupId()).thenReturn("space");
-    when(spaceService.isMember(any(Space.class), eq("john"))).thenReturn(true);
-    when(spaceService.isSuperManager(eq("john"))).thenReturn(false);
 
     // When
     Response response = newsRestResourcesV1.patchNews(request, "id123", updatedNews);
@@ -811,7 +733,8 @@ public class NewsRestResourcesV1Test {
     oldnews.setPinned(false);
     oldnews.setId("id123");
     oldnews.setSpaceId("space");
-
+    oldnews.setCanEdit(true);
+    
     News updatedNews = new News();
     updatedNews.setPinned(true);
     updatedNews.setTitle("title updated");
@@ -828,9 +751,6 @@ public class NewsRestResourcesV1Test {
     Mockito.doNothing().when(newsService).pinNews("id123");
     when(newsService.getNewsById("id123")).thenReturn(oldnews);
     when(spaceService.getSpaceById(anyString())).thenReturn(space);
-    when(space.getGroupId()).thenReturn("space");
-    when(spaceService.isMember(any(Space.class), eq("john"))).thenReturn(true);
-    when(spaceService.isSuperManager(eq("john"))).thenReturn(true);
 
     // When
     Response response = newsRestResourcesV1.patchNews(request, "id123", updatedNews);
@@ -861,7 +781,8 @@ public class NewsRestResourcesV1Test {
     oldnews.setPinned(true);
     oldnews.setId("id123");
     oldnews.setSpaceId("space");
-
+    oldnews.setCanEdit(true);
+    
     News updatedNews = new News();
     updatedNews.setPinned(false);
 
@@ -875,9 +796,7 @@ public class NewsRestResourcesV1Test {
     Mockito.doNothing().when(newsService).unpinNews("id123");
     when(newsService.getNewsById("id123")).thenReturn(oldnews);
     when(spaceService.getSpaceById(anyString())).thenReturn(space);
-    when(space.getGroupId()).thenReturn("space");
-    when(spaceService.isMember(any(Space.class), eq("john"))).thenReturn(true);
-    when(spaceService.isSuperManager(eq("john"))).thenReturn(true);
+
     // When
     Response response = newsRestResourcesV1.patchNews(request, "id123", updatedNews);
 
@@ -895,9 +814,6 @@ public class NewsRestResourcesV1Test {
                                                                       container);
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getRemoteUser()).thenReturn("john");
-    when(spaceService.getSpaceById(anyString())).thenReturn(new Space());
-    when(spaceService.isMember(any(Space.class), eq("john"))).thenReturn(false);
-    when(spaceService.isSuperManager(eq("john"))).thenReturn(false);
 
     // When
     Response response = newsRestResourcesV1.updateNews(request, "1", null);
@@ -936,8 +852,6 @@ public class NewsRestResourcesV1Test {
                                                                       container);
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getRemoteUser()).thenReturn("john");
-    when(spaceService.isMember(any(Space.class), eq("john"))).thenReturn(false);
-    when(spaceService.isSuperManager(eq("john"))).thenReturn(false);
     when(newsService.getNewsById("1")).thenReturn(news);
 
     // When


### PR DESCRIPTION
Before this fix:

- It is not possible for super admin or super spaces admin who are not space members to create news (write an article not shown on composer) or edit news (from news detail and news app)
- It is possible for a redactional space members to create a news directly with the rest service
- It is possible for any space member to edit a news even if he is not the news poster directly with the rest service (It is not possible by interface since the edit button has the right

This PR will adjust and harmonize add/edit news rest service permissions with UI ones