### PR TITLE
TASK-44216: Make sure that non-breaking spaces aren't considered in news's body.

### DIFF
--- a/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
+++ b/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
@@ -261,7 +261,7 @@ export default {
       return this.newsId !== null;
     },
     postDisabled: function () {
-      return this.uploading || !this.news.title || !this.news.title.trim() || !this.news.body || !this.news.body.replace(/&nbsp;/g, '').trim();
+      return this.uploading || !this.news.title || !this.news.title.trim() || !this.news.body || !this.news.body.replace(/<p>&nbsp;<\/p>/g, '').replace(/&nbsp;/g, '').trim();
     },
     updateDisabled: function () {
       // disable update button while uploading an attachment


### PR DESCRIPTION
In news's article body the non-breaking spaces are considered as plain text, i fixed the computed property in order to remove non-breaking spaces while checking for enabling the post button.