### PR TITLE
Task-43588: Fix horizontal scroll in snapshot page when a news with a long summary is pinned

### DIFF
--- a/webapp/src/main/webapp/css/news.less
+++ b/webapp/src/main/webapp/css/news.less
@@ -2356,6 +2356,7 @@
       .rightText {
         width: 100%;
         .rightTitle {
+          word-break: break-word;
           overflow: hidden;
           white-space: initial;
           -webkit-line-clamp: 1;
@@ -2532,6 +2533,7 @@
   }
 
   .contentTitle {
+    word-break: break-word;
     overflow: hidden;
     white-space: initial;
     -webkit-line-clamp: 1 !important;
@@ -2547,6 +2549,7 @@
   }
 
   .contentBody {
+    word-break: break-word;
     white-space: initial !important;
     -webkit-line-clamp: 3 !important;
     -webkit-box-orient: vertical !important;
@@ -2573,6 +2576,7 @@
     color: rgba(0, 0, 0, 0.87);
     font-weight: 700;
     font-size: 14px;
+    word-break: break-word;
 
   }
 


### PR DESCRIPTION
**Actual behavior:**  When we pin a news having a long summary, an horizontal scroll coming from latest news widget will be shown on snapshot page
**New behavior:**  We add a word-break css style for body content and title in order to split the word (not in the middle) and wrap it into next line.