### PR TITLE
Task-43594: Fix bad display of article detail with long summary

### DIFF
--- a/webapp/src/main/webapp/css/news.less
+++ b/webapp/src/main/webapp/css/news.less
@@ -224,6 +224,7 @@
 }
 
 .newsDetails-description {
+  word-break: break-word;
   background-color: #FFFFFF;
   text-align: center;
   .newsEditComponent {


### PR DESCRIPTION
**Actual behavior:**  When we post an article with a long summary and view the article detail, the summary exceeds the article banner and an horizontal scroll appears.
**New behavior:**  We add a word-break css style for the summary in order to split the word (not in the middle) and wrap it into next line.