### PR TITLE
Task-44749: Save draft while editing a posted article

### DIFF
--- a/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
@@ -383,9 +383,11 @@ public class NewsServiceImpl implements NewsService {
             }
             sendNotification(newMentionedNews, NotificationConstants.NOTIFICATION_CONTEXT.MENTION_IN_NEWS);
           }
+          indexingService.reindex(NewsIndexingServiceConnector.TYPE, String.valueOf(news.getId()));
+        } else if ("draft".equals(news.getPublicationState())) {
+          publicationService.changeState(newsNode, "draft", new HashMap<>());
         }
       }
-      indexingService.reindex(NewsIndexingServiceConnector.TYPE, String.valueOf(news.getId()));
       return news;
     } finally {
       if (session != null) {

--- a/webapp/src/main/webapp/WEB-INF/conf/news/nodetypes-templates/news/views/view1.gtmpl
+++ b/webapp/src/main/webapp/WEB-INF/conf/news/nodetypes-templates/news/views/view1.gtmpl
@@ -109,7 +109,7 @@
     }
     def updatedDate = LocalDateTime.ofInstant(news.updateDate.toInstant(), TimeZone.getDefault().toZoneId());
     def newsUpdatedDate = updatedDate.format(mediumDateFormat);
-    if( news.updateDate.getTime() == newsPublicationDate.getTime() ){
+    if(news.updateDate != null && newsPublicationDate != null && news.updateDate.getTime() == newsPublicationDate.getTime()){
       newsUpdatedDate = null;
     }
     def newsTitle = news.title.replaceAll("'", "\\\\'").replaceAll("</script", "</scr\\\\ipt");

--- a/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
+++ b/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
@@ -276,7 +276,8 @@ export default {
                  && this.news.title === this.originalNews.title
                  && this.news.summary === this.originalNews.summary
                  && this.news.body === this.originalNews.body
-                 && this.news.pinned === this.originalNews.pinned) {
+                 && this.news.pinned === this.originalNews.pinned
+                 && this.news.publicationState !== 'draft') {
         return true;
       }
 
@@ -457,6 +458,7 @@ export default {
             this.news.pinned = fetchedNode.pinned;
             this.news.archived = fetchedNode.archived;
             this.news.spaceId = fetchedNode.spaceId;
+            this.news.publicationState = fetchedNode.publicationState;
             this.initCKEditor();
             this.initCKEditorData(fetchedNode.body);
 

--- a/webapp/src/main/webapp/news/components/NewsApp.vue
+++ b/webapp/src/main/webapp/news/components/NewsApp.vue
@@ -286,21 +286,22 @@ export default {
         const newsIllustration = item.illustrationURL == null ? '/news/images/newsImageDefault.png' : item.illustrationURL;
         const newsIllustrationUpdatedTime = item.illustrationUpdateDate == null ? '' : item.illustrationUpdateDate.time;
         const activityId = item.activities ? item.activities.split(';')[0].split(':')[1] : '';
+        const isDraft = item.publicationState === 'draft';
         result.push({
           newsId: item.id,
           newsText: this.getNewsText(item.summary, item.body),
           illustrationURL: `${newsIllustration}?${newsIllustrationUpdatedTime}`,
           title: item.title,
-          updatedDate: item.publicationState !== 'draft' ? newsPublicationDate : newsUpdateDate,
+          updatedDate: !isDraft ? newsPublicationDate : newsUpdateDate,
           spaceDisplayName: item.spaceDisplayName,
           spaceUrl: item.spaceUrl,
-          url: item.publicationState === 'draft' ? `${eXo.env.portal.context}/${eXo.env.portal.portalName}/news/editor?spaceId=${item.spaceId}&newsId=${item.id}` : item.url,
+          url: isDraft ? `${eXo.env.portal.context}/${eXo.env.portal.portalName}/news/editor?spaceId=${item.spaceId}&newsId=${item.id}&activityId=${activityId}` : item.url,
           authorFullName: item.authorDisplayName,
           authorProfileURL: `${eXo.env.portal.context}/${eXo.env.portal.portalName}/profile/${item.author}`,
           viewsCount: item.viewsCount == null ? 0 : item.viewsCount,
           activityId: activityId,
           canEdit: item.canEdit,
-          canDelete: item.canDelete,
+          canDelete: item.canDelete && !(isDraft && activityId),
           archived: item.archived,
           draft: item.publicationState === 'draft',
           canArchive: item.canArchive,


### PR DESCRIPTION
Prior to this change, it was not possible to save drafts when editing an already posted article. After this change, the posted news drafts are saved while editing and available for the news author from drafts filter of news application.