### PR TITLE
TASK-45184: Fix UISharedNewsStreamActivity and UINewsStreamActivity look

### DIFF
--- a/webapp/src/main/webapp/groovy/news/webui/activity/UINewsStreamActivity.gtmpl
+++ b/webapp/src/main/webapp/groovy/news/webui/activity/UINewsStreamActivity.gtmpl
@@ -224,7 +224,7 @@
 			</div><!--end heading-->
 			<div class="description <%=isArchived ? "newsArchived" : ""%>">
           <img src="$illustrationURL" class="newsSmallIllustration" alt="News"/>
-          <div class="newsDetailsApp">
+          <div class="newsDetails">
               <div class="newsTitle">
                 <% if (isArchived) { %>
                   <i class="uiIconArchived" data-original-title="$archivedLabel" rel="tooltip" data-placement="bottom"></i>

--- a/webapp/src/main/webapp/groovy/news/webui/activity/UISharedNewsStreamActivity.gtmpl
+++ b/webapp/src/main/webapp/groovy/news/webui/activity/UISharedNewsStreamActivity.gtmpl
@@ -210,7 +210,7 @@ def streamOwner = activity.getStreamOwner();
 
                     <div class="description <%=isArchived ? "newsArchived" : ""%>">
                         <img src="$illustrationURL" class="newsSmallIllustration" alt="News"/>
-                        <div class="newsDetailsApp">
+                        <div class="newsDetails">
                             <div class="newsTitle">
                                 <% if (isArchived) { %>
                                   <i class="uiIconArchived" data-original-title="$archivedLabel" rel="tooltip" data-placement="bottom"></i>


### PR DESCRIPTION
Prior to this change, css class newsDetails has been changed by newsDetailsApp which causes a regression on the UISharedNewsStreamActivity  and UINewsStreamActivity look. Thus, this change is reverted to fix this problem