### PR TITLE
Task-45328: Implement Publish news drawer from the new editor 

### DIFF
--- a/services/src/main/resources/locale/portlet/news/News_en.properties
+++ b/services/src/main/resources/locale/portlet/news/News_en.properties
@@ -23,6 +23,10 @@ news.composer.draft=My drafts ({0})
 news.composer.draft.savingDraftStatus=Saving draft... 
 news.composer.draft.savedDraftStatus=Draft saved
 news.composer.draft.delete.confirmation=Are you sure you want to delete this draft?
+news.composer.postArticle=Post article
+news.composer.postImmediately=Post immediately
+news.composer.postLater=Post later
+news.composer.chooseDatePublish=Choose when you want your article to be published:
 
 news.composer.attachments.header=Attach files
 news.composer.attachments.drop=Drop files here

--- a/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
+++ b/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="VuetifyApp">
     <div v-show="loading">
       <div class="VuetifyApp loadingComposer">
         <v-progress-circular
@@ -11,6 +11,7 @@
       v-show="canCreatNews && !loading"
       id="newsActivityComposer"
       class="newsComposer">
+      <exo-news-publish-drawer ref="publishNewsDrawer" @post-article="postNews" />
       <div class="newsComposerActions">
         <div class="newsFormButtons">
           <div class="newsFormLeftActions">
@@ -44,31 +45,35 @@
                   :disabled="postDisabled || postingNews"
                   elevation="0"
                   class="btn btn-primary"
-                  @click="postNews">
+                  @click="openDrawer">
                   {{ $t("news.composer.post") }}
                 </v-btn>
               </v-app>
             </div>
           </div>
-          <div v-show="editMode" class="newsFormRightActions">
-            <button
-              id="newsEdit"
-              :disabled="updateDisabled"
-              class="btn btn-primary"
-              @click.prevent="updateNews">
-              {{ $t("news.edit.update") }}
-            </button>
-            <button
-              id="newsUpdateAndPost"
-              :disabled="news.archived ? true: updateDisabled"
-              :class="[news.archived ? 'unauthorizedPin' : '']"
-              class="btn"
-              @click.prevent="updateAndPostNews">
-              {{ $t("news.edit.update.post") }}
-            </button>
-            <button class="btn" @click="goBack">
-              {{ $t("news.composer.btn.cancel") }}
-            </button>
+          <div v-show="editMode" class="VuetifyApp">
+            <v-app>
+              <div class="d-flex flex-row">
+                <v-btn
+                  id="newsEdit"
+                  :disabled="updateDisabled"
+                  class="btn btn-primary mr-2 "
+                  @click.prevent="updateNews">
+                  {{ $t("news.edit.update") }}
+                </v-btn>
+                <v-btn
+                  id="newsUpdateAndPost"
+                  :disabled="news.archived ? true: updateDisabled"
+                  :class="[news.archived ? 'unauthorizedPin' : '']"
+                  class="btn mr-2"
+                  @click.prevent="updateAndPostNews">
+                  {{ $t("news.edit.update.post") }}
+                </v-btn>
+                <v-btn class="btn mr-6" @click="goBack">
+                  {{ $t("news.composer.btn.cancel") }}
+                </v-btn>
+              </div>
+            </v-app>
           </div>
         </div>
         <div id="newsTop"></div>
@@ -155,7 +160,7 @@
           </div>
         </div>
       </div>
-    <!-- end -->
+      <!-- end -->
     </div>
     
     <div v-show="!canCreatNews && !loading" class="newsComposer">
@@ -518,7 +523,11 @@ export default {
         });
       }, this.autoSaveDelay);
     },
-
+    openDrawer() {
+      if (this.$refs.publishNewsDrawer) {
+        this.$refs.publishNewsDrawer.open();
+      }
+    },
     postNews: function () {
       if (this.news.pinned === true) {
         const confirmText = this.$t('news.broadcast.confirm');

--- a/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
+++ b/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
@@ -1,7 +1,7 @@
 <template>
-  <div class="VuetifyApp">
+  <v-app>
     <div v-show="loading">
-      <div class="VuetifyApp loadingComposer">
+      <div class="loadingComposer">
         <v-progress-circular
           indeterminate
           color="primary" />
@@ -37,43 +37,38 @@
           </div>
           <div class="newsFormRightActions">
             <p class="draftSavingStatus">{{ draftSavingStatus }}</p>
-            <div v-show="!editMode" class="VuetifyApp">
-              <v-app>
-                <v-btn
-                  id="newsPost"
-                  :loading="postingNews"
-                  :disabled="postDisabled || postingNews"
-                  elevation="0"
-                  class="btn btn-primary"
-                  @click="openDrawer">
-                  {{ $t("news.composer.post") }}
-                </v-btn>
-              </v-app>
-            </div>
+            <v-btn
+              v-show="!editMode"
+              id="newsPost"
+              :loading="postingNews"
+              :disabled="postDisabled || postingNews"
+              elevation="0"
+              class="btn btn-primary"
+              @click="openDrawer">
+              {{ $t("news.composer.post") }}
+            </v-btn>
           </div>
-          <div v-show="editMode" class="VuetifyApp">
-            <v-app>
-              <div class="d-flex flex-row">
-                <v-btn
-                  id="newsEdit"
-                  :disabled="updateDisabled"
-                  class="btn btn-primary mr-2 "
-                  @click.prevent="updateNews">
-                  {{ $t("news.edit.update") }}
-                </v-btn>
-                <v-btn
-                  id="newsUpdateAndPost"
-                  :disabled="news.archived ? true: updateDisabled"
-                  :class="[news.archived ? 'unauthorizedPin' : '']"
-                  class="btn mr-2"
-                  @click.prevent="updateAndPostNews">
-                  {{ $t("news.edit.update.post") }}
-                </v-btn>
-                <v-btn class="btn mr-6" @click="goBack">
-                  {{ $t("news.composer.btn.cancel") }}
-                </v-btn>
-              </div>
-            </v-app>
+          <div v-show="editMode">
+            <div class="d-flex flex-row">
+              <v-btn
+                id="newsEdit"
+                :disabled="updateDisabled"
+                class="btn btn-primary mr-2 "
+                @click.prevent="updateNews">
+                {{ $t("news.edit.update") }}
+              </v-btn>
+              <v-btn
+                id="newsUpdateAndPost"
+                :disabled="news.archived ? true: updateDisabled"
+                :class="[news.archived ? 'unauthorizedPin' : '']"
+                class="btn mr-2"
+                @click.prevent="updateAndPostNews">
+                {{ $t("news.edit.update.post") }}
+              </v-btn>
+              <v-btn class="btn mr-6" @click="goBack">
+                {{ $t("news.composer.btn.cancel") }}
+              </v-btn>
+            </div>
           </div>
         </div>
         <div id="newsTop"></div>
@@ -116,26 +111,21 @@
           </div>
         </div>
       </form>
-
-      <div class="VuetifyApp">
-        <v-app>
-          <v-btn
-            class="attachmentsButton"
-            fixed
-            bottom
-            right
-            fab
-            x-large
-            @click="openApp()">
-            <i class="uiIconAttachment"></i>
-            <v-progress-circular
-              :class="uploading ? 'uploading' : ''"
-              indeterminate>
-              {{ news.attachments.length }}
-            </v-progress-circular>
-          </v-btn>
-        </v-app>
-      </div>
+      <v-btn
+        class="attachmentsButton"
+        fixed
+        bottom
+        right
+        fab
+        x-large
+        @click="openApp()">
+        <i class="uiIconAttachment"></i>
+        <v-progress-circular
+          :class="uploading ? 'uploading' : ''"
+          indeterminate>
+          {{ news.attachments.length }}
+        </v-progress-circular>
+      </v-btn>
       <exo-attachments
         ref="attachmentsComponent"
         :space-id="news.spaceId"
@@ -178,7 +168,7 @@
         </div>
       </div>
     </div>
-  </div>
+  </v-app>
 </template>
 
 <script>

--- a/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsPublishDrawer.vue
+++ b/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsPublishDrawer.vue
@@ -12,22 +12,7 @@
           <v-radio
             :label="$t('news.composer.postImmediately')"
             value="immediate" />
-          <v-radio
-            :label="$t('news.composer.postLater')"
-            value="later" />
         </v-radio-group>
-        <div v-if="postArticleMode==='later'" class="ml-4">
-          <div class="grey--text my-4">{{ $t('news.composer.chooseDatePublish') }}</div>
-          <div class="d-flex flex-row flex-grow-1">
-            <date-picker
-              v-model="datePublished"
-              class="flex-grow-1 my-auto" />
-            <div class="d-flex flex-row flex-grow-0">
-              <slot name="datePublishedDateTime"></slot>
-              <time-picker v-model="datePublishedTime" class="me-4" />
-            </div>
-          </div>
-        </div>
       </template>
       <template slot="footer">
         <div class="d-flex justify-end">
@@ -47,10 +32,7 @@
 export default {
   data: () => ({
     disabled: true,
-    showDatePublishing: false,
     postArticleMode: 'immediate',
-    datePublished: null,
-    datePublishedTime: null,
   }),
   methods: {
     open() {

--- a/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsPublishDrawer.vue
+++ b/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsPublishDrawer.vue
@@ -1,0 +1,67 @@
+<template>
+  <v-app>
+    <exo-drawer
+      ref="publishNewsDrawer"
+      body-classes="hide-scroll decrease-z-index-more"
+      right>
+      <template slot="title">
+        {{ $t('news.composer.postArticle') }}
+      </template>
+      <template slot="content">
+        <v-radio-group v-model="postArticleMode" class="ml-2">
+          <v-radio
+            :label="$t('news.composer.postImmediately')"
+            value="immediate" />
+          <v-radio
+            :label="$t('news.composer.postLater')"
+            value="later" />
+        </v-radio-group>
+        <div v-if="postArticleMode==='later'" class="ml-4">
+          <div class="grey--text my-4">{{ $t('news.composer.chooseDatePublish') }}</div>
+          <div class="d-flex flex-row flex-grow-1">
+            <date-picker
+              v-model="datePublished"
+              class="flex-grow-1 my-auto" />
+            <div class="d-flex flex-row flex-grow-0">
+              <slot name="datePublishedDateTime"></slot>
+              <time-picker v-model="datePublishedTime" class="me-4" />
+            </div>
+          </div>
+        </div>
+      </template>
+      <template slot="footer">
+        <div class="d-flex justify-end">
+          <v-btn
+            :disabled="disabled"
+            class="btn btn-primary ms-2"
+            @click="selectPostMode">
+            {{ $t('news.composer.post') }}
+          </v-btn>
+        </div>
+      </template>
+    </exo-drawer>
+  </v-app>
+</template>
+
+<script>
+export default {
+  data: () => ({
+    disabled: true,
+    showDatePublishing: false,
+    postArticleMode: 'immediate',
+    datePublished: null,
+    datePublishedTime: null,
+  }),
+  methods: {
+    open() {
+      if (this.$refs.publishNewsDrawer) {
+        this.disabled = false;
+        this.$refs.publishNewsDrawer.open();
+      }
+    },
+    selectPostMode() {
+      this.$emit('post-article', this.postArticleMode);
+    },
+  }
+};
+</script>

--- a/webapp/src/main/webapp/news-activity-composer-app/index.jsp
+++ b/webapp/src/main/webapp/news-activity-composer-app/index.jsp
@@ -5,8 +5,11 @@
   NewsService newsService = CommonsUtils.getService(NewsService.class);
   boolean showPinInput = newsService.canPinNews();
 %>
+<div class="VuetifyApp">
+  <div id="NewsComposerApp">
+  </div>
+</div>
 
-<div id="NewsComposerApp"></div>
 
 <script>
 require(['PORTLET/news/NewsComposer'], function(newsComposer) {

--- a/webapp/src/main/webapp/news-activity-composer-app/initComponents.js
+++ b/webapp/src/main/webapp/news-activity-composer-app/initComponents.js
@@ -1,9 +1,11 @@
 import ExoNewsActivityComposer  from './components/ExoNewsActivityComposer.vue';
 import ExoNewsFileDrop from './components/ExoNewsFileDrop.vue';
+import ExoNewsPublishDrawer from './components/ExoNewsPublishDrawer.vue';
 
 const components = {
   'exo-news-activity-composer': ExoNewsActivityComposer,
   'exo-news-file-drop': ExoNewsFileDrop,
+  'exo-news-publish-drawer': ExoNewsPublishDrawer,
 };
 
 for (const key in components) {

--- a/webapp/src/main/webapp/skin/less/news.less
+++ b/webapp/src/main/webapp/skin/less/news.less
@@ -830,7 +830,6 @@
 }
 
 .newsComposer {
-  .VuetifyApp {
     .v-btn--fab.v-btn--fixed.v-btn--bottom.attachmentsButton {
       bottom: 50px;
       right: 80px ~'; /** orientation=lt */ ';
@@ -872,7 +871,6 @@
     .v-navigation-drawer {
       z-index: 20;
     }
-  }
 }
 
 .videoDialog {


### PR DESCRIPTION
Prior to this change, from news editor when creating a news, we can post directly the news. After this change, posting a news should be done using a publish drawer