### PR TITLE
Task-45576: Display a warning message when editing a posted article having already a draft 

### DIFF
--- a/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
@@ -707,6 +707,7 @@ public class NewsServiceImpl implements NewsService {
     news.setUpdater(getLastUpdater(node));
     news.setUpdateDate(getLastUpdatedDate(node));
     news.setDraftUpdater(getStringProperty(node, "exo:lastModifier"));
+    news.setDraftUpdateDate(getDateProperty(node, "exo:dateModified"));
     news.setPath(getPath(node));
     if (node.hasProperty("publication:currentState")) {
       news.setPublicationState(node.getProperty("publication:currentState").getString());

--- a/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
@@ -706,6 +706,7 @@ public class NewsServiceImpl implements NewsService {
     news.setPublicationDate(getPublicationDate(node));
     news.setUpdater(getLastUpdater(node));
     news.setUpdateDate(getLastUpdatedDate(node));
+    news.setDraftUpdater(getStringProperty(node, "exo:lastModifier"));
     news.setPath(getPath(node));
     if (node.hasProperty("publication:currentState")) {
       news.setPublicationState(node.getProperty("publication:currentState").getString());
@@ -788,7 +789,10 @@ public class NewsServiceImpl implements NewsService {
       news.setAuthorAvatarUrl(identity.getProfile().getAvatarUrl());
     }
 
-
+    Identity draftUpdaterIdentity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, news.getDraftUpdater(), true);
+    if (draftUpdaterIdentity != null && draftUpdaterIdentity.getProfile() != null) {
+      news.setDraftUpdaterDisplayName(draftUpdaterIdentity.getProfile().getFullName());
+    }
 
     return news;
   }

--- a/services/src/main/java/org/exoplatform/news/model/News.java
+++ b/services/src/main/java/org/exoplatform/news/model/News.java
@@ -21,6 +21,10 @@ public class News {
 
   private String               updater;
 
+  private String               draftUpdater;
+
+  private String               draftUpdaterDisplayName;
+
   private String               uploadId;
 
   private byte[]               illustration;
@@ -119,6 +123,21 @@ public class News {
 
   public void setUpdater(String updater) {
     this.updater = updater;
+  }
+
+  public String getDraftUpdater() {
+    return draftUpdater;
+  }
+
+  public void setDraftUpdater(String draftUpdater) {
+    this.draftUpdater = draftUpdater;
+  }
+  public String getDraftUpdaterDisplayName() {
+    return draftUpdaterDisplayName;
+  }
+
+  public void setDraftUpdaterDisplayName(String draftUpdaterDisplayName) {
+    this.draftUpdaterDisplayName = draftUpdaterDisplayName;
   }
 
   public String getUploadId() {

--- a/services/src/main/java/org/exoplatform/news/model/News.java
+++ b/services/src/main/java/org/exoplatform/news/model/News.java
@@ -39,6 +39,8 @@ public class News {
 
   private Date                 updateDate;
 
+  private Date                 draftUpdateDate;
+
   private boolean              pinned;
 
   private boolean              archived;
@@ -194,6 +196,14 @@ public class News {
 
   public void setUpdateDate(Date updateDate) {
     this.updateDate = updateDate;
+  }
+
+  public Date getDraftUpdateDate() {
+    return draftUpdateDate;
+  }
+
+  public void setDraftUpdateDate(Date draftUpdateDate) {
+    this.draftUpdateDate = draftUpdateDate;
   }
 
   public boolean isPinned() {

--- a/services/src/main/resources/locale/portlet/news/News_en.properties
+++ b/services/src/main/resources/locale/portlet/news/News_en.properties
@@ -50,6 +50,7 @@ news.drafts.btn.delete=Delete
 news.drafts.delete.confirmation.message=Are you sure you want to delete this draft?
 news.drafts.delete.confirmation.btn.delete=Delete
 news.drafts.delete.confirmation.btn.cancel=Cancel
+news.drafts.warning.youAreEditingDraft=You are editing a draft created by {0} at {1}
 
 news.edit.editNews=Edit article
 news.edit.update=Update

--- a/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
+++ b/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
@@ -302,7 +302,7 @@ export default {
       return this.news.pinned ? this.$t('news.unbroadcast.action') : this.$t('news.broadcast.action');
     },
     draftWarningText() {
-      return this.$t('news.drafts.warning.youAreEditingDraft').replace('{0}', this.news.draftUpdaterDisplayName).replace('{1}', this.formatDate(this.news.updateDate.time));
+      return this.$t('news.drafts.warning.youAreEditingDraft').replace('{0}', this.news.draftUpdaterDisplayName).replace('{1}', this.formatDate(this.news.draftUpdateDate.time));
     }
   },
   watch: {
@@ -487,7 +487,7 @@ export default {
             this.news.activityId = fetchedNode.activityId;
             this.news.updater = fetchedNode.updater;
             this.news.draftUpdaterDisplayName = fetchedNode.draftUpdaterDisplayName;
-            this.news.updateDate = fetchedNode.updateDate;
+            this.news.draftUpdateDate = fetchedNode.draftUpdateDate;
             this.initCKEditor();
             this.initCKEditorData(fetchedNode.body);
 

--- a/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
+++ b/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
@@ -117,7 +117,7 @@
             colored-border
             class="warningAlert">
             <i class="fas fa-exclamation-circle exclamationIcon"></i>
-            <span class="warningText">{{ $t('news.drafts.warning.youAreEditingDraft').replace('{0}', this.news.draftUpdaterDisplayName).replace('{1}', formatDate(this.news.updateDate.time)) }}</span>
+            <span class="warningText">{{ draftWarningText }}</span>
           </v-alert>
         </div>
       </form>
@@ -301,6 +301,9 @@ export default {
     originalTitle() {
       return this.news.pinned ? this.$t('news.unbroadcast.action') : this.$t('news.broadcast.action');
     },
+    draftWarningText() {
+      return this.$t('news.drafts.warning.youAreEditingDraft').replace('{0}', this.news.draftUpdaterDisplayName).replace('{1}', this.formatDate(this.news.updateDate.time));
+    }
   },
   watch: {
     'news.title': function() {

--- a/webapp/src/main/webapp/skin/less/news.less
+++ b/webapp/src/main/webapp/skin/less/news.less
@@ -821,6 +821,23 @@
           margin-bottom: 0;
         }
       }
+
+      .warningAlert {
+        border: 0;
+        color: @warningColor;
+
+        .exclamationIcon {
+          color: @warningColor;
+          font-size: 20px;
+          margin-right: 8px;
+        }
+        .warningText {
+          color: @warningText;
+        }
+        .v-alert__dismissible {
+          color: @warningColor !important;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Prior to this change, we can modify directly a posted article on edit mode (already modified by another user). This PR will display a warning/alert message with the last article modifier et the last article modification date.