### PR TITLE
Task-45534: Fix pinned article detail back button redirection for non news space members 

### DIFF
--- a/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
@@ -807,6 +807,8 @@ public class NewsServiceImpl implements NewsService {
       String currentUser = getCurrentUserId();
       boolean hiddenSpace = space.getVisibility().equals(Space.HIDDEN) && !spaceService.isMember(space, currentUser) && !spaceService.isSuperManager(currentUser);
       news.setHiddenSpace(hiddenSpace);
+      boolean isSpaceMember =  spaceService.isSuperManager(getCurrentUserId()) || spaceService.isMember(space, getCurrentUserId());
+      news.setSpaceMember(isSpaceMember);
       news.setSpaceDisplayName(spaceName);
       if(StringUtils.isNotEmpty(space.getGroupId())) {
         String spaceGroupId = space.getGroupId().split("/")[2];

--- a/services/src/main/java/org/exoplatform/news/model/News.java
+++ b/services/src/main/java/org/exoplatform/news/model/News.java
@@ -53,6 +53,8 @@ public class News {
 
   private String               spaceUrl;
 
+  private boolean              isSpaceMember;
+
   private String               path;
 
   private String               publicationState;
@@ -236,6 +238,14 @@ public class News {
 
   public void setSpaceUrl(String spaceUrl) {
     this.spaceUrl = spaceUrl;
+  }
+
+  public boolean isSpaceMember() {
+    return isSpaceMember;
+  }
+
+  public void setSpaceMember(boolean spaceMember) {
+    isSpaceMember = spaceMember;
   }
 
   public String getPath() {

--- a/webapp/src/main/webapp/WEB-INF/conf/news/nodetypes-templates/news/views/view1.gtmpl
+++ b/webapp/src/main/webapp/WEB-INF/conf/news/nodetypes-templates/news/views/view1.gtmpl
@@ -147,6 +147,7 @@
         url: '${news.url}',
         activityId: '${activityId}',
         hiddenSpace: ${news.hiddenSpace},
+        isSpaceMember: ${news.isSpaceMember},
       },
       showEditButton: $showEditButton,
       showPinInput: $showPinInput,

--- a/webapp/src/main/webapp/groovy/news/webui/activity/UINewsFullActivity.gtmpl
+++ b/webapp/src/main/webapp/groovy/news/webui/activity/UINewsFullActivity.gtmpl
@@ -152,6 +152,7 @@
       spaceAvatarUrl: '${news.spaceAvatarUrl}',
       url: '${news.url}',
       hiddenSpace: ${news.hiddenSpace},
+      isSpaceMember: ${news.isSpaceMember},
     },
     showEditButton: $showEditButton,
     showPinInput: $showPinInput,

--- a/webapp/src/main/webapp/groovy/news/webui/activity/UISharedNewsFullActivity.gtmpl
+++ b/webapp/src/main/webapp/groovy/news/webui/activity/UISharedNewsFullActivity.gtmpl
@@ -165,6 +165,7 @@ if (activity && news) {
        spaceDisplayName: "${news.spaceDisplayName}",
        spaceUrl:'${news.spaceUrl}',
        hiddenSpace: ${news.hiddenSpace},
+       isSpaceMember: ${news.isSpaceMember},
      },
     showShareButton: false,
     showEditButton: false,

--- a/webapp/src/main/webapp/news-details/components/ExoNewsDetails.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsDetails.vue
@@ -199,7 +199,7 @@ export default {
       return this.news && (this.news.profileAvatarURL || this.news.authorAvatarUrl);
     },
     backURL() {
-      return this.news && this.news.url.includes('/news/detail?content-id=') ? `${eXo.env.portal.context}/${eXo.env.portal.portalName}` : this.news.spaceUrl;
+      return this.news && this.news.isSpaceMember ? this.news.spaceUrl : `${eXo.env.portal.context}/${eXo.env.portal.portalName}`;
     },
     updaterFullName() {
       return (this.news && this.news.updaterFullName) || (this.updaterIdentity && this.updaterIdentity.profile && this.updaterIdentity.profile.fullname);

--- a/webapp/src/main/webapp/news-details/components/ExoNewsDetails.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsDetails.vue
@@ -1,6 +1,6 @@
 <template>
   <div id="newsDetails">
-    <a class="backBtn" :href="news.spaceUrl"><i class="uiIconBack"></i></a>
+    <a class="backBtn" :href="backURL"><i class="uiIconBack"></i></a>
     <exo-news-details-action-menu
       v-if="showEditButton"
       :news="news"
@@ -197,6 +197,9 @@ export default {
     },
     authorAvatarURL() {
       return this.news && (this.news.profileAvatarURL || this.news.authorAvatarUrl);
+    },
+    backURL() {
+      return this.news && this.news.url.includes('/news/detail?content-id=') ? `${eXo.env.portal.context}/${eXo.env.portal.portalName}` : this.news.spaceUrl;
     },
     updaterFullName() {
       return (this.news && this.news.updaterFullName) || (this.updaterIdentity && this.updaterIdentity.profile && this.updaterIdentity.profile.fullname);


### PR DESCRIPTION
Prior to this change, when we click on back button from a pinned article detail as non news space member and non super spaces or user admin, we are redirected to non-acces-space page. This PR will update the redirection to the snapshot page in that case. 