### PR TITLE
Task-45336: Implement scheduled news filter in news app

### DIFF
--- a/services/src/main/java/org/exoplatform/news/NewsUtils.java
+++ b/services/src/main/java/org/exoplatform/news/NewsUtils.java
@@ -81,15 +81,8 @@ public class NewsUtils {
   public static List<Space> getRedactorOrManagerSpaces(String userId) throws Exception {
     SpaceService spaceService = CommonsUtils.getService(SpaceService.class);
     ListAccess<Space> spacesAccess = spaceService.getMemberSpaces(userId);
-    List<Space> spaces = new ArrayList<>();
     int spacesSize = spacesAccess.getSize();
-    int limitToFetch = Math.min(spacesSize, 20);
-    int offsetToFetch = 0;
-    while (limitToFetch > 0) {
-      spaces = Arrays.asList(spacesAccess.load(offsetToFetch, limitToFetch));
-      offsetToFetch += limitToFetch;
-      limitToFetch = Math.min((spacesSize - offsetToFetch), 20);
-    }
+    List<Space> spaces = Arrays.asList(spacesAccess.load(0, spacesSize));
     return spaces.stream()
                  .filter(space -> (spaceService.isManager(space, userId) || spaceService.isRedactor(space, userId)))
                  .collect(Collectors.toList());

--- a/services/src/main/java/org/exoplatform/news/NewsUtils.java
+++ b/services/src/main/java/org/exoplatform/news/NewsUtils.java
@@ -84,12 +84,9 @@ public class NewsUtils {
   public static List<Space> getSpacesWhichIsManagerOrRedactor(String userId) throws SpaceException {
     SpaceService spaceService = CommonsUtils.getService(SpaceService.class);
     List<Space> spaces = spaceService.getSpaces(userId);
-    return spaces.stream().filter(space -> {
-      if (spaceService.isManager(space, userId) || spaceService.isRedactor(space, userId)) {
-        return true;
-      }
-      return false;
-    }).collect(Collectors.toList());
+    return spaces.stream()
+                 .filter(space -> (spaceService.isManager(space, userId) || spaceService.isRedactor(space, userId)))
+                 .collect(Collectors.toList());
   }
 
 }

--- a/services/src/main/java/org/exoplatform/news/NewsUtils.java
+++ b/services/src/main/java/org/exoplatform/news/NewsUtils.java
@@ -80,9 +80,8 @@ public class NewsUtils {
 
   public static List<Space> getRedactorOrManagerSpaces(String userId) throws Exception {
     SpaceService spaceService = CommonsUtils.getService(SpaceService.class);
-    ListAccess<Space> spacesAccess = spaceService.getMemberSpaces(userId);
-    int spacesSize = spacesAccess.getSize();
-    List<Space> spaces = Arrays.asList(spacesAccess.load(0, spacesSize));
+    ListAccess<Space> memberSpacesListAccess = spaceService.getMemberSpaces(userId);
+    List<Space> spaces = Arrays.asList(memberSpacesListAccess.load(0, memberSpacesListAccess.getSize()));
     return spaces.stream()
                  .filter(space -> (spaceService.isManager(space, userId) || spaceService.isRedactor(space, userId)))
                  .collect(Collectors.toList());

--- a/services/src/main/java/org/exoplatform/news/NewsUtils.java
+++ b/services/src/main/java/org/exoplatform/news/NewsUtils.java
@@ -81,7 +81,7 @@ public class NewsUtils {
     return identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, username);
   }
 
-  public static List<Space> getSpacesWhichIsManagerOrRedactor(String userId) throws SpaceException {
+  public static List<Space> getRedactorOrManagerSpaces(String userId) throws SpaceException {
     SpaceService spaceService = CommonsUtils.getService(SpaceService.class);
     List<Space> spaces = spaceService.getSpaces(userId);
     return spaces.stream()

--- a/services/src/main/java/org/exoplatform/news/NewsUtils.java
+++ b/services/src/main/java/org/exoplatform/news/NewsUtils.java
@@ -8,11 +8,16 @@ import org.exoplatform.services.log.Log;
 import org.exoplatform.social.core.identity.model.Identity;
 import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;
 import org.exoplatform.social.core.manager.IdentityManager;
+import org.exoplatform.social.core.space.SpaceException;
+import org.exoplatform.social.core.space.model.Space;
+import org.exoplatform.social.core.space.spi.SpaceService;
 
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.regex.Matcher;
+import java.util.stream.Collectors;
 
 public class NewsUtils {
 
@@ -74,6 +79,17 @@ public class NewsUtils {
       return null;
     }
     return identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, username);
+  }
+
+  public static List<Space> getSpacesWhichIsManagerOrRedactor(String userId) throws SpaceException {
+    SpaceService spaceService = CommonsUtils.getService(SpaceService.class);
+    List<Space> spaces = spaceService.getSpaces(userId);
+    return spaces.stream().filter(space -> {
+      if (spaceService.isManager(space, userId) || spaceService.isRedactor(space, userId)) {
+        return true;
+      }
+      return false;
+    }).collect(Collectors.toList());
   }
 
 }

--- a/services/src/main/java/org/exoplatform/news/filter/NewsFilter.java
+++ b/services/src/main/java/org/exoplatform/news/filter/NewsFilter.java
@@ -9,6 +9,8 @@ public class NewsFilter {
   private boolean      archivedNews;
 
   private boolean      draftNews;
+  
+  private boolean      scheduleNews;
 
   private String       searchText;
 
@@ -47,6 +49,14 @@ public class NewsFilter {
 
   public void setDraftNews(boolean draftNews) {
     this.draftNews = draftNews;
+  }
+
+  public boolean isScheduleNews() {
+    return scheduleNews;
+  }
+
+  public void setScheduleNews(boolean scheduleNews) {
+    this.scheduleNews = scheduleNews;
   }
 
   public String getSearchText() {

--- a/services/src/main/java/org/exoplatform/news/filter/NewsFilter.java
+++ b/services/src/main/java/org/exoplatform/news/filter/NewsFilter.java
@@ -10,7 +10,7 @@ public class NewsFilter {
 
   private boolean      draftNews;
   
-  private boolean      scheduleNews;
+  private boolean      scheduledNews;
 
   private String       searchText;
 
@@ -51,12 +51,12 @@ public class NewsFilter {
     this.draftNews = draftNews;
   }
 
-  public boolean isScheduleNews() {
-    return scheduleNews;
+  public boolean isScheduledNews() {
+    return scheduledNews;
   }
 
-  public void setScheduleNews(boolean scheduleNews) {
-    this.scheduleNews = scheduleNews;
+  public void setScheduledNews(boolean scheduledNews) {
+    this.scheduledNews = scheduledNews;
   }
 
   public String getSearchText() {

--- a/services/src/main/java/org/exoplatform/news/queryBuilder/NewsQueryBuilder.java
+++ b/services/src/main/java/org/exoplatform/news/queryBuilder/NewsQueryBuilder.java
@@ -73,16 +73,14 @@ public class NewsQueryBuilder {
           sqlQuery.append(currentIdentityId).append("' IN exo:newsModifiersIds AND exo:activities <> '')");
           sqlQuery.append(" OR ");
           sqlQuery.append("( exo:author = '").append(filter.getAuthor()).append("' AND exo:activities = ''))");
-        } else if (filter.isScheduleNews()) {
-          List<Space> spacesFiltered = NewsUtils.getSpacesWhichIsManagerOrRedactor(currentIdentity.getUserId());
+        } else if (filter.isScheduledNews()) {
+          List<Space> allowedScheduledNewsSpaces = NewsUtils.getRedactorOrManagerSpaces(currentIdentity.getUserId());
           sqlQuery.append("publication:currentState = 'staged'");
-          sqlQuery.append(" AND exo:author = '").append(filter.getAuthor()).append("'");
-          if (spacesFiltered != null && !spacesFiltered.isEmpty()) {
-            sqlQuery.append("OR publication:currentState = 'staged'");
-            for (Space space : spacesFiltered) {
-              sqlQuery.append(" AND exo:spaceId = '").append(space.getId()).append("'");
-            }
+          sqlQuery.append(" AND (exo:author = '").append(filter.getAuthor()).append("'");
+          for (Space space : allowedScheduledNewsSpaces ) {
+            sqlQuery.append(" OR exo:spaceId = '").append(space.getId()).append("'");
           }
+          sqlQuery.append(" )");
         } else {
           if (StringUtils.isNotEmpty(filter.getAuthor())) {
             sqlQuery.append("exo:author = '").append(filter.getAuthor()).append("' AND ");

--- a/services/src/main/java/org/exoplatform/news/queryBuilder/NewsQueryBuilder.java
+++ b/services/src/main/java/org/exoplatform/news/queryBuilder/NewsQueryBuilder.java
@@ -77,7 +77,7 @@ public class NewsQueryBuilder {
           List<Space> spacesFiltered = NewsUtils.getSpacesWhichIsManagerOrRedactor(currentIdentity.getUserId());
           sqlQuery.append("publication:currentState = 'staged'");
           sqlQuery.append(" AND exo:author = '").append(filter.getAuthor()).append("'");
-          if (spacesFiltered != null && spacesFiltered.size() != 0) {
+          if (spacesFiltered != null && !spacesFiltered.isEmpty()) {
             sqlQuery.append("OR publication:currentState = 'staged'");
             for (Space space : spacesFiltered) {
               sqlQuery.append(" AND exo:spaceId = '").append(space.getId()).append("'");

--- a/services/src/main/java/org/exoplatform/news/queryBuilder/NewsQueryBuilder.java
+++ b/services/src/main/java/org/exoplatform/news/queryBuilder/NewsQueryBuilder.java
@@ -72,6 +72,9 @@ public class NewsQueryBuilder {
           sqlQuery.append(currentIdentityId).append("' IN exo:newsModifiersIds AND exo:activities <> '')");
           sqlQuery.append(" OR ");
           sqlQuery.append("( exo:author = '").append(filter.getAuthor()).append("' AND exo:activities = ''))");
+        } else if(filter.isScheduleNews()) {
+          sqlQuery.append("publication:currentState = 'staged'");
+          sqlQuery.append("AND exo:author = '").append(filter.getAuthor()).append("'");
         } else {
           if (StringUtils.isNotEmpty(filter.getAuthor())) {
             sqlQuery.append("exo:author = '").append(filter.getAuthor()).append("' AND ");

--- a/services/src/main/java/org/exoplatform/news/rest/NewsRestResourcesV1.java
+++ b/services/src/main/java/org/exoplatform/news/rest/NewsRestResourcesV1.java
@@ -307,13 +307,13 @@ public class NewsRestResourcesV1 implements ResourceContainer, Startable {
       if (news == null) {
         return Response.status(Response.Status.NOT_FOUND).build();
       }
-      Space space = spaceService.getSpaceById(news.getSpaceId());
+      Space newsSpace = spaceService.getSpaceById(news.getSpaceId());
       if (StringUtils.equals(news.getPublicationState(), PublicationDefaultStates.STAGED)
-          && !canViewScheduleNews(authenticatedUser, space, news)) {
+          && !canViewScheduledNews(authenticatedUser, newsSpace, news)) {
         return Response.status(Response.Status.UNAUTHORIZED).build();
       }
       if (!news.isPinned() && StringUtils.equals(news.getPublicationState(), PublicationDefaultStates.PUBLISHED)
-          && !canViewNews(authenticatedUser, space)) {
+          && !canViewNews(authenticatedUser, newsSpace)) {
         return Response.status(Response.Status.UNAUTHORIZED).build();
       }
       
@@ -325,8 +325,8 @@ public class NewsRestResourcesV1 implements ResourceContainer, Startable {
         String newsActivities = news.getActivities();
         for (String act : newsActivities.split(";")) {
           String spaceId = act.split(":")[0];
-          Space space1 = spaceService.getSpaceById(spaceId);
-          spacesList.add(space1);
+          Space space = spaceService.getSpaceById(spaceId);
+          spacesList.add(space);
         }
         filteredNews.setSharedInSpacesList(spacesList);
         return Response.ok(filteredNews).build();
@@ -889,7 +889,7 @@ public class NewsRestResourcesV1 implements ResourceContainer, Startable {
           if (StringUtils.isNotEmpty(author)) {
             newsFilter.setAuthor(author);
           }
-          newsFilter.setScheduleNews(true);
+          newsFilter.setScheduledNews(true);
           break;
         }
       }
@@ -916,7 +916,7 @@ public class NewsRestResourcesV1 implements ResourceContainer, Startable {
     return spaceService.isSuperManager(authenticatedUser) || (space != null && spaceService.isMember(space, authenticatedUser));
   }
 
-  private boolean canViewScheduleNews(String authenticatedUser, Space space, News news) throws Exception {
+  private boolean canViewScheduledNews(String authenticatedUser, Space space, News news) throws Exception {
     return StringUtils.equals(news.getAuthor(), authenticatedUser) || (space != null
         && (spaceService.isManager(space, authenticatedUser) || spaceService.isRedactor(space, authenticatedUser)));
   }

--- a/services/src/main/java/org/exoplatform/news/rest/NewsRestResourcesV1.java
+++ b/services/src/main/java/org/exoplatform/news/rest/NewsRestResourcesV1.java
@@ -916,7 +916,7 @@ public class NewsRestResourcesV1 implements ResourceContainer, Startable {
     return spaceService.isSuperManager(authenticatedUser) || (space != null && spaceService.isMember(space, authenticatedUser));
   }
 
-  private boolean canViewScheduledNews(String authenticatedUser, Space space, News news) throws Exception {
+  private boolean canViewScheduledNews(String authenticatedUser, Space space, News news) {
     return StringUtils.equals(news.getAuthor(), authenticatedUser) || (space != null
         && (spaceService.isManager(space, authenticatedUser) || spaceService.isRedactor(space, authenticatedUser)));
   }

--- a/services/src/main/java/org/exoplatform/news/rest/NewsRestResourcesV1.java
+++ b/services/src/main/java/org/exoplatform/news/rest/NewsRestResourcesV1.java
@@ -90,7 +90,7 @@ public class NewsRestResourcesV1 implements ResourceContainer, Startable {
   private Map<String, String>    newsToDeleteQueue = new HashMap<>();
 
   private enum FilterType {
-    PINNED, MYPOSTED, ARCHIVED, DRAFTS, ALL
+    PINNED, MYPOSTED, ARCHIVED, DRAFTS, SCHEDULED, ALL
   }
 
   public NewsRestResourcesV1(NewsService newsService,
@@ -863,29 +863,36 @@ public class NewsRestResourcesV1 implements ResourceContainer, Startable {
     if (StringUtils.isNotEmpty(filter)) {
       FilterType filterType = FilterType.valueOf(filter.toUpperCase());
       switch (filterType) {
-      case PINNED: {
-        newsFilter.setPinnedNews(true);
-        break;
-      }
-
-      case MYPOSTED: {
-        if (StringUtils.isNotEmpty(author)) {
-          newsFilter.setAuthor(author);
+        case PINNED: {
+          newsFilter.setPinnedNews(true);
+          break;
         }
-        break;
-      }
 
-      case ARCHIVED: {
-        newsFilter.setArchivedNews(true);
-        break;
-      }
-      case DRAFTS: {
-        if (StringUtils.isNotEmpty(author)) {
-          newsFilter.setAuthor(author);
+        case MYPOSTED: {
+          if (StringUtils.isNotEmpty(author)) {
+            newsFilter.setAuthor(author);
+          }
+          break;
         }
-        newsFilter.setDraftNews(true);
-        break;
-      }
+
+        case ARCHIVED: {
+          newsFilter.setArchivedNews(true);
+          break;
+        }
+        case DRAFTS: {
+          if (StringUtils.isNotEmpty(author)) {
+            newsFilter.setAuthor(author);
+          }
+          newsFilter.setDraftNews(true);
+          break;
+        }
+        case SCHEDULED: {
+          if (StringUtils.isNotEmpty(author)) {
+            newsFilter.setAuthor(author);
+          }
+          newsFilter.setScheduleNews(true);
+          break;
+        }
       }
     }
     // Set text to search news with

--- a/services/src/main/resources/locale/portlet/news/News_en.properties
+++ b/services/src/main/resources/locale/portlet/news/News_en.properties
@@ -161,6 +161,7 @@ news.app.filter.pinned=Published articles
 news.app.filter.myPosted=My posted articles
 news.app.filter.archived=Archived articles
 news.app.filter.drafts=Drafts
+news.app.filter.scheduled=Scheduled
 news.app.filter.bySpaces=Filter by spaces
 news.app.filter.drawer.reset=Reset
 news.app.filter.drawer.apply=Apply

--- a/services/src/test/java/org/exoplatform/news/NewsServiceImplTest.java
+++ b/services/src/test/java/org/exoplatform/news/NewsServiceImplTest.java
@@ -737,6 +737,64 @@ public class NewsServiceImplTest {
   }
 
   @Test
+  public void shouldScheduleNews() throws Exception {
+    // Given
+    DataDistributionType dataDistributionType = mock(DataDistributionType.class);
+    when(dataDistributionManager.getDataDistributionType(DataDistributionMode.NONE)).thenReturn(dataDistributionType);
+    NewsServiceImpl newsService = new NewsServiceImpl(repositoryService,
+                                                      sessionProviderService,
+                                                      nodeHierarchyCreator,
+                                                      dataDistributionManager,
+                                                      spaceService,
+                                                      activityManager,
+                                                      identityManager,
+                                                      uploadService,
+                                                      imageProcessor,
+                                                      linkManager,
+                                                      publicationServiceImpl,
+                                                      publicationManagerImpl,
+                                                      wcmPublicationServiceImpl,
+                                                      newsSearchConnector,
+                                                      newsAttachmentsService,
+                                                      indexingService,
+                                                      newsESSearchConnector,
+                                                      userACL);
+    News news = new News();
+    news.setTitle("new scheduled news title");
+    news.setSummary("new scheduled news summary");
+    news.setBody("new scheduled news body");
+    news.setUploadId(null);
+    String sDate1 = "22/08/2019";
+    Date date1 = new SimpleDateFormat("dd/MM/yyyy").parse(sDate1);
+    news.setCreationDate(date1);
+    news.setSpaceId("spaceTest");
+    news.setAuthor("root");
+
+    News scheduledNews = new News();
+    String datePostScheduled = "06/18/2021 15:01:16 +0100";
+    scheduledNews.setId("id123");
+    scheduledNews.setSchedulePostDate(datePostScheduled);
+    scheduledNews.setPublicationState("staged");
+
+    when(sessionProviderService.getSystemSessionProvider(any())).thenReturn(sessionProvider);
+    when(sessionProviderService.getSessionProvider(any())).thenReturn(sessionProvider);
+    when(sessionProvider.getSession(any(), any())).thenReturn(session);
+    when(repository.getConfiguration()).thenReturn(repositoryEntry);
+    when(repositoryEntry.getDefaultWorkspaceName()).thenReturn("collaboration");
+    NewsServiceImpl newsServiceSpy = Mockito.spy(newsService);
+    Mockito.doReturn(scheduledNews).when(newsServiceSpy).scheduleNews(news);
+
+
+    // When
+    News scheduleNews = newsServiceSpy.scheduleNews(news);
+
+    // Then
+    assertNotNull(scheduleNews);
+    assertEquals("staged", scheduleNews.getPublicationState());
+    assertEquals("06/18/2021 15:01:16 +0100", scheduleNews.getSchedulePostDate());
+  }
+
+  @Test
   public void shouldUnPinNews() throws Exception {
     // Given
 

--- a/services/src/test/java/org/exoplatform/news/queryBuilder/NewsQueryBuilderTest.java
+++ b/services/src/test/java/org/exoplatform/news/queryBuilder/NewsQueryBuilderTest.java
@@ -2,16 +2,32 @@ package org.exoplatform.news.queryBuilder;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.List;
 
+import org.exoplatform.commons.utils.CommonsUtils;
+import org.exoplatform.news.NewsUtils;
 import org.exoplatform.news.filter.NewsFilter;
 import org.exoplatform.services.security.ConversationState;
 import org.exoplatform.services.security.MembershipEntry;
+import org.exoplatform.social.core.space.model.Space;
+import org.exoplatform.social.core.space.spi.SpaceService;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
+@RunWith(PowerMockRunner.class)
+@PowerMockIgnore({"com.sun.*", "org.w3c.*", "javax.naming.*", "javax.xml.*", "org.xml.*", "javax.management.*"})
+@PrepareForTest(CommonsUtils.class)
 public class NewsQueryBuilderTest {
+  @Mock
+  SpaceService               spaceService;
 
   @Test
   public void shouldCreateQueryWithPinnedStateAndSearchTextAndAuthorAndOneSpaceAndCurrentUserIsNoPublisher() throws Exception {
@@ -145,6 +161,43 @@ public class NewsQueryBuilderTest {
     // then
     assertNotNull(query);
     assertEquals("SELECT * FROM exo:news WHERE ( exo:archived = 'true' AND exo:author = 'john') AND (publication:currentState = 'published' OR (publication:currentState = 'draft' AND exo:activities <> '' )) AND jcr:path LIKE '/Groups/spaces/%' ORDER BY jcr:score DESC",
+                 query.toString());
+  }
+
+  @PrepareForTest(NewsUtils.class)
+  @Test
+  public void shouldCreateQueryWithStagedStateWhenCurrentUserIsAuthor() throws Exception {
+    // Given
+    NewsQueryBuilder queryBuilder = new NewsQueryBuilder();
+    NewsFilter filter = new NewsFilter();
+    filter.setScheduledNews(true);
+    filter.setAuthor("john");
+    org.exoplatform.services.security.Identity currentIdentity = new org.exoplatform.services.security.Identity("john");
+    MembershipEntry membershipentry = new MembershipEntry("/platform/web-contributors", "publisher");
+    List<MembershipEntry> memberships = new ArrayList<MembershipEntry>();
+    memberships.add(membershipentry);
+    currentIdentity.setMemberships(memberships);
+    ConversationState state = new ConversationState(currentIdentity);
+    ConversationState.setCurrent(state);
+    List<Space> spaces = new ArrayList<>();
+    Space space1 = new Space();
+    space1.setId("1");
+    space1.setPrettyName("space1");
+    Space space2 = new Space();
+    space2.setId("2");
+    space2.setPrettyName("space2");
+    spaces.add(space1);
+    spaces.add(space2);
+
+    PowerMockito.mockStatic(NewsUtils.class);
+    when(NewsUtils.getRedactorOrManagerSpaces(currentIdentity.getUserId())).thenReturn(spaces);
+
+    // when
+    StringBuilder query = queryBuilder.buildQuery(filter);
+
+    // then
+    assertNotNull(query);
+    assertEquals("SELECT * FROM exo:news WHERE publication:currentState = 'staged' AND (exo:author = 'john' OR exo:spaceId = '1' OR exo:spaceId = '2' ) AND jcr:path LIKE '/Groups/spaces/%' ORDER BY null DESC",
                  query.toString());
   }
 }

--- a/services/src/test/java/org/exoplatform/news/rest/NewsRestResourcesV1Test.java
+++ b/services/src/test/java/org/exoplatform/news/rest/NewsRestResourcesV1Test.java
@@ -1923,4 +1923,39 @@ public class NewsRestResourcesV1Test {
     }
   }
 
+  @Test
+  public void shouldGetStagedNewsWhenCurrentUserIsAuthor() throws Exception {
+    // Given
+    NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
+                                                                      newsAttachmentsService,
+                                                                      spaceService,
+                                                                      identityManager,
+                                                                      container);
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    lenient().when(request.getRemoteUser()).thenReturn("john");
+    lenient().when(request.getLocale()).thenReturn(new Locale("en"));
+    News news = new News();
+    news.setSpaceId("1");
+    news.setAuthor("john");
+    news.setPublicationState(PublicationDefaultStates.STAGED);
+    List<News> allNews = new ArrayList<>();
+    allNews.add(news);
+
+    lenient().when(newsService.getNews(any())).thenReturn(allNews);
+    lenient().when(spaceService.isMember(any(Space.class), any())).thenReturn(true);
+    lenient().when(spaceService.getSpaceById(anyString())).thenReturn(new Space());
+
+    // When
+    Response response = newsRestResourcesV1.getNews(request, "john", null, null, null, 0, 10, false);
+
+    // Then
+    assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+    NewsEntity newsEntity = (NewsEntity) response.getEntity();
+    List<News> newsList = newsEntity.getNews();
+    assertNotNull(newsList);
+    assertEquals(1, newsList.size());
+    assertEquals(PublicationDefaultStates.STAGED, newsList.get(0).getPublicationState());
+    assertEquals("john", newsList.get(0).getAuthor());
+  }
+
 }

--- a/services/src/test/java/org/exoplatform/news/rest/NewsRestResourcesV1Test.java
+++ b/services/src/test/java/org/exoplatform/news/rest/NewsRestResourcesV1Test.java
@@ -913,6 +913,36 @@ public class NewsRestResourcesV1Test {
   }
 
   @Test
+  public void shouldGetOkWhenScheduleNews() throws Exception {
+    // Given
+    NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
+                                                                      newsAttachmentsService,
+                                                                      spaceService,
+                                                                      identityManager,
+                                                                      container);
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    lenient().when(request.getRemoteUser()).thenReturn("john");
+    News news = new News();
+    news.setId("1");
+    news.setPublicationState(PublicationDefaultStates.STAGED);
+    news.setCanEdit(true);
+    news.setSpaceId("1");
+    Space space1 = new Space();
+    space1.setId("1");
+    space1.setPrettyName("space1");
+    lenient().when(newsService.getNewsById(anyString(), anyBoolean())).thenReturn(news);
+    lenient().when(spaceService.getSpaceById(anyString())).thenReturn(space1);
+    lenient().when(spaceService.isMember(any(Space.class), eq("john"))).thenReturn(true);
+    lenient().when(spaceService.isSuperManager(eq("john"))).thenReturn(true);
+
+    // When
+    Response response = newsRestResourcesV1.scheduleNews(request, news);
+
+    // Then
+    assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+  }
+
+  @Test
   public void shouldGetNotAuthorizedWhenCreatingNewsDraftAndNewsExistsAndUserIsNotMemberOfTheSpaceNorSuperManager() throws Exception {
     // Given
     NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,

--- a/webapp/src/main/webapp/news/components/NewsApp.vue
+++ b/webapp/src/main/webapp/news/components/NewsApp.vue
@@ -196,7 +196,11 @@ export default {
       showArchiveButton: true,
       showShareButton: true,
       loadingNews: true,
-      initialized: false
+      initialized: false,
+      dateTimeFormat: {
+        hour: '2-digit',
+        minute: '2-digit',
+      },
     };
   },
   computed: {

--- a/webapp/src/main/webapp/news/components/NewsApp.vue
+++ b/webapp/src/main/webapp/news/components/NewsApp.vue
@@ -21,8 +21,7 @@
             :size="30"
             :width="3"
             indeterminate
-            class="loadingRing"
-            color="#578dc9" />
+            class="loadingRing" />
         </v-app>
       </div>
       <div class="newsAppToolbarRight">
@@ -54,8 +53,7 @@
         :size="40"
         :width="4"
         indeterminate
-        class="loadingRing"
-        color="#578dc9" />
+        class="loadingRing" />
     </v-app>
     <div
       v-if="newsList.length"
@@ -80,7 +78,7 @@
               :news-id="news.newsId"
               :activities="news.activities" />
             <exo-news-details-action-menu
-              v-if="news.canEdit "
+              v-if="news.canEdit && !news.schedulePostDate"
               :news="news"
               :show-edit-button="news.canEdit && !isDraftsFilter"
               :show-delete-button="news.canDelete"
@@ -113,7 +111,10 @@
             <div class="newsDate">
               <i class="uiIconClock"></i>
               <span v-if="news && news.schedulePostDate">
-                {{ news.schedulePostDate }}
+                <date-format
+                  :value="news.schedulePostDate"
+                  :format="dateFormat"
+                  class="newsTime" />
                 -
                 <date-format
                   :value="news.schedulePostDate"
@@ -200,6 +201,11 @@ export default {
       dateTimeFormat: {
         hour: '2-digit',
         minute: '2-digit',
+      },
+      dateFormat: {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
       },
     };
   },
@@ -298,7 +304,6 @@ export default {
 
       data.forEach((item) => {
         const newsPublicationDate = item.publicationDate != null ? new Date(item.publicationDate.time).toLocaleDateString(local, options) : null;
-        const schedulePostDate = item.schedulePostDate != null ? new Date(item.schedulePostDate).toLocaleDateString(local, options) : null;
         const newsUpdateDate = new Date(item.updateDate.time).toLocaleDateString(local, options);
         const newsIllustration = item.illustrationURL == null ? '/news/images/newsImageDefault.png' : item.illustrationURL;
         const newsIllustrationUpdatedTime = item.illustrationUpdateDate == null ? '' : item.illustrationUpdateDate.time;
@@ -321,7 +326,7 @@ export default {
           archived: item.archived,
           draft: item.publicationState === 'draft',
           scheduled: item.publicationState === 'staged',
-          schedulePostDate: schedulePostDate,
+          schedulePostDate: item.schedulePostDate,
           canArchive: item.canArchive,
           pinned: item.pinned,
           activities: item.activities,

--- a/webapp/src/main/webapp/skin/less/news.less
+++ b/webapp/src/main/webapp/skin/less/news.less
@@ -2036,7 +2036,7 @@
 
       .newsDate {
         color: @color-appNews-information;
-        .timeNewsApp {
+        .newsTime {
           display: inline;
         }
         .uiIconClock {

--- a/webapp/src/main/webapp/skin/less/news.less
+++ b/webapp/src/main/webapp/skin/less/news.less
@@ -1580,6 +1580,7 @@
 
   .loadingRing {
     margin: 15px auto;
+    color:@primaryColorDefault;
   }
 
   .newsAppToolBar {

--- a/webapp/src/main/webapp/skin/less/news.less
+++ b/webapp/src/main/webapp/skin/less/news.less
@@ -2036,7 +2036,9 @@
 
       .newsDate {
         color: @color-appNews-information;
-
+        .timeNewsApp {
+          display: inline;
+        }
         .uiIconClock {
           top: 0;
 


### PR DESCRIPTION
Priori to this change, there is no way to view the scheduled news. With this PR, it will be possible to: 
- Filter by scheduled news in News App .
- The scheduled news are viewable by the news author, news space redactors and managers.