### PR TITLE
Task-46034: Generate news activity for scheduled news

### DIFF
--- a/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
@@ -214,7 +214,7 @@ public class NewsServiceImpl implements NewsService {
    * @throws Exception when error
    */
   public News createNews(News news) throws Exception {
-    SessionProvider sessionProvider = sessionProviderService.getSessionProvider(null);
+    SessionProvider sessionProvider = SessionProvider.createSystemProvider();
     Session session = sessionProvider.getSession(
                                                  repositoryService.getCurrentRepository()
                                                                   .getConfiguration()
@@ -252,7 +252,7 @@ public class NewsServiceImpl implements NewsService {
    * @throws Exception when error
    */
   public News getNewsById(String id, boolean editMode) throws Exception {
-    SessionProvider sessionProvider = sessionProviderService.getSessionProvider(null);
+    SessionProvider sessionProvider = SessionProvider.createSystemProvider();
 
     Session session = sessionProvider.getSession(
                                                  repositoryService.getCurrentRepository()
@@ -280,7 +280,8 @@ public class NewsServiceImpl implements NewsService {
    */
   @Override
   public List<News> getNews(NewsFilter filter) throws Exception {
-    SessionProvider sessionProvider = sessionProviderService.getSessionProvider(null);
+    SessionProvider sessionProvider = SessionProvider.createSystemProvider();
+
     Session session = sessionProvider.getSession(
                                                  (repositoryService.getCurrentRepository()
                                                                    .getConfiguration()
@@ -352,7 +353,7 @@ public class NewsServiceImpl implements NewsService {
    * @throws Exception when error
    */
   public News updateNews(News news) throws Exception {
-    SessionProvider sessionProvider = sessionProviderService.getSystemSessionProvider(null);
+    SessionProvider sessionProvider = SessionProvider.createSystemProvider();
     Session session = sessionProvider.getSession(
                                                  repositoryService.getCurrentRepository()
                                                                   .getConfiguration()
@@ -615,7 +616,7 @@ public class NewsServiceImpl implements NewsService {
    * @throws Exception when error
    */
   public void shareNews(SharedNews sharedNews, List<Space> spaces) throws Exception {
-    SessionProvider sessionProvider = sessionProviderService.getSystemSessionProvider(null);
+    SessionProvider sessionProvider = SessionProvider.createSystemProvider();
     Session session = sessionProvider.getSession(
                                                  repositoryService.getCurrentRepository()
                                                                   .getConfiguration()
@@ -1182,7 +1183,7 @@ public class NewsServiceImpl implements NewsService {
 
   protected void updateNewsActivities(ExoSocialActivity activity, News news) throws Exception {
     if (activity.getId() != null) {
-      SessionProvider sessionProvider = sessionProviderService.getSessionProvider(null);
+      SessionProvider sessionProvider = SessionProvider.createSystemProvider();
       Session session = sessionProvider.getSession(
                                                    repositoryService.getCurrentRepository()
                                                                     .getConfiguration()
@@ -1208,7 +1209,7 @@ public class NewsServiceImpl implements NewsService {
 
   protected void sendNotification(News news, NotificationConstants.NOTIFICATION_CONTEXT context) throws Exception {
     String contentAuthor = news.getAuthor();
-    String currentUser = getCurrentUserId();
+    String currentUser = getCurrentUserId() != null ? getCurrentUserId() : contentAuthor;
     String activities = news.getActivities();
     String contentTitle = news.getTitle();
     String contentBody = news.getBody();

--- a/services/src/main/java/org/exoplatform/news/listener/NewsPublicationListener.java
+++ b/services/src/main/java/org/exoplatform/news/listener/NewsPublicationListener.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2003-2021 eXo Platform SAS.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see<http://www.gnu.org/licenses/>.
+ */
+package org.exoplatform.news.listener;
+
+import javax.jcr.Node;
+
+import org.apache.commons.lang3.StringUtils;
+
+import org.exoplatform.news.NewsService;
+import org.exoplatform.news.model.News;
+import org.exoplatform.services.cms.CmsService;
+import org.exoplatform.services.listener.Event;
+import org.exoplatform.services.listener.Listener;
+import org.exoplatform.services.wcm.extensions.publication.lifecycle.authoring.AuthoringPublicationConstant;
+import org.exoplatform.services.wcm.publication.PublicationDefaultStates;
+import org.exoplatform.services.wcm.publication.lifecycle.stageversion.StageAndVersionPublicationConstant;
+import org.exoplatform.services.wcm.utils.WCMCoreUtils;
+
+public class NewsPublicationListener extends Listener<CmsService, Node> {
+
+  private NewsService newsService;
+
+  public NewsPublicationListener() {
+    newsService = WCMCoreUtils.getService(NewsService.class);
+  }
+
+  public void onEvent(Event<CmsService, Node> event) throws Exception {
+    if (AuthoringPublicationConstant.POST_CHANGE_STATE_EVENT.equals(event.getEventName())) {
+      Node targetNode = event.getData();
+      if (targetNode.isNodeType("exo:news") && targetNode.getProperty(StageAndVersionPublicationConstant.CURRENT_STATE).getString().equals(PublicationDefaultStates.PUBLISHED)) {
+        News news = newsService.convertNodeToNews(targetNode, false);
+        if (StringUtils.isEmpty(news.getActivities())) {
+          newsService.createNews(news);
+        }
+      }
+    }
+  }
+}

--- a/services/src/main/java/org/exoplatform/news/notification/utils/NotificationUtils.java
+++ b/services/src/main/java/org/exoplatform/news/notification/utils/NotificationUtils.java
@@ -9,14 +9,10 @@ import org.exoplatform.commons.utils.PropertyManager;
 import org.exoplatform.container.PortalContainer;
 import org.exoplatform.news.model.News;
 import org.exoplatform.services.jcr.RepositoryService;
-import org.exoplatform.services.jcr.ext.app.SessionProviderService;
 import org.exoplatform.services.jcr.ext.common.SessionProvider;
 import org.exoplatform.services.organization.OrganizationService;
 import org.exoplatform.services.organization.User;
 import org.exoplatform.services.organization.UserHandler;
-import org.exoplatform.social.core.identity.model.Identity;
-import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;
-import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.social.core.service.LinkProvider;
 import org.exoplatform.social.core.space.model.Space;
 
@@ -33,8 +29,7 @@ public class NotificationUtils {
   }
 
   public static String getNewsIllustration(News news) throws Exception {
-    SessionProviderService sessionProviderService = CommonsUtils.getService(SessionProviderService.class);
-    SessionProvider sessionProvider = sessionProviderService.getSessionProvider(null);
+    SessionProvider sessionProvider = SessionProvider.createSystemProvider();
     RepositoryService repositoryService = CommonsUtils.getService(RepositoryService.class);
     Session session = sessionProvider.getSession(
                                                  repositoryService.getCurrentRepository()

--- a/services/src/test/java/org/exoplatform/news/NewsServiceImplTest.java
+++ b/services/src/test/java/org/exoplatform/news/NewsServiceImplTest.java
@@ -1,26 +1,54 @@
 package org.exoplatform.news;
 
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyBoolean;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.text.SimpleDateFormat;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import javax.jcr.ItemNotFoundException;
 import javax.jcr.Node;
 import javax.jcr.NodeIterator;
 import javax.jcr.Property;
-import javax.jcr.Session;
 import javax.jcr.Workspace;
 import javax.jcr.query.QueryManager;
 import javax.jcr.query.QueryResult;
 import javax.jcr.version.Version;
 import javax.jcr.version.VersionHistory;
 import javax.jcr.version.VersionIterator;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.AdditionalMatchers;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 import org.exoplatform.commons.api.notification.NotificationContext;
 import org.exoplatform.commons.api.notification.command.NotificationCommand;
@@ -47,6 +75,7 @@ import org.exoplatform.services.ecm.publication.impl.PublicationServiceImpl;
 import org.exoplatform.services.jcr.RepositoryService;
 import org.exoplatform.services.jcr.config.RepositoryEntry;
 import org.exoplatform.services.jcr.core.ExtendedNode;
+import org.exoplatform.services.jcr.core.ExtendedSession;
 import org.exoplatform.services.jcr.core.ManageableRepository;
 import org.exoplatform.services.jcr.ext.app.SessionProviderService;
 import org.exoplatform.services.jcr.ext.common.SessionProvider;
@@ -78,18 +107,6 @@ import org.exoplatform.social.core.service.LinkProvider;
 import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceService;
 import org.exoplatform.upload.UploadService;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
-import org.mockito.AdditionalMatchers;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 @RunWith(PowerMockRunner.class)
 @PowerMockIgnore({"com.sun.*", "org.w3c.*", "javax.naming.*", "javax.xml.*", "org.xml.*", "javax.management.*"})
@@ -112,7 +129,7 @@ public class NewsServiceImplTest {
   SessionProvider            sessionProvider;
 
   @Mock
-  Session                    session;
+  ExtendedSession            session;
 
   @Mock
   NodeHierarchyCreator       nodeHierarchyCreator;
@@ -192,12 +209,10 @@ public class NewsServiceImplTest {
     Node node = mock(Node.class);
     Property property = mock(Property.class);
     when(property.getString()).thenReturn("");
-    when(sessionProviderService.getSystemSessionProvider(any())).thenReturn(sessionProvider);
-    when(sessionProviderService.getSessionProvider(any())).thenReturn(sessionProvider);
     when(repositoryService.getCurrentRepository()).thenReturn(repository);
     when(repository.getConfiguration()).thenReturn(repositoryEntry);
+    when(repository.getSystemSession(anyString())).thenReturn(session);
     when(repositoryEntry.getDefaultWorkspaceName()).thenReturn("collaboration");
-    when(sessionProvider.getSession(any(), any())).thenReturn(session);
     when(session.getNodeByUUID(nullable(String.class))).thenReturn(node);
     Workspace workSpace = mock(Workspace.class);
     when(session.getWorkspace()).thenReturn(workSpace);
@@ -248,12 +263,11 @@ public class NewsServiceImplTest {
                                                   indexingService,
                                                   newsESSearchConnector,
                                                   userACL);
-    when(sessionProviderService.getSystemSessionProvider(any())).thenReturn(sessionProvider);
-    when(sessionProviderService.getSessionProvider(any())).thenReturn(sessionProvider);
     when(repositoryService.getCurrentRepository()).thenReturn(repository);
     when(repository.getConfiguration()).thenReturn(repositoryEntry);
+    when(repository.getSystemSession(anyString())).thenReturn(session);
+    when(repository.getConfiguration()).thenReturn(repositoryEntry);
     when(repositoryEntry.getDefaultWorkspaceName()).thenReturn("collaboration");
-    when(sessionProvider.getSession(any(), any())).thenReturn(session);
     when(session.getNodeByUUID(nullable(String.class))).thenReturn(null);
 
     // When
@@ -288,12 +302,10 @@ public class NewsServiceImplTest {
     Node node = mock(Node.class);
     Property property = mock(Property.class);
     when(property.getString()).thenReturn("");
-    when(sessionProviderService.getSystemSessionProvider(any())).thenReturn(sessionProvider);
-    when(sessionProviderService.getSessionProvider(any())).thenReturn(sessionProvider);
     when(repositoryService.getCurrentRepository()).thenReturn(repository);
     when(repository.getConfiguration()).thenReturn(repositoryEntry);
+    when(repository.getSystemSession(anyString())).thenReturn(session);
     when(repositoryEntry.getDefaultWorkspaceName()).thenReturn("collaboration");
-    when(sessionProvider.getSession(any(), any())).thenReturn(session);
     when(session.getNodeByUUID(nullable(String.class))).thenReturn(node);
     Workspace workSpace = mock(Workspace.class);
     when(session.getWorkspace()).thenReturn(workSpace);
@@ -409,12 +421,10 @@ public class NewsServiceImplTest {
     Property property = mock(Property.class);
     PowerMockito.mockStatic(CommonsUtils.class);
     when(CommonsUtils.getService(NewsESSearchConnector.class)).thenReturn(null);
-    when(sessionProviderService.getSystemSessionProvider(any())).thenReturn(sessionProvider);
-    when(sessionProviderService.getSessionProvider(any())).thenReturn(sessionProvider);
     when(repositoryService.getCurrentRepository()).thenReturn(repository);
     when(repository.getConfiguration()).thenReturn(repositoryEntry);
+    when(repository.getSystemSession(anyString())).thenReturn(session);
     when(repositoryEntry.getDefaultWorkspaceName()).thenReturn("collaboration");
-    when(sessionProvider.getSession(any(), any())).thenReturn(session);
     when(session.getNodeByUUID(nullable(String.class))).thenReturn(newsNode);
     when(newsNode.getProperty(nullable(String.class))).thenReturn(property);
     when(newsNode.getNode(eq("illustration"))).thenReturn(illustrationNode);
@@ -468,12 +478,10 @@ public class NewsServiceImplTest {
     Property property = mock(Property.class);
     PowerMockito.mockStatic(CommonsUtils.class);
     when(CommonsUtils.getService(NewsESSearchConnector.class)).thenReturn(null);
-    when(sessionProviderService.getSystemSessionProvider(any())).thenReturn(sessionProvider);
-    when(sessionProviderService.getSessionProvider(any())).thenReturn(sessionProvider);
     when(repositoryService.getCurrentRepository()).thenReturn(repository);
     when(repository.getConfiguration()).thenReturn(repositoryEntry);
+    when(repository.getSystemSession(anyString())).thenReturn(session);
     when(repositoryEntry.getDefaultWorkspaceName()).thenReturn("collaboration");
-    when(sessionProvider.getSession(any(), any())).thenReturn(session);
     when(session.getNodeByUUID(nullable(String.class))).thenReturn(newsNode);
     when(newsNode.getProperty(nullable(String.class))).thenReturn(property);
     when(newsNode.getNode(eq("illustration"))).thenReturn(illustrationNode);
@@ -524,12 +532,11 @@ public class NewsServiceImplTest {
     ExtendedNode newsNode = mock(ExtendedNode.class);
     Property property = mock(Property.class);
     when(property.getString()).thenReturn("");
-    when(sessionProviderService.getSystemSessionProvider(any())).thenReturn(sessionProvider);
-    when(sessionProviderService.getSessionProvider(any())).thenReturn(sessionProvider);
     when(repositoryService.getCurrentRepository()).thenReturn(repository);
     when(repository.getConfiguration()).thenReturn(repositoryEntry);
+    when(repository.getSystemSession(anyString())).thenReturn(session);
+    when(repository.getConfiguration()).thenReturn(repositoryEntry);
     when(repositoryEntry.getDefaultWorkspaceName()).thenReturn("collaboration");
-    when(sessionProvider.getSession(any(), any())).thenReturn(session);
     when(session.getNodeByUUID(nullable(String.class))).thenReturn(newsNode);
     Workspace workSpace = mock(Workspace.class);
     when(session.getWorkspace()).thenReturn(workSpace);
@@ -689,12 +696,10 @@ public class NewsServiceImplTest {
     Identity poster = mock(Identity.class);
     Identity spaceIdentity = mock(Identity.class);
     Property property = mock(Property.class);
-    when(sessionProviderService.getSystemSessionProvider(any())).thenReturn(sessionProvider);
-    when(sessionProviderService.getSessionProvider(any())).thenReturn(sessionProvider);
     when(repositoryService.getCurrentRepository()).thenReturn(repository);
     when(repository.getConfiguration()).thenReturn(repositoryEntry);
+    when(repository.getSystemSession(anyString())).thenReturn(session);
     when(repositoryEntry.getDefaultWorkspaceName()).thenReturn("collaboration");
-    when(sessionProvider.getSession(any(), any())).thenReturn(session);
     when(session.getNodeByUUID(nullable(String.class))).thenReturn(node);
     when(spaceService.getSpaceById("spaceTest")).thenReturn(space);
     when(nodeHierarchyCreator.getJcrPath("groupsPath")).thenReturn("spaces");
@@ -1288,11 +1293,10 @@ public class NewsServiceImplTest {
     news.setSpaceId("1");
     NewsServiceImpl newsServiceSpy = Mockito.spy(newsService);
 
-    when(sessionProviderService.getSystemSessionProvider(any())).thenReturn(sessionProvider);
     when(repositoryService.getCurrentRepository()).thenReturn(repository);
     when(repository.getConfiguration()).thenReturn(repositoryEntry);
+    when(repository.getSystemSession(anyString())).thenReturn(session);
     when(repositoryEntry.getDefaultWorkspaceName()).thenReturn("collaboration");
-    when(sessionProvider.getSession(any(), any())).thenReturn(session);
     when(session.getItem(nullable(String.class))).thenReturn(applicationDataNode);
     when(session.getNodeByUUID(nullable(String.class))).thenReturn(newsNode);
     Mockito.doReturn(news).when(newsServiceSpy).createNewsDraft(news);
@@ -1313,9 +1317,9 @@ public class NewsServiceImplTest {
     // Given
     DataDistributionType dataDistributionType = mock(DataDistributionType.class);
     when(dataDistributionManager.getDataDistributionType(DataDistributionMode.NONE)).thenReturn(dataDistributionType);
-    when(sessionProviderService.getSystemSessionProvider(any())).thenReturn(sessionProvider);
-    when(sessionProviderService.getSessionProvider(any())).thenReturn(sessionProvider);
-    when(sessionProvider.getSession(any(), any())).thenReturn(session);
+    when(repositoryService.getCurrentRepository()).thenReturn(repository);
+    when(repository.getConfiguration()).thenReturn(repositoryEntry);
+    when(repository.getSystemSession(anyString())).thenReturn(session);
 
     NewsServiceImpl newsService = new NewsServiceImpl(repositoryService,
                                                       sessionProviderService,
@@ -1361,7 +1365,6 @@ public class NewsServiceImplTest {
     when(repositoryService.getCurrentRepository()).thenReturn(repository);
     when(repository.getConfiguration()).thenReturn(repositoryEntry);
     when(repositoryEntry.getDefaultWorkspaceName()).thenReturn("collaboration");
-    when(sessionProvider.getSession(any(), any())).thenReturn(session);
     when(session.getItem(nullable(String.class))).thenReturn(applicationDataNode);
     when(session.getNodeByUUID(nullable(String.class))).thenReturn(newsNode);
     when(spaceService.getSpaceById("1")).thenReturn(space1);
@@ -1399,11 +1402,10 @@ public class NewsServiceImplTest {
                                                       indexingService,
                                                       newsESSearchConnector,
                                                       userACL);
-    when(sessionProviderService.getSessionProvider(any())).thenReturn(sessionProvider);
     when(repositoryService.getCurrentRepository()).thenReturn(repository);
     when(repository.getConfiguration()).thenReturn(repositoryEntry);
+    when(repository.getSystemSession(anyString())).thenReturn(session);
     when(repositoryEntry.getDefaultWorkspaceName()).thenReturn("collaboration");
-    when(sessionProvider.getSession(any(), any())).thenReturn(session);
     QueryManager qm = mock(QueryManager.class);
     Workspace workSpace = mock(Workspace.class);
     when(session.getWorkspace()).thenReturn(workSpace);
@@ -1482,11 +1484,11 @@ public class NewsServiceImplTest {
                                                       indexingService,
                                                       newsESSearchConnector,
                                                       userACL);
-    when(sessionProviderService.getSessionProvider(any())).thenReturn(sessionProvider);
+    
     when(repositoryService.getCurrentRepository()).thenReturn(repository);
     when(repository.getConfiguration()).thenReturn(repositoryEntry);
+    when(repository.getSystemSession(anyString())).thenReturn(session);
     when(repositoryEntry.getDefaultWorkspaceName()).thenReturn("collaboration");
-    when(sessionProvider.getSession(any(), any())).thenReturn(session);
     QueryManager qm = mock(QueryManager.class);
     Workspace workSpace = mock(Workspace.class);
     when(session.getWorkspace()).thenReturn(workSpace);
@@ -2143,11 +2145,10 @@ public class NewsServiceImplTest {
     when(identityManager.getOrCreateIdentity("organization", "root", false)).thenReturn(poster);
     when(identityManager.getOrCreateIdentity("space", "space1", false)).thenReturn(spaceIdentity);
     when(spaceService.getSpaceById("1")).thenReturn(space);
-    when(sessionProviderService.getSessionProvider(any())).thenReturn(sessionProvider);
     when(repositoryService.getCurrentRepository()).thenReturn(repository);
     when(repository.getConfiguration()).thenReturn(repositoryEntry);
+    when(repository.getSystemSession(anyString())).thenReturn(session);
     when(repositoryEntry.getDefaultWorkspaceName()).thenReturn("collaboration");
-    when(sessionProvider.getSession(any(), any())).thenReturn(session);
     when(session.getNodeByUUID("id123")).thenReturn(newsNode);
     when(newsNode.hasProperty("exo:activities")).thenReturn(true);
     // When
@@ -2180,11 +2181,11 @@ public class NewsServiceImplTest {
                                                       indexingService,
                                                       newsESSearchConnector,
                                                       userACL);
-    when(sessionProviderService.getSessionProvider(any())).thenReturn(sessionProvider);
     when(repositoryService.getCurrentRepository()).thenReturn(repository);
     when(repository.getConfiguration()).thenReturn(repositoryEntry);
+    when(repository.getSystemSession(anyString())).thenReturn(session);
+    
     when(repositoryEntry.getDefaultWorkspaceName()).thenReturn("collaboration");
-    when(sessionProvider.getSession(any(), any())).thenReturn(session);
     QueryManager qm = mock(QueryManager.class);
     Workspace workSpace = mock(Workspace.class);
     when(session.getWorkspace()).thenReturn(workSpace);
@@ -2363,11 +2364,10 @@ public class NewsServiceImplTest {
     ConversationState state = new ConversationState(currentIdentity);
     ConversationState.setCurrent(state);
 
-    when(sessionProviderService.getSessionProvider(any())).thenReturn(sessionProvider);
     when(repositoryService.getCurrentRepository()).thenReturn(repository);
     when(repository.getConfiguration()).thenReturn(repositoryEntry);
+    when(repository.getSystemSession(anyString())).thenReturn(session);
     when(repositoryEntry.getDefaultWorkspaceName()).thenReturn("collaboration");
-    when(sessionProvider.getSession(any(), any())).thenReturn(session);
     when(spaceService.getSpaceById("1")).thenReturn(space1);
     when(spaceService.isMember(space1, "root")).thenReturn(true);
     when(session.getNodeByUUID("id123")).thenReturn(null);
@@ -2427,11 +2427,10 @@ public class NewsServiceImplTest {
     when(identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "root")).thenReturn(rootIdentity);
 
     Node newsNode = mock(Node.class);
-    when(sessionProviderService.getSessionProvider(any())).thenReturn(sessionProvider);
     when(repositoryService.getCurrentRepository()).thenReturn(repository);
     when(repository.getConfiguration()).thenReturn(repositoryEntry);
+    when(repository.getSystemSession(anyString())).thenReturn(session);
     when(repositoryEntry.getDefaultWorkspaceName()).thenReturn("collaboration");
-    when(sessionProvider.getSession(any(), any())).thenReturn(session);
     when(spaceService.getSpaceById("1")).thenReturn(space1);
     when(spaceService.isMember(space1, "root")).thenReturn(true);
     when(session.getNodeByUUID("id123")).thenReturn(newsNode);
@@ -2516,11 +2515,10 @@ public class NewsServiceImplTest {
                                                       indexingService,
                                                       newsESSearchConnector,
                                                       userACL);
-    when(sessionProviderService.getSessionProvider(any())).thenReturn(sessionProvider);
     when(repositoryService.getCurrentRepository()).thenReturn(repository);
     when(repository.getConfiguration()).thenReturn(repositoryEntry);
+    when(repository.getSystemSession(anyString())).thenReturn(session);
     when(repositoryEntry.getDefaultWorkspaceName()).thenReturn("collaboration");
-    when(sessionProvider.getSession(any(), any())).thenReturn(session);
     QueryManager qm = mock(QueryManager.class);
     Workspace workSpace = mock(Workspace.class);
     when(session.getWorkspace()).thenReturn(workSpace);
@@ -2872,12 +2870,10 @@ public class NewsServiceImplTest {
     Node parentNode = mock(Node.class);
     Node illustrationNode = mock(Node.class);
     Property property = mock(Property.class);
-    when(sessionProviderService.getSystemSessionProvider(any())).thenReturn(sessionProvider);
-    when(sessionProviderService.getSessionProvider(any())).thenReturn(sessionProvider);
     when(repositoryService.getCurrentRepository()).thenReturn(repository);
     when(repository.getConfiguration()).thenReturn(repositoryEntry);
+    when(repository.getSystemSession(anyString())).thenReturn(session);
     when(repositoryEntry.getDefaultWorkspaceName()).thenReturn("collaboration");
-    when(sessionProvider.getSession(any(), any())).thenReturn(session);
     when(session.getNodeByUUID(nullable(String.class))).thenReturn(newsNode);
     when(newsNode.getProperty(nullable(String.class))).thenReturn(property);
     when(newsNode.getName()).thenReturn("Untitled");
@@ -2940,12 +2936,10 @@ public class NewsServiceImplTest {
     Node parentNode = mock(Node.class);
     Node illustrationNode = mock(Node.class);
     Property property = mock(Property.class);
-    when(sessionProviderService.getSystemSessionProvider(any())).thenReturn(sessionProvider);
-    when(sessionProviderService.getSessionProvider(any())).thenReturn(sessionProvider);
     when(repositoryService.getCurrentRepository()).thenReturn(repository);
     when(repository.getConfiguration()).thenReturn(repositoryEntry);
+    when(repository.getSystemSession(anyString())).thenReturn(session);
     when(repositoryEntry.getDefaultWorkspaceName()).thenReturn("collaboration");
-    when(sessionProvider.getSession(any(), any())).thenReturn(session);
     when(session.getNodeByUUID(nullable(String.class))).thenReturn(newsNode);
     when(newsNode.getProperty(nullable(String.class))).thenReturn(property);
     when(newsNode.getName()).thenReturn("Untitled");
@@ -2969,7 +2963,6 @@ public class NewsServiceImplTest {
     when(repositoryService.getCurrentRepository()).thenReturn(repository);
     when(repository.getConfiguration()).thenReturn(repositoryEntry);
     when(repositoryEntry.getDefaultWorkspaceName()).thenReturn("collaboration");
-    when(sessionProvider.getSession(any(), any())).thenReturn(session);
     when(spaceService.getSpaceById("1")).thenReturn(space1);
     when(spaceService.isMember(space1, "root")).thenReturn(true);
     when(session.getNodeByUUID("id123")).thenReturn(newsNode);

--- a/services/src/test/java/org/exoplatform/news/notification/utils/NotificationUtilsTest.java
+++ b/services/src/test/java/org/exoplatform/news/notification/utils/NotificationUtilsTest.java
@@ -1,16 +1,12 @@
 package org.exoplatform.news.notification.utils;
 
-import org.exoplatform.commons.utils.CommonsUtils;
-import org.exoplatform.commons.utils.PropertyManager;
-import org.exoplatform.container.ExoContainerContext;
-import org.exoplatform.container.PortalContainer;
-import org.exoplatform.news.model.News;
-import org.exoplatform.services.jcr.RepositoryService;
-import org.exoplatform.services.jcr.config.RepositoryEntry;
-import org.exoplatform.services.jcr.core.ManageableRepository;
-import org.exoplatform.services.jcr.ext.app.SessionProviderService;
-import org.exoplatform.services.jcr.ext.common.SessionProvider;
-import org.exoplatform.social.core.space.model.Space;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import javax.jcr.Node;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
@@ -18,13 +14,17 @@ import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import javax.jcr.Node;
-import javax.jcr.Session;
-
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import org.exoplatform.commons.utils.CommonsUtils;
+import org.exoplatform.commons.utils.PropertyManager;
+import org.exoplatform.container.ExoContainerContext;
+import org.exoplatform.container.PortalContainer;
+import org.exoplatform.news.model.News;
+import org.exoplatform.services.jcr.RepositoryService;
+import org.exoplatform.services.jcr.config.RepositoryEntry;
+import org.exoplatform.services.jcr.core.ExtendedSession;
+import org.exoplatform.services.jcr.core.ManageableRepository;
+import org.exoplatform.services.jcr.ext.app.SessionProviderService;
+import org.exoplatform.social.core.space.model.Space;
 
 @RunWith(PowerMockRunner.class)
 @PowerMockIgnore("javax.management.*")
@@ -85,19 +85,18 @@ public class NotificationUtilsTest {
   public void shouldGetTheDefaultIllustrationWhenTheNodeHasNotIllustration() throws Exception {
     // Given
     SessionProviderService sessionProviderService = mock(SessionProviderService.class);
+    
     PowerMockito.mockStatic(CommonsUtils.class);
     when(CommonsUtils.getService(SessionProviderService.class)).thenReturn(sessionProviderService);
-    SessionProvider sessionProvider = mock(SessionProvider.class);
-    when(sessionProviderService.getSessionProvider(null)).thenReturn(sessionProvider);
     RepositoryService repositoryService = mock(RepositoryService.class);
     when(CommonsUtils.getService(RepositoryService.class)).thenReturn(repositoryService);
     ManageableRepository repository = mock(ManageableRepository.class);
     when(repositoryService.getCurrentRepository()).thenReturn(repository);
     RepositoryEntry repositoryEntry = mock(RepositoryEntry.class);
     when(repository.getConfiguration()).thenReturn(repositoryEntry);
+    ExtendedSession session = mock(ExtendedSession.class);
+    when(repository.getSystemSession(any())).thenReturn(session);
     when(repositoryEntry.getDefaultWorkspaceName()).thenReturn("collaboration");
-    Session session = mock(Session.class);
-    when(sessionProvider.getSession(any(), any())).thenReturn(session);
     Node node = mock(Node.class);
     when(session.getNodeByUUID("id123")).thenReturn(node);
     when(node.hasNode("illustration")).thenReturn(false);

--- a/webapp/src/main/webapp/WEB-INF/conf/configuration.xml
+++ b/webapp/src/main/webapp/WEB-INF/conf/configuration.xml
@@ -29,7 +29,7 @@
   <import>war:/conf/news/dynamic-container-configuration.xml</import>
   <import>war:/conf/news/search-configuration.xml</import>
   <import>war:/conf/news/gamification-configuration.xml</import>
-  <import>war:/conf/news/news-job-configuration.xml</import>
+  <import>war:/conf/news/news-publication-configuration.xml</import>
   <import profiles="app-center">war:/conf/news/app-center-configuration.xml</import>
 
 </configuration>

--- a/webapp/src/main/webapp/WEB-INF/conf/news/news-publication-configuration.xml
+++ b/webapp/src/main/webapp/WEB-INF/conf/news/news-publication-configuration.xml
@@ -21,7 +21,7 @@
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd http://www.exoplatform.org/xml/ns/kernel_1_2.xsd"
    xmlns="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd">
-     <external-component-plugins>
+  <external-component-plugins>
     <target-component>org.exoplatform.services.scheduler.JobSchedulerService</target-component>
     <component-plugin>
       <name>newsPostLaterJob</name>
@@ -46,6 +46,16 @@
           <property name="predefinedPath" value="collaboration:/Groups/spaces"/>
         </properties-param>
       </init-params>
+    </component-plugin>
+  </external-component-plugins>
+  
+  <external-component-plugins>
+    <target-component>org.exoplatform.services.listener.ListenerService</target-component>
+    <component-plugin>
+      <name>PublicationService.event.postChangeState</name>
+      <set-method>addListener</set-method>
+      <type>org.exoplatform.news.listener.NewsPublicationListener</type>
+      <description>this listener will create news activity when news publication state is updated from "staged" to "published"</description>
     </component-plugin>
   </external-component-plugins>
 </configuration>


### PR DESCRIPTION
Prior to this change, after scheduling a news, when the scheduled date arrives, the news activity is not posted. With this PR, the news activity will be posted when the scheduled date arrives and the corresponding notification is sent.