### PR TITLE
Task-47085: Fix no notification when a scheduled article is finally posted

### DIFF
--- a/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
@@ -1230,7 +1230,7 @@ public class NewsServiceImpl implements NewsService {
 
   protected void updateNewsActivities(ExoSocialActivity activity, News news) throws Exception {
     if (activity.getId() != null) {
-      SessionProvider sessionProvider = sessionProviderService.getSessionProvider(null);
+      SessionProvider sessionProvider = sessionProviderService.getSystemSessionProvider(null);
       Session session = sessionProvider.getSession(
                                                    repositoryService.getCurrentRepository()
                                                                     .getConfiguration()

--- a/services/src/main/java/org/exoplatform/news/notification/utils/NotificationUtils.java
+++ b/services/src/main/java/org/exoplatform/news/notification/utils/NotificationUtils.java
@@ -31,7 +31,7 @@ public class NotificationUtils {
 
   public static String getNewsIllustration(News news) throws Exception {
     SessionProviderService sessionProviderService = CommonsUtils.getService(SessionProviderService.class);
-    SessionProvider sessionProvider = sessionProviderService.getSessionProvider(null);
+    SessionProvider sessionProvider = sessionProviderService.getSystemSessionProvider(null);
     RepositoryService repositoryService = CommonsUtils.getService(RepositoryService.class);
     Session session = sessionProvider.getSession(
                                                  repositoryService.getCurrentRepository()


### PR DESCRIPTION
- When you use` sessionProviderService.getSessionProvider(null)` : it throws null pointer exception, so we use
 `sessionProviderService.getSystemSessionProvider(null) ` to avoid this problem.