### PR TITLE
task-47214: hide article attachments in news details when detected by DLP

### DIFF
--- a/services/src/main/java/org/exoplatform/news/NewsAttachmentsServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/NewsAttachmentsServiceImpl.java
@@ -374,7 +374,9 @@ public class NewsAttachmentsServiceImpl implements NewsAttachmentsService {
           String attachmentId = value.getString();
           try {
             Node attachmentNode = newsNode.getSession().getNodeByUUID(attachmentId);
-            attachmentsNode.add(attachmentNode);
+            if (!attachmentNode.getPath().startsWith("/Quarantine/")) {
+              attachmentsNode.add(attachmentNode);
+            }
           } catch (Exception e) {
             LOG.error("Cannot get News attachment " + attachmentId + " of News " + newsNode.getUUID(), e);
           }

--- a/services/src/test/java/org/exoplatform/news/NewsAttachmentsServiceImplTest.java
+++ b/services/src/test/java/org/exoplatform/news/NewsAttachmentsServiceImplTest.java
@@ -206,9 +206,14 @@ public class NewsAttachmentsServiceImplTest {
     lenient().when(session.getNodeByUUID(eq("id123"))).thenReturn(node);
     Node attachmentNode = mock(Node.class);
     lenient().when(attachmentNode.getPath()).thenReturn("/folder/subFolder/attachNode");
+    Node attachmentNode1 = mock(Node.class);
+    lenient().when(attachmentNode1.getPath()).thenReturn("/folder/subFolder/attachNode1");
+    Node attachmentNode2 = mock(Node.class);
+    // quarantined attachment
+    lenient().when(attachmentNode2.getPath()).thenReturn("/Quarantine/attachNode2");
     lenient().when(session.getNodeByUUID(eq("idAttach1"))).thenReturn(attachmentNode);
-    lenient().when(session.getNodeByUUID(eq("idAttach2"))).thenReturn(attachmentNode);
-    lenient().when(session.getNodeByUUID(eq("idAttach3"))).thenReturn(attachmentNode);
+    lenient().when(session.getNodeByUUID(eq("idAttach2"))).thenReturn(attachmentNode1);
+    lenient().when(session.getNodeByUUID(eq("idAttach3"))).thenReturn(attachmentNode2);
 
 
     // When
@@ -216,7 +221,7 @@ public class NewsAttachmentsServiceImplTest {
 
     // Then
     assertNotNull(newsAttachments);
-    assertEquals(3, newsAttachments.size());
+    assertEquals(2, newsAttachments.size());
   }
 
   @Test

--- a/services/src/test/java/org/exoplatform/news/NewsAttachmentsServiceImplTest.java
+++ b/services/src/test/java/org/exoplatform/news/NewsAttachmentsServiceImplTest.java
@@ -205,6 +205,7 @@ public class NewsAttachmentsServiceImplTest {
     lenient().when(node.getProperty(eq("exo:attachmentsIds"))).thenReturn(attachmentIdsProperty);
     lenient().when(session.getNodeByUUID(eq("id123"))).thenReturn(node);
     Node attachmentNode = mock(Node.class);
+    lenient().when(attachmentNode.getPath()).thenReturn("/folder/subFolder/attachNode");
     lenient().when(session.getNodeByUUID(eq("idAttach1"))).thenReturn(attachmentNode);
     lenient().when(session.getNodeByUUID(eq("idAttach2"))).thenReturn(attachmentNode);
     lenient().when(session.getNodeByUUID(eq("idAttach3"))).thenReturn(attachmentNode);
@@ -459,10 +460,13 @@ public class NewsAttachmentsServiceImplTest {
     lenient().when(session.getNodeByUUID(eq("id123"))).thenReturn(node);
     ExtendedNode attachmentNode1 = mock(ExtendedNode.class);
     lenient().when(attachmentNode1.canAddMixin(eq("exo:privilegeable"))).thenReturn(true);
+    lenient().when(attachmentNode1.getPath()).thenReturn("/folder/subFolder/attachNode1");
     ExtendedNode attachmentNode2 = mock(ExtendedNode.class);
     lenient().when(attachmentNode2.canAddMixin(eq("exo:privilegeable"))).thenReturn(false);
+    lenient().when(attachmentNode2.getPath()).thenReturn("/folder/subFolder/attachNode2");
     ExtendedNode attachmentNode3 = mock(ExtendedNode.class);
     lenient().when(attachmentNode3.canAddMixin(eq("exo:privilegeable"))).thenReturn(true);
+    lenient().when(attachmentNode3.getPath()).thenReturn("/folder/subFolder/attachNode3");
     lenient().when(session.getNodeByUUID(eq("idAttach1"))).thenReturn(attachmentNode1);
     lenient().when(session.getNodeByUUID(eq("idAttach2"))).thenReturn(attachmentNode2);
     lenient().when(session.getNodeByUUID(eq("idAttach3"))).thenReturn(attachmentNode3);
@@ -508,10 +512,13 @@ public class NewsAttachmentsServiceImplTest {
     lenient().when(session.getNodeByUUID(eq("id123"))).thenReturn(node);
     ExtendedNode attachmentNode1 = mock(ExtendedNode.class);
     lenient().when(attachmentNode1.isNodeType(eq("exo:privilegeable"))).thenReturn(true);
+    lenient().when(attachmentNode1.getPath()).thenReturn("/folder/subFolder/attachNode1");
     ExtendedNode attachmentNode2 = mock(ExtendedNode.class);
     lenient().when(attachmentNode2.isNodeType(eq("exo:privilegeable"))).thenReturn(false);
+    lenient().when(attachmentNode2.getPath()).thenReturn("/folder/subFolder/attachNode2");
     ExtendedNode attachmentNode3 = mock(ExtendedNode.class);
     lenient().when(attachmentNode3.isNodeType(eq("exo:privilegeable"))).thenReturn(true);
+    lenient().when(attachmentNode3.getPath()).thenReturn("/folder/subFolder/attachNode3");
     lenient().when(session.getNodeByUUID(eq("idAttach1"))).thenReturn(attachmentNode1);
     lenient().when(session.getNodeByUUID(eq("idAttach2"))).thenReturn(attachmentNode2);
     lenient().when(session.getNodeByUUID(eq("idAttach3"))).thenReturn(attachmentNode3);
@@ -552,6 +559,7 @@ public class NewsAttachmentsServiceImplTest {
     lenient().when(node.getProperty(eq("exo:attachmentsIds"))).thenReturn(attachmentIdsProperty);
     lenient().when(session.getNodeByUUID(eq("id123"))).thenReturn(node);
     Node attachmentNode = mock(Node.class);
+    lenient().when(attachmentNode.getPath()).thenReturn("/folder/subFolder/attachNode");
     lenient().when(session.getNodeByUUID(eq("idAttach1"))).thenReturn(attachmentNode);
     lenient().when(session.getNodeByUUID(eq("idAttach2"))).thenReturn(attachmentNode);
     lenient().when(session.getNodeByUUID(eq("idAttach3"))).thenReturn(attachmentNode);

--- a/webapp/src/main/webapp/schedule-news-drawer/components/ExoScheduleNewsDrawer.vue
+++ b/webapp/src/main/webapp/schedule-news-drawer/components/ExoScheduleNewsDrawer.vue
@@ -26,13 +26,12 @@
             <span slot="label" class="postModeText">{{ $t('news.composer.postImmediately') }}</span>
           </v-radio>
           <v-radio
-            v-if="allowPostingLater"
             value="later"
             class="mt-4"
             @click="changeDisable">
             <span slot="label" class="postModeText">{{ $t('news.composer.postLater') }}</span>
           </v-radio>
-          <div v-if="(postArticleMode==='later' && allowPostingLater) || !allowNotPost && postArticleMode !=='immediate'" class="mt-4 ml-4">
+          <div v-if="showPostLaterMessage" class="mt-4 ml-4">
             <div class="grey--text my-4 scheduleInfoCursor">{{ $t('news.composer.choosePostDate') }}</div>
             <div class="d-flex flex-row flex-grow-1">
               <slot name="postDate"></slot>
@@ -51,13 +50,12 @@
           </div>
           <v-radio
             v-if="allowNotPost"
-            :label="$t('news.composer.notPost')"
             value="notPost"
             class="postModeText mt-4"
             @click="changeDisable">
             <span slot="label" class="postModeText">{{ $t('news.composer.cancelPost') }}</span>
           </v-radio>
-          <div v-if="allowNotPost && postArticleMode!=='later' && postArticleMode !=='immediate'" class="grey--text my-4 ml-4 scheduleInfoCursor">{{ $t('news.composer.chooseNotPost') }}</div>
+          <div v-if="showDontPostMessage" class="grey--text my-4 ml-4 scheduleInfoCursor">{{ $t('news.composer.chooseNotPost') }}</div>
         </v-radio-group>
       </template>
       <template slot="footer">
@@ -101,7 +99,6 @@ export default {
     disabled: false,
     postArticleMode: 'later',
     postDateTime: '8:00',
-    allowPostingLater: false,
     editScheduledNews: false,
     allowNotPost: false,
     schedulePostDate: null,
@@ -142,11 +139,15 @@ export default {
       const currentDate = new Date();
       return this.postDate && Number(new Date(this.postDate.getTime())) < currentDate.getTime() ? new Date(currentDate.getTime() + 1800000) : null;
     },
+    showDontPostMessage() {
+      return this.allowNotPost && this.postArticleMode !== 'later' && this.postArticleMode !== 'immediate';
+    },
+    showPostLaterMessage() {
+      return this.postArticleMode === 'later' || !this.allowNotPost && this.postArticleMode !== 'immediate';
+    }
   },
   created() {
     this.initializeDate();
-    this.$featureService.isFeatureEnabled('news.postLater')
-      .then(enabled => this.allowPostingLater = enabled);
     this.$root.$on('open-schedule-drawer', (scheduleMode) => {
       this.editScheduledNews = scheduleMode;
       if (scheduleMode === 'editScheduledNews') {

--- a/webapp/src/main/webapp/skin/less/news.less
+++ b/webapp/src/main/webapp/skin/less/news.less
@@ -116,7 +116,7 @@
 
   .newsTitle {
     padding-bottom: 10px;
-    font-weight: bold;
+    font-family: Helvetica, regular, sans-serif;
 
     a {
       color: @textColorDefault;
@@ -291,7 +291,7 @@
         margin: 20px auto 0;
         .newsTitleLink {
           color: @textColorDefault;
-          font-size: 24px;
+          font-size: 21pt;
           line-height: 3.5rem;
         }
       }
@@ -354,8 +354,8 @@
       max-width: 80%;
       margin: auto;
       font-style: italic;
-      font-size: 16px;
-      color: grey;
+      font-size: 16pt;
+      color: @grayLight;
     }
     .fullDetailsBody {
       border-top: 1px #ced2d5 solid;
@@ -363,8 +363,8 @@
       padding-top: 20px;
       padding-bottom: 30px;
       letter-spacing: .1px;
-      line-height: 1.7em;
-      font-size: 14px;
+      line-height: 1.6em;
+      font-size: 14pt;
       max-width: 80%;
       margin: auto;
       word-break: break-word;
@@ -396,7 +396,7 @@
     }
 
     .fullDetailsBody span:first-of-type {
-      line-height: 1.7em;
+      line-height: 1.6em;
     }
   }
 
@@ -539,7 +539,7 @@
   left: 0 ~'; /** orientation=lt */ ';
   right: 0 ~'; /** orientation=rt */ ';
   top: 0;
-  background: #FFFFFF;
+  background: @grayLighter;
   z-index: 10000;
 
   .btn[disabled] {
@@ -650,8 +650,10 @@
         .draftSavingStatus {
           margin-right: 7px ~'; /** orientation=lt */ ';
           margin-left: 7px ~'; /** orientation=rt */ ';
-          font-style: italic;
           padding-top: 10px;
+          font-family: Helvetica, regular, sans-serif;
+          font-size: 14px;
+          color: @grayDark;
         }
 
         button {
@@ -705,7 +707,6 @@
 
   #newsForm {
     padding: 2px 0;
-    margin-bottom: 55px;
     overflow: auto;
     z-index: 5;
     background-color: #eeeeee;
@@ -3896,3 +3897,49 @@ input.ignore-vuetify-classes.datePickerText.flex-grow-0 {
   filter: opacity(0.4);
 }
 
+#newsBody {
+  h1 {
+    display: block;
+    font-size: 2em ;
+    margin-block-start: 0.67em;
+    margin-block-end: 0.67em;
+    margin-inline-start: 0px;
+    margin-inline-end: 0px;
+    font-weight: normal;
+    line-height: 1.2;
+    color: @grayDark;
+  }
+  h2 {
+    display: block;
+    font-size: 1.5em;
+    margin-block-start: 0.83em;
+    margin-block-end: 0.83em;
+    margin-inline-start: 0px;
+    margin-inline-end: 0px;
+    font-weight: normal;
+    line-height: 1.2;
+    color: @grayDark;
+  }
+  h3 {
+    display: block;
+    font-size: 1.17em ;
+    margin-block-start: 1em ;
+    margin-block-end: 1em ;
+    margin-inline-start: 0px;
+    margin-inline-end: 0px;
+    font-weight: normal;
+    line-height: 1.2;
+    color: @grayDark;
+  }
+  p {
+    font-size:14pt;
+    display: block;
+    margin-block-start: 1em;
+    margin-block-end: 1em;
+    margin-inline-start: 0px;
+    margin-inline-end: 0px;
+    font-weight: normal;
+    line-height: 1.2;
+    color: @grayDark;
+  }
+}


### PR DESCRIPTION
 When an attached document to an article is detected by DLPs the document should not be available from the article's details