### PR TITLE
Task-47085: Fix no notification when a scheduled article is finally posted

### DIFF
--- a/services/src/main/java/org/exoplatform/news/NewsService.java
+++ b/services/src/main/java/org/exoplatform/news/NewsService.java
@@ -3,6 +3,7 @@ package org.exoplatform.news;
 import java.util.List;
 
 import javax.jcr.Node;
+import javax.jcr.Session;
 
 import org.exoplatform.commons.exception.ObjectNotFoundException;
 import org.exoplatform.news.filter.NewsFilter;
@@ -112,5 +113,7 @@ public interface NewsService {
   News scheduleNews(News news) throws Exception;
 
   News cancelScheduleNews(News news) throws Exception;
+
+  News createNews(News news, Session session) throws Exception;
 
 }

--- a/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
@@ -205,9 +205,15 @@ public class NewsServiceImpl implements NewsService {
     if (StringUtils.isEmpty(news.getId())) {
       news = createNewsDraft(news);
     } else {
-      postNewsActivity(news, session);
-      updateNews(news);
-      sendNotification(news, NotificationConstants.NOTIFICATION_CONTEXT.POST_NEWS, session);
+      try {
+        postNewsActivity(news, session);
+        updateNews(news);
+        sendNotification(news, NotificationConstants.NOTIFICATION_CONTEXT.POST_NEWS, session);
+      } finally {
+        if (session != null) {
+          session.logout();
+        }
+      }
     }
 
     if (news.isPinned()) {
@@ -221,9 +227,9 @@ public class NewsServiceImpl implements NewsService {
     if (StringUtils.isEmpty(news.getId())) {
       news = createNewsDraft(news);
     } else {
-        postNewsActivity(news, session);
-        updateNews(news);
-        sendNotification(news, NotificationConstants.NOTIFICATION_CONTEXT.POST_NEWS, session);
+      postNewsActivity(news, session);
+      updateNews(news);
+      sendNotification(news, NotificationConstants.NOTIFICATION_CONTEXT.POST_NEWS, session);
     }
 
     if (news.isPinned()) {

--- a/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
@@ -221,15 +221,9 @@ public class NewsServiceImpl implements NewsService {
     if (StringUtils.isEmpty(news.getId())) {
       news = createNewsDraft(news);
     } else {
-      try {
         postNewsActivity(news, session);
         updateNews(news);
         sendNotification(news, NotificationConstants.NOTIFICATION_CONTEXT.POST_NEWS, session);
-      } finally {
-        if (session != null) {
-          session.logout();
-        }
-      }
     }
 
     if (news.isPinned()) {

--- a/services/src/main/java/org/exoplatform/news/listener/NewsPublicationListener.java
+++ b/services/src/main/java/org/exoplatform/news/listener/NewsPublicationListener.java
@@ -42,7 +42,6 @@ public class NewsPublicationListener extends Listener<CmsService, Node> {
 
   private SessionProviderService sessionProviderService;
 
-
   public NewsPublicationListener() {
     newsService = WCMCoreUtils.getService(NewsService.class);
     sessionProviderService = WCMCoreUtils.getService(SessionProviderService.class);
@@ -52,24 +51,24 @@ public class NewsPublicationListener extends Listener<CmsService, Node> {
     ExoContainer container = PortalContainer.getInstance();
     RepositoryService repositoryService = container.getComponentInstanceOfType(RepositoryService.class);
     SessionProvider systemProvider = sessionProviderService.getSystemSessionProvider(null);
-    Session session = systemProvider.getSession(
-                                                repositoryService.getCurrentRepository()
-                                                                 .getConfiguration()
-                                                                 .getDefaultWorkspaceName(),
-                                                repositoryService.getCurrentRepository());
-    if (AuthoringPublicationConstant.POST_CHANGE_STATE_EVENT.equals(event.getEventName())) {
-      Node targetNode = event.getData();
-      if (targetNode.isNodeType("exo:news") && targetNode.getProperty(StageAndVersionPublicationConstant.CURRENT_STATE).getString().equals(PublicationDefaultStates.PUBLISHED)) {
-        News news = newsService.convertNodeToNews(targetNode, false);
-        if (StringUtils.isEmpty(news.getActivities())) {
-          try {
+    Session session = null;
+    try {
+      session = systemProvider.getSession(repositoryService.getCurrentRepository().getConfiguration().getDefaultWorkspaceName(),
+                                          repositoryService.getCurrentRepository());
+      if (AuthoringPublicationConstant.POST_CHANGE_STATE_EVENT.equals(event.getEventName())) {
+        Node targetNode = event.getData();
+        if (targetNode.isNodeType("exo:news") && targetNode.getProperty(StageAndVersionPublicationConstant.CURRENT_STATE)
+                                                           .getString()
+                                                           .equals(PublicationDefaultStates.PUBLISHED)) {
+          News news = newsService.convertNodeToNews(targetNode, false);
+          if (StringUtils.isEmpty(news.getActivities())) {
             newsService.createNews(news, session);
-          } finally {
-            if (session != null) {
-              session.logout();
-            }
           }
         }
+      }
+    } finally {
+      if (session != null) {
+        session.logout();
       }
     }
   }

--- a/services/src/main/java/org/exoplatform/news/listener/NewsPublicationListener.java
+++ b/services/src/main/java/org/exoplatform/news/listener/NewsPublicationListener.java
@@ -51,8 +51,7 @@ public class NewsPublicationListener extends Listener<CmsService, Node> {
   public void onEvent(Event<CmsService, Node> event) throws Exception {
     ExoContainer container = PortalContainer.getInstance();
     RepositoryService repositoryService = container.getComponentInstanceOfType(RepositoryService.class);
-    SessionProvider systemProvider = SessionProvider.createSystemProvider();
-    sessionProviderService.setSessionProvider(null, systemProvider);
+    SessionProvider systemProvider = sessionProviderService.getSystemSessionProvider(null);
     Session session = systemProvider.getSession(
                                                 repositoryService.getCurrentRepository()
                                                                  .getConfiguration()
@@ -63,7 +62,13 @@ public class NewsPublicationListener extends Listener<CmsService, Node> {
       if (targetNode.isNodeType("exo:news") && targetNode.getProperty(StageAndVersionPublicationConstant.CURRENT_STATE).getString().equals(PublicationDefaultStates.PUBLISHED)) {
         News news = newsService.convertNodeToNews(targetNode, false);
         if (StringUtils.isEmpty(news.getActivities())) {
-          newsService.createNews(news, session);
+          try {
+            newsService.createNews(news, session);
+          } finally {
+            if (session != null) {
+              session.logout();
+            }
+          }
         }
       }
     }

--- a/services/src/main/java/org/exoplatform/news/listener/NewsPublicationListener.java
+++ b/services/src/main/java/org/exoplatform/news/listener/NewsPublicationListener.java
@@ -42,8 +42,6 @@ public class NewsPublicationListener extends Listener<CmsService, Node> {
 
   private SessionProviderService sessionProviderService;
 
-  private RepositoryService      repositoryService;
-
 
   public NewsPublicationListener() {
     newsService = WCMCoreUtils.getService(NewsService.class);

--- a/services/src/main/java/org/exoplatform/news/notification/utils/NotificationUtils.java
+++ b/services/src/main/java/org/exoplatform/news/notification/utils/NotificationUtils.java
@@ -35,20 +35,14 @@ public class NotificationUtils {
     if (!currentDomain.endsWith("/")) {
       currentDomain += "/";
     }
-    try {
-      Node newsNode = session.getNodeByUUID(news.getId());
-      if (newsNode == null) {
-        throw new ItemNotFoundException("Cannot find a node with UUID equals to " + news.getId() + ", it may not exist");
-      }
-      if (newsNode.hasNode("illustration")) {
-        illustrationURL.append(currentDomain).append("portal/rest/v1/news/").append(news.getId()).append("/illustration");
-      } else {
-        illustrationURL.append(currentDomain).append("news/images/newsImageDefault.png");
-      }
-    } finally {
-      if (session != null) {
-        session.logout();
-      }
+    Node newsNode = session.getNodeByUUID(news.getId());
+    if (newsNode == null) {
+      throw new ItemNotFoundException("Cannot find a node with UUID equals to " + news.getId() + ", it may not exist");
+    }
+    if (newsNode.hasNode("illustration")) {
+      illustrationURL.append(currentDomain).append("portal/rest/v1/news/").append(news.getId()).append("/illustration");
+    } else {
+      illustrationURL.append(currentDomain).append("news/images/newsImageDefault.png");
     }
     return illustrationURL.toString();
   }

--- a/services/src/main/java/org/exoplatform/news/notification/utils/NotificationUtils.java
+++ b/services/src/main/java/org/exoplatform/news/notification/utils/NotificationUtils.java
@@ -29,15 +29,7 @@ public class NotificationUtils {
     return user.getFullName();
   }
 
-  public static String getNewsIllustration(News news) throws Exception {
-    SessionProviderService sessionProviderService = CommonsUtils.getService(SessionProviderService.class);
-    SessionProvider sessionProvider = sessionProviderService.getSessionProvider(null);
-    RepositoryService repositoryService = CommonsUtils.getService(RepositoryService.class);
-    Session session = sessionProvider.getSession(
-                                                 repositoryService.getCurrentRepository()
-                                                                  .getConfiguration()
-                                                                  .getDefaultWorkspaceName(),
-                                                 repositoryService.getCurrentRepository());
+  public static String getNewsIllustration(News news, Session session) throws Exception {
     StringBuffer illustrationURL = new StringBuffer();
     String currentDomain = CommonsUtils.getCurrentDomain();
     if (!currentDomain.endsWith("/")) {

--- a/services/src/test/java/org/exoplatform/news/NewsServiceImplTest.java
+++ b/services/src/test/java/org/exoplatform/news/NewsServiceImplTest.java
@@ -1151,8 +1151,8 @@ public class NewsServiceImplTest {
     when(newsRootNode.hasNode(eq("Pinned"))).thenReturn(true);
     when(newsRootNode.getNode(eq("Pinned"))).thenReturn(pinnedRootNode);
     Mockito.doNothing()
-            .when(newsServiceSpy)
-            .sendNotification(news, NotificationConstants.NOTIFICATION_CONTEXT.PUBLISH_IN_NEWS);
+           .when(newsServiceSpy)
+           .sendNotification(news, NotificationConstants.NOTIFICATION_CONTEXT.PUBLISH_IN_NEWS, session);
 
     // When
     newsServiceSpy.pinNews("id123");
@@ -1238,11 +1238,11 @@ public class NewsServiceImplTest {
 
     Mockito.doNothing().when(newsServiceSpy).pinNews("id123");
     Mockito.doReturn(createdNewsDraft).when(newsServiceSpy).createNewsDraft(news);
-    Mockito.doNothing().when(newsServiceSpy).postNewsActivity(createdNewsDraft);
+    Mockito.doNothing().when(newsServiceSpy).postNewsActivity(createdNewsDraft, session);
     Mockito.doNothing().when(publicationServiceImpl).changeState(newsNode, PublicationDefaultStates.PUBLISHED, new HashMap<>());
     Mockito.doNothing()
            .when(newsServiceSpy)
-           .sendNotification(createdNewsDraft, NotificationConstants.NOTIFICATION_CONTEXT.POST_NEWS);
+           .sendNotification(createdNewsDraft, NotificationConstants.NOTIFICATION_CONTEXT.POST_NEWS, session);
     // When
     News createdNews = newsServiceSpy.createNews(news);
 
@@ -1889,9 +1889,9 @@ public class NewsServiceImplTest {
     when(session.getItem(nullable(String.class))).thenReturn(applicationDataNode);
     when(session.getNodeByUUID(nullable(String.class))).thenReturn(newsNode);
     Mockito.doReturn(news).when(newsServiceSpy).createNewsDraft(news);
-    Mockito.doNothing().when(newsServiceSpy).postNewsActivity(news);
+    Mockito.doNothing().when(newsServiceSpy).postNewsActivity(news, session);
     Mockito.doNothing().when(publicationServiceImpl).changeState(newsNode, PublicationDefaultStates.PUBLISHED, new HashMap<>());
-    Mockito.doNothing().when(newsServiceSpy).sendNotification(news, NotificationConstants.NOTIFICATION_CONTEXT.POST_NEWS);
+    Mockito.doNothing().when(newsServiceSpy).sendNotification(news, NotificationConstants.NOTIFICATION_CONTEXT.POST_NEWS, session);
 
     // When
     newsServiceSpy.createNews(news);
@@ -1959,16 +1959,16 @@ public class NewsServiceImplTest {
     when(session.getNodeByUUID(nullable(String.class))).thenReturn(newsNode);
     when(spaceService.getSpaceById("1")).thenReturn(space1);
     Mockito.doReturn(news).when(newsServiceSpy).updateNews(news);
-    Mockito.doNothing().when(newsServiceSpy).postNewsActivity(news);
+    Mockito.doNothing().when(newsServiceSpy).postNewsActivity(news, session);
     Mockito.doNothing().when(publicationServiceImpl).changeState(newsNode, PublicationDefaultStates.PUBLISHED, new HashMap<>());
-    Mockito.doNothing().when(newsServiceSpy).sendNotification(news, NotificationConstants.NOTIFICATION_CONTEXT.POST_NEWS);
+    Mockito.doNothing().when(newsServiceSpy).sendNotification(news, NotificationConstants.NOTIFICATION_CONTEXT.POST_NEWS, session);
 
     // When
     newsServiceSpy.createNews(news);
 
     // Then
     verify(newsServiceSpy, times(1)).updateNews(news);
-    verify(newsServiceSpy, times(1)).sendNotification(news, NotificationConstants.NOTIFICATION_CONTEXT.POST_NEWS);
+    verify(newsServiceSpy, times(1)).sendNotification(news, NotificationConstants.NOTIFICATION_CONTEXT.POST_NEWS, session);
   }
 
   @Test
@@ -2681,7 +2681,7 @@ public class NewsServiceImplTest {
     when(spaceService.getSpaceById("1")).thenReturn(space);
 
     // When
-    newsService.postNewsActivity(news);
+    newsService.postNewsActivity(news, session);
 
     // Then
     ArgumentCaptor<Identity> identityCaptor = ArgumentCaptor.forClass(Identity.class);
@@ -2744,7 +2744,7 @@ public class NewsServiceImplTest {
     when(session.getNodeByUUID("id123")).thenReturn(newsNode);
     when(newsNode.hasProperty("exo:activities")).thenReturn(true);
     // When
-    newsService.updateNewsActivities(activity, news);
+    newsService.updateNewsActivities(activity, news, session);
 
     // Then
     assertEquals("1:38", news.getActivities());
@@ -2910,7 +2910,7 @@ public class NewsServiceImplTest {
     exceptionRule.expect(NullPointerException.class);
     exceptionRule.expectMessage("Cannot find a space with id 1, it may not exist");
 
-    newsService.sendNotification(news, NotificationConstants.NOTIFICATION_CONTEXT.POST_NEWS);
+    newsService.sendNotification(news, NotificationConstants.NOTIFICATION_CONTEXT.POST_NEWS, session);
 
   }
 
@@ -2972,7 +2972,7 @@ public class NewsServiceImplTest {
     exceptionRule.expect(ItemNotFoundException.class);
     exceptionRule.expectMessage("Cannot find a node with UUID equals to id123, it may not exist");
 
-    newsService.sendNotification(news, NotificationConstants.NOTIFICATION_CONTEXT.POST_NEWS);
+    newsService.sendNotification(news, NotificationConstants.NOTIFICATION_CONTEXT.POST_NEWS, session);
 
   }
 
@@ -3083,7 +3083,7 @@ public class NewsServiceImplTest {
     setRootAsCurrentIdentity();
 
     // When
-    newsService.sendNotification(news, NotificationConstants.NOTIFICATION_CONTEXT.POST_NEWS);
+    newsService.sendNotification(news, NotificationConstants.NOTIFICATION_CONTEXT.POST_NEWS, session);
 
     // Then
     verify(notificationExecutor, times(1)).execute(ctx);

--- a/services/src/test/java/org/exoplatform/news/listener/NewsGamificationIntegrationListenerTest.java
+++ b/services/src/test/java/org/exoplatform/news/listener/NewsGamificationIntegrationListenerTest.java
@@ -1,11 +1,18 @@
 package org.exoplatform.news.listener;
 
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
 import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.news.NewsService;
 import org.exoplatform.news.NewsUtils;
 import org.exoplatform.news.model.News;
+import org.exoplatform.services.jcr.RepositoryService;
+import org.exoplatform.services.jcr.config.RepositoryEntry;
+import org.exoplatform.services.jcr.core.ManageableRepository;
+import org.exoplatform.services.jcr.ext.app.SessionProviderService;
+import org.exoplatform.services.jcr.ext.common.SessionProvider;
 import org.exoplatform.services.listener.Event;
 import org.exoplatform.services.listener.Listener;
 import org.exoplatform.services.listener.ListenerService;
@@ -16,6 +23,7 @@ import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import javax.jcr.Session;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 @RunWith(PowerMockRunner.class)
@@ -29,8 +37,32 @@ public class NewsGamificationIntegrationListenerTest {
   @Mock
   NewsService     newsService;
 
+  @Mock
+  RepositoryService repositoryService;
+
+  @Mock
+  SessionProviderService sessionProviderService;
+
+  @Mock
+  ManageableRepository repository;
+
+  @Mock
+  RepositoryEntry repositoryEntry;
+
+  @Mock
+  SessionProvider sessionProvider;
+
+  @Mock
+  Session session;
+
   @Test
   public void testAddGamificationPointsAfterCreatingAnArticle() throws Exception { // NOSONAR
+    when(sessionProviderService.getSystemSessionProvider(any())).thenReturn(sessionProvider);
+    when(sessionProviderService.getSessionProvider(any())).thenReturn(sessionProvider);
+    when(repositoryService.getCurrentRepository()).thenReturn(repository);
+    when(repository.getConfiguration()).thenReturn(repositoryEntry);
+    when(repositoryEntry.getDefaultWorkspaceName()).thenReturn("collaboration");
+    when(sessionProvider.getSession(any(), any())).thenReturn(session);
     News news = new News();
     news.setTitle("title");
     news.setAuthor("jean");
@@ -46,7 +78,7 @@ public class NewsGamificationIntegrationListenerTest {
         executeListener.set(true);
       }
     });
-    newsService.createNews(news);
+    newsService.createNews(news, session);
     assertTrue(executeListener.get());
   }
 

--- a/services/src/test/java/org/exoplatform/news/notification/utils/NotificationUtilsTest.java
+++ b/services/src/test/java/org/exoplatform/news/notification/utils/NotificationUtilsTest.java
@@ -107,7 +107,7 @@ public class NotificationUtilsTest {
     news.setId("id123");
 
     // When
-    String illustrationUrl = NotificationUtils.getNewsIllustration(news);
+    String illustrationUrl = NotificationUtils.getNewsIllustration(news, session);
 
     assertEquals("http://localhost:8080/news/images/newsImageDefault.png", illustrationUrl);
   }


### PR DESCRIPTION
**-Problem:**  When we use `sessionProviderService.getSessionProvider(null)` : it throws null pointer exception, when `NewsPublicationListener` launch.
**-Solution:**  We create 2 methods for news creation: the first one that use `getSessionProvider` , the second calls by `NewsPublicationListener` and use system session provider