### PR TITLE
TASK-47367: Add loading effect on post news button

### DIFF
--- a/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
+++ b/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
@@ -11,7 +11,9 @@
       v-show="canCreatNews && !loading"
       id="newsActivityComposer"
       class="newsComposer">
-      <schedule-news-drawer @post-article="postNews" />
+      <schedule-news-drawer
+        :posting-news="postingNews"
+        @post-article="postNews" />
       <div class="newsComposerActions">
         <div class="newsFormButtons">
           <div class="newsFormLeftActions">

--- a/webapp/src/main/webapp/schedule-news-drawer/components/ExoScheduleNewsDrawer.vue
+++ b/webapp/src/main/webapp/schedule-news-drawer/components/ExoScheduleNewsDrawer.vue
@@ -62,6 +62,7 @@
         <div v-if="editScheduledNews !== 'editScheduledNews'" class="d-flex justify-end">
           <v-btn
             :disabled="disabled"
+            :loading="postingNews"
             class="btn btn-primary ms-2"
             @click="selectPostMode">
             {{ saveButtonLabel }}
@@ -92,6 +93,10 @@ export default {
       type: String,
       required: false,
       default: null
+    },
+    postingNews: {
+      type: Boolean,
+      default: false
     },
   },
   data: () => ({


### PR DESCRIPTION
The loading effect is not removed, but still appears on the first post button. This fix adds the same condition of loading to the post button in the drawer. 