### PR TITLE
TASK-47234 Cache News Object with activity

### DIFF
--- a/services/src/main/java/org/exoplatform/news/activity/processor/ActivityNewsProcessor.java
+++ b/services/src/main/java/org/exoplatform/news/activity/processor/ActivityNewsProcessor.java
@@ -1,0 +1,37 @@
+package org.exoplatform.news.activity.processor;
+
+import java.util.HashMap;
+
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.news.NewsService;
+import org.exoplatform.news.model.News;
+import org.exoplatform.social.core.BaseActivityProcessorPlugin;
+import org.exoplatform.social.core.activity.model.ExoSocialActivity;
+
+public class ActivityNewsProcessor extends BaseActivityProcessorPlugin {
+
+  private NewsService newsService;
+
+  public ActivityNewsProcessor(NewsService newsService, InitParams initParams) {
+    super(initParams);
+    this.newsService = newsService;
+  }
+
+  @Override
+  public void processActivity(ExoSocialActivity activity) {
+    if (activity.isComment()
+        || activity.getType() == null
+        || !activity.getTemplateParams().containsKey("newsId")) {
+      return;
+    }
+    if (activity.getLinkedProcessedEntities() == null) {
+      activity.setLinkedProcessedEntities(new HashMap<>());
+    }
+    News news = (News) activity.getLinkedProcessedEntities().get("news");
+    if (news == null) {
+      news = newsService.getNewsById(activity.getTemplateParams().get("newsId"), false);
+      activity.getLinkedProcessedEntities().put("news", news);
+    }
+  }
+
+}

--- a/webapp/src/main/webapp/WEB-INF/conf/news/activity-listener-configuration.xml
+++ b/webapp/src/main/webapp/WEB-INF/conf/news/activity-listener-configuration.xml
@@ -27,5 +27,17 @@
       <set-method>addActivityEventListener</set-method>
       <type>org.exoplatform.news.listener.NewsActivityListener</type>
     </component-plugin>
+    <component-plugin>
+      <name>ActivityNewsProcessor</name>
+      <set-method>addProcessorPlugin</set-method>
+      <type>org.exoplatform.news.activity.processor.ActivityNewsProcessor</type>
+      <init-params>
+        <value-param>
+          <name>priority</name>
+          <description>priority of this processor (lower are executed first)</description>
+          <value>30</value>
+        </value-param>
+      </init-params>
+    </component-plugin>
   </external-component-plugins>
 </configuration>

--- a/webapp/src/main/webapp/news-extensions/extensions.js
+++ b/webapp/src/main/webapp/news-extensions/extensions.js
@@ -41,13 +41,15 @@ const newsActivityTypeExtensionOptions = {
   },
   extendSharedActivity: (activity, isActivityDetail) => isActivityDetail,
   showSharedInformationFooter: (activity, isActivityDetail) => isActivityDetail,
-  init: activity => {
+  init: (activity, isActivityDetail) => {
     let activityId = activity.id;
     if (activity.parentActivity) {
       activityId = activity.parentActivity.id;
     }
-    return Vue.prototype.$newsServices.getNewsByActivityId(activityId)
-      .then(news => activity.news = news);
+    if (!activity.news || isActivityDetail) {
+      return Vue.prototype.$newsServices.getNewsByActivityId(activityId)
+        .then(news => activity.news = news);
+    }
   },
   canEdit: () => false,
   canShare: () => true,


### PR DESCRIPTION
Prior to this change, the News attached to an activity was retrieved from database with a specific REST request for each activity. This change will avoid retrieving News from front in activity preview mode only. In fact in standalone mode, the specific activity permissions has to be retrieved switch user.