### PR TITLE
task-47214: hide article attachments in news details when detected by DLP (#205)

### DIFF
--- a/services/src/main/java/org/exoplatform/news/NewsAttachmentsServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/NewsAttachmentsServiceImpl.java
@@ -374,7 +374,9 @@ public class NewsAttachmentsServiceImpl implements NewsAttachmentsService {
           String attachmentId = value.getString();
           try {
             Node attachmentNode = newsNode.getSession().getNodeByUUID(attachmentId);
-            attachmentsNode.add(attachmentNode);
+            if (!attachmentNode.getPath().startsWith("/Quarantine/")) {
+              attachmentsNode.add(attachmentNode);
+            }
           } catch (Exception e) {
             LOG.error("Cannot get News attachment " + attachmentId + " of News " + newsNode.getUUID(), e);
           }

--- a/services/src/test/java/org/exoplatform/news/NewsAttachmentsServiceImplTest.java
+++ b/services/src/test/java/org/exoplatform/news/NewsAttachmentsServiceImplTest.java
@@ -205,9 +205,15 @@ public class NewsAttachmentsServiceImplTest {
     lenient().when(node.getProperty(eq("exo:attachmentsIds"))).thenReturn(attachmentIdsProperty);
     lenient().when(session.getNodeByUUID(eq("id123"))).thenReturn(node);
     Node attachmentNode = mock(Node.class);
+    lenient().when(attachmentNode.getPath()).thenReturn("/folder/subFolder/attachNode");
+    Node attachmentNode1 = mock(Node.class);
+    lenient().when(attachmentNode1.getPath()).thenReturn("/folder/subFolder/attachNode1");
+    Node attachmentNode2 = mock(Node.class);
+    // quarantined attachment
+    lenient().when(attachmentNode2.getPath()).thenReturn("/Quarantine/attachNode2");
     lenient().when(session.getNodeByUUID(eq("idAttach1"))).thenReturn(attachmentNode);
-    lenient().when(session.getNodeByUUID(eq("idAttach2"))).thenReturn(attachmentNode);
-    lenient().when(session.getNodeByUUID(eq("idAttach3"))).thenReturn(attachmentNode);
+    lenient().when(session.getNodeByUUID(eq("idAttach2"))).thenReturn(attachmentNode1);
+    lenient().when(session.getNodeByUUID(eq("idAttach3"))).thenReturn(attachmentNode2);
 
 
     // When
@@ -215,7 +221,7 @@ public class NewsAttachmentsServiceImplTest {
 
     // Then
     assertNotNull(newsAttachments);
-    assertEquals(3, newsAttachments.size());
+    assertEquals(2, newsAttachments.size());
   }
 
   @Test
@@ -459,10 +465,13 @@ public class NewsAttachmentsServiceImplTest {
     lenient().when(session.getNodeByUUID(eq("id123"))).thenReturn(node);
     ExtendedNode attachmentNode1 = mock(ExtendedNode.class);
     lenient().when(attachmentNode1.canAddMixin(eq("exo:privilegeable"))).thenReturn(true);
+    lenient().when(attachmentNode1.getPath()).thenReturn("/folder/subFolder/attachNode1");
     ExtendedNode attachmentNode2 = mock(ExtendedNode.class);
     lenient().when(attachmentNode2.canAddMixin(eq("exo:privilegeable"))).thenReturn(false);
+    lenient().when(attachmentNode2.getPath()).thenReturn("/folder/subFolder/attachNode2");
     ExtendedNode attachmentNode3 = mock(ExtendedNode.class);
     lenient().when(attachmentNode3.canAddMixin(eq("exo:privilegeable"))).thenReturn(true);
+    lenient().when(attachmentNode3.getPath()).thenReturn("/folder/subFolder/attachNode3");
     lenient().when(session.getNodeByUUID(eq("idAttach1"))).thenReturn(attachmentNode1);
     lenient().when(session.getNodeByUUID(eq("idAttach2"))).thenReturn(attachmentNode2);
     lenient().when(session.getNodeByUUID(eq("idAttach3"))).thenReturn(attachmentNode3);
@@ -508,10 +517,13 @@ public class NewsAttachmentsServiceImplTest {
     lenient().when(session.getNodeByUUID(eq("id123"))).thenReturn(node);
     ExtendedNode attachmentNode1 = mock(ExtendedNode.class);
     lenient().when(attachmentNode1.isNodeType(eq("exo:privilegeable"))).thenReturn(true);
+    lenient().when(attachmentNode1.getPath()).thenReturn("/folder/subFolder/attachNode1");
     ExtendedNode attachmentNode2 = mock(ExtendedNode.class);
     lenient().when(attachmentNode2.isNodeType(eq("exo:privilegeable"))).thenReturn(false);
+    lenient().when(attachmentNode2.getPath()).thenReturn("/folder/subFolder/attachNode2");
     ExtendedNode attachmentNode3 = mock(ExtendedNode.class);
     lenient().when(attachmentNode3.isNodeType(eq("exo:privilegeable"))).thenReturn(true);
+    lenient().when(attachmentNode3.getPath()).thenReturn("/folder/subFolder/attachNode3");
     lenient().when(session.getNodeByUUID(eq("idAttach1"))).thenReturn(attachmentNode1);
     lenient().when(session.getNodeByUUID(eq("idAttach2"))).thenReturn(attachmentNode2);
     lenient().when(session.getNodeByUUID(eq("idAttach3"))).thenReturn(attachmentNode3);
@@ -552,6 +564,7 @@ public class NewsAttachmentsServiceImplTest {
     lenient().when(node.getProperty(eq("exo:attachmentsIds"))).thenReturn(attachmentIdsProperty);
     lenient().when(session.getNodeByUUID(eq("id123"))).thenReturn(node);
     Node attachmentNode = mock(Node.class);
+    lenient().when(attachmentNode.getPath()).thenReturn("/folder/subFolder/attachNode");
     lenient().when(session.getNodeByUUID(eq("idAttach1"))).thenReturn(attachmentNode);
     lenient().when(session.getNodeByUUID(eq("idAttach2"))).thenReturn(attachmentNode);
     lenient().when(session.getNodeByUUID(eq("idAttach3"))).thenReturn(attachmentNode);


### PR DESCRIPTION
When an attached document to an article is detected by DLPs the document should not be available from the article's details