### PR TITLE
Task-47085: Fix session timeout when creating news

### DIFF
--- a/services/src/main/java/org/exoplatform/news/listener/NewsPublicationListener.java
+++ b/services/src/main/java/org/exoplatform/news/listener/NewsPublicationListener.java
@@ -48,27 +48,29 @@ public class NewsPublicationListener extends Listener<CmsService, Node> {
   }
 
   public void onEvent(Event<CmsService, Node> event) throws Exception {
-    ExoContainer container = PortalContainer.getInstance();
-    RepositoryService repositoryService = container.getComponentInstanceOfType(RepositoryService.class);
-    SessionProvider systemProvider = sessionProviderService.getSystemSessionProvider(null);
-    Session session = null;
-    try {
-      session = systemProvider.getSession(repositoryService.getCurrentRepository().getConfiguration().getDefaultWorkspaceName(),
-                                          repositoryService.getCurrentRepository());
-      if (AuthoringPublicationConstant.POST_CHANGE_STATE_EVENT.equals(event.getEventName())) {
-        Node targetNode = event.getData();
-        if (targetNode.isNodeType("exo:news") && targetNode.getProperty(StageAndVersionPublicationConstant.CURRENT_STATE)
-                                                           .getString()
-                                                           .equals(PublicationDefaultStates.PUBLISHED)) {
-          News news = newsService.convertNodeToNews(targetNode, false);
-          if (StringUtils.isEmpty(news.getActivities())) {
+    if (AuthoringPublicationConstant.POST_CHANGE_STATE_EVENT.equals(event.getEventName())) {
+      ExoContainer container = PortalContainer.getInstance();
+      RepositoryService repositoryService = container.getComponentInstanceOfType(RepositoryService.class);
+      SessionProvider systemProvider = sessionProviderService.getSystemSessionProvider(null);
+      Session session = systemProvider.getSession(
+                                                  repositoryService.getCurrentRepository()
+                                                                   .getConfiguration()
+                                                                   .getDefaultWorkspaceName(),
+                                                  repositoryService.getCurrentRepository());
+      Node targetNode = event.getData();
+      if (targetNode.isNodeType("exo:news") && targetNode.getProperty(StageAndVersionPublicationConstant.CURRENT_STATE)
+                                                         .getString()
+                                                         .equals(PublicationDefaultStates.PUBLISHED)) {
+        News news = newsService.convertNodeToNews(targetNode, false);
+        if (StringUtils.isEmpty(news.getActivities())) {
+          try {
             newsService.createNews(news, session);
+          } finally {
+            if (session != null) {
+              session.logout();
+            }
           }
         }
-      }
-    } finally {
-      if (session != null) {
-        session.logout();
       }
     }
   }


### PR DESCRIPTION
Prior to this change, the jcr session is always closed in `NewsPublicationListener` and since this listener is launched when we create draft news, we have a session timeout. With this PR, we ensure that the listener is not launched for draft news creation.