### PR TITLE
MAINT-47231: Allow saving inserted and dropped images in news body to be saved in draft

### DIFF
--- a/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
+++ b/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
@@ -433,6 +433,13 @@ export default {
           },
           change: function (evt) {
             self.news.body = evt.editor.getData();
+            self.autoSave();
+          },
+          drop: function (evt) {
+            window.setTimeout(() => {
+              self.news.body = evt.editor.getData();
+              self.autoSave();
+            }, 1000);
           }
         }
       });


### PR DESCRIPTION
Allow inserted and dropped images in news body to be saved in draft by attaching the auto-save function to change and drop events of new ckeditor.