### PR TITLE
MAINT-47992: Fix exception when posting a news (#238)

### DIFF
--- a/webapp/src/main/webapp/schedule-news-drawer/components/ExoScheduleNewsDrawer.vue
+++ b/webapp/src/main/webapp/schedule-news-drawer/components/ExoScheduleNewsDrawer.vue
@@ -152,7 +152,9 @@ export default {
     }
   },
   created() {
-    this.initializeDate();
+    if (this.newsId) {
+      this.initializeDate();
+    }
     this.$root.$on('open-schedule-drawer', (scheduleMode) => {
       this.editScheduledNews = scheduleMode;
       if (scheduleMode === 'editScheduledNews') {


### PR DESCRIPTION
Before this fix when we post a news, the rest url portal/rest/v1/news/null?editMode= is executed with null newsId which causes an exception on server logs. With this PR, we will keep calling the rest service only when the newsId is not null.

Backported from PR #239