### PR TITLE
Task-48190 : The switch to an article button shouldn't be displayed when exceed 1300 chars in stream main page

### DIFF
--- a/webapp/src/main/webapp/news-extensions/extensions.js
+++ b/webapp/src/main/webapp/news-extensions/extensions.js
@@ -95,7 +95,7 @@ export function initExtensions() {
   if (eXo.env.portal.spaceId) {
     canUserCreateNews(eXo.env.portal.spaceId)
       .then(canCreateNews => {
-        switchToArticleActivityComposerPlugin.enabled = newsActivityComposerPlugin.enabled = eXo.env.portal.spaceId && canCreateNews;
+        switchToArticleActivityComposerPlugin.enabled = newsActivityComposerPlugin.enabled = (eXo.env.portal.spaceId && eXo.env.portal.spaceId !== '') && canCreateNews;
         extensionRegistry.registerExtension('ActivityComposer', 'activity-composer-action', newsActivityComposerPlugin);
         document.dispatchEvent(new CustomEvent('activity-composer-extension-updated'));
       });


### PR DESCRIPTION
Issue: When adding a post with exceeding 1300 chars, the switch to an article button is displayed on mainstream and space stream.
Solution: I have added a check to verify if is mainstream or space stream, and I display the switch to an article button only on space stream.