### PR TITLE
Task-48372: Fix wrong redirection from News details page to space page stream.

### DIFF
--- a/webapp/src/main/webapp/news-details/components/ExoNewsDetails.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsDetails.vue
@@ -219,7 +219,7 @@ export default {
       return this.news && (this.news.profileAvatarURL || this.news.authorAvatarUrl);
     },
     backURL() {
-      return this.news && this.news.isSpaceMember ? this.news.spaceUrl : `${eXo.env.portal.context}/${eXo.env.portal.portalName}`;
+      return this.news && this.news.spaceMember ? this.news.spaceUrl : `${eXo.env.portal.context}/${eXo.env.portal.portalName}`;
     },
     updaterFullName() {
       return (this.news && this.news.updaterFullName) || (this.updaterIdentity && this.updaterIdentity.profile && this.updaterIdentity.profile.fullname);


### PR DESCRIPTION
Issue: before this fix, when we click on the return button from the news article, the user is redirected to the Snapshot page.
Solution: the fix will ensure that the right variable is checked on the news object( spaceMember)