### PR TITLE
Maint-47865: Remove archive button from news details

### DIFF
--- a/webapp/src/main/webapp/news-details/components/ExoNewsDetails.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsDetails.vue
@@ -54,13 +54,6 @@
               <a class="activityLinkColor newsTitleLink">{{ newsTitle }}</a>
             </div>
             <div v-if="archivedNews" class="newsArchived">
-              <exo-news-archive
-                v-if="archivedNews"
-                :news-id="newsId"
-                :news-archived="archivedNews"
-                :news-title="newsTitle"
-                :pinned="news.pinned"
-                @update-archived-field="updateArchivedField" />
               <span class="newsArchiveLabel"> ( {{ $t('news.archive.label') }} ) </span>
             </div>
           </div>
@@ -254,7 +247,7 @@ export default {
     },
     archivedNews() {
       return this.news && this.news.archived;
-    },
+    },    
     illustrationURL() {
       return this.news && this.news.illustrationURL;
     },
@@ -330,10 +323,6 @@ export default {
     }
   },
   methods: {
-    updateArchivedField() {
-      // eslint-disable-next-line vue/no-mutating-props
-      this.news.archived = false;
-    },
     openPreview(attachedFile) {
       const self = this;
       window.require(['SHARED/documentPreview'], function(documentPreview) {

--- a/webapp/src/main/webapp/skin/less/news.less
+++ b/webapp/src/main/webapp/skin/less/news.less
@@ -129,7 +129,6 @@
       font-weight: 100;
       color: grey;
       font-style: italic;
-      margin-top: -10px;
       font-size: 14px;
     }
   }


### PR DESCRIPTION
Before this fix, when an article is archived, the unarchive button is displayed in news details without any unarchive action and the (Archived) information label is not well displayed in the news details box.
With this PR, the unarchive button is removed in order to allow unarchiving action only from news app and the position of (Archived) information label is fixed in the news details box.