### PR TITLE
Task-42873: Change the published news detail page when accessible by non space members

### DIFF
--- a/webapp/src/main/webapp/news-details/components/ExoNewsDetails.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsDetails.vue
@@ -289,6 +289,7 @@ export default {
           return this.$nextTick();
         })
         .finally(() => {
+          document.title = this.$t('news.window.title', {0: this.news.title});
           this.$root.$emit('application-loaded');
         });
     } else {


### PR DESCRIPTION
**Problem:**  When displaying published article for non space member, the tabs content  is `News details`.
**Solution:**  When getting the news to be displayed, we set the right document title `News: title of article`