### PR TITLE
Task-48372 : Fix wrong redirection from News details page to space page strea (#260)

### DIFF
--- a/webapp/src/main/webapp/news-details/components/ExoNewsDetails.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsDetails.vue
@@ -10,6 +10,13 @@
     <schedule-news-drawer
       @post-article="postNews"
       :news-id="newsId" />
+    <exo-news-details-action-menu
+      v-if="showEditButton"
+      :news="news"
+      :show-edit-button="showEditButton"
+      :show-delete-button="showDeleteButton"
+      @delete="deleteConfirmDialog"
+      @edit="editLink" />
     <div class="newsDetailsIcons">
       <exo-news-pin
         v-if="showPinButton"
@@ -18,13 +25,6 @@
         :news-archived="archivedNews"
         :news-title="newsTitle" />
     </div>
-    <exo-news-details-action-menu
-      v-if="showEditButton"
-      :news="news"
-      :show-edit-button="showEditButton"
-      :show-delete-button="showDeleteButton"
-      @delete="deleteConfirmDialog"
-      @edit="editLink" />
     <exo-confirm-dialog
       ref="deleteConfirmDialog"
       :message="$t('news.message.confirmDeleteNews')"
@@ -219,7 +219,7 @@ export default {
       return this.news && (this.news.profileAvatarURL || this.news.authorAvatarUrl);
     },
     backURL() {
-      return this.news && this.news.isSpaceMember ? this.news.spaceUrl : `${eXo.env.portal.context}/${eXo.env.portal.portalName}`;
+      return this.news && this.news.spaceMember ? this.news.spaceUrl : `${eXo.env.portal.context}/${eXo.env.portal.portalName}`;
     },
     updaterFullName() {
       return (this.news && this.news.updaterFullName) || (this.updaterIdentity && this.updaterIdentity.profile && this.updaterIdentity.profile.fullname);

--- a/webapp/src/main/webapp/news-details/components/ExoNewsPin.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsPin.vue
@@ -11,7 +11,7 @@
       id="newsPinButton"
       :title="pinLabel"
       :class="[newsArchived ? 'unauthorizedPin' : '']"
-      class="btn my-7 mr-10"
+      class="btn my-5"
       @click="confirmAction">
       <v-icon
         :class="broadcastArticleClass"

--- a/webapp/src/main/webapp/skin/less/news.less
+++ b/webapp/src/main/webapp/skin/less/news.less
@@ -33,7 +33,6 @@
     margin: 20px 20px 13px 0;
   }
   .newsDetailsIcons {
-    position: absolute;
     top: -9px;
     width: 100%;
     text-align: center;


### PR DESCRIPTION
Issue: before this fix, when we click on the return button from the news article, the user is redirected to the Snapshot page.
Solution: the fix will ensure that the right variable is checked on the news object( spaceMember).
