### PR TITLE
Task-47159: Add the possibility to publish an article when editing a schedule to be posted immediately or later.

### DIFF
--- a/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
@@ -1081,7 +1081,8 @@ public class NewsServiceImpl implements NewsService {
     Space currentSpace = spaceService.getSpaceById(spaceId);
     return authenticatedUser.equals(posterId) || spaceService.isSuperManager(authenticatedUser)
         || currentIdentity.isMemberOf(PLATFORM_WEB_CONTRIBUTORS_GROUP, PUBLISHER_MEMBERSHIP_NAME)
-        || currentIdentity.isMemberOf(currentSpace.getGroupId(), MANAGER_MEMBERSHIP_NAME);
+        || currentIdentity.isMemberOf(currentSpace.getGroupId(), MANAGER_MEMBERSHIP_NAME)
+        || currentIdentity.isMemberOf(PLATFORM_ADMINISTRATORS_GROUP, "*");
   }
 
   @Override

--- a/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
@@ -1219,9 +1219,7 @@ public class NewsServiceImpl implements NewsService {
         startPublishedDate.setTime(format.parse(schedulePostDate));
         scheduledNewsNode.setProperty(AuthoringPublicationConstant.START_TIME_PROPERTY, startPublishedDate);
         scheduledNewsNode.setProperty(LAST_PUBLISHER, getCurrentUserId());
-        if (news.isPinned()) {
-          scheduledNewsNode.setProperty("exo:pinned", true);
-        }
+        scheduledNewsNode.setProperty("exo:pinned", news.isPinned());
         scheduledNewsNode.save();
         publicationService.changeState(scheduledNewsNode, PublicationDefaultStates.STAGED, new HashMap<>());
       }

--- a/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
+++ b/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
@@ -13,6 +13,7 @@
       class="newsComposer">
       <schedule-news-drawer
         :posting-news="postingNews"
+        :news-id="newsId"
         @post-article="postNews" />
       <div class="newsComposerActions">
         <div class="newsFormButtons">
@@ -557,7 +558,7 @@ export default {
       }
     },
     postNews: function (schedulePostDate, postArticleMode, publish) {
-      this.news.pinned = (publish === 'true');
+      this.news.pinned = publish;
       this.doPostNews(schedulePostDate);
     },
     doPostNews: function (schedulePostDate) {

--- a/webapp/src/main/webapp/news-details/components/ExoNewsDetails.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsDetails.vue
@@ -168,7 +168,7 @@ export default {
     activityId: {
       type: String,
       required: false,
-      default: null
+      default: ''
     },
     showEditButton: {
       type: Boolean,
@@ -399,7 +399,7 @@ export default {
     },
     postNews(schedulePostDate, postArticleMode, publish) {
       this.news.timeZoneId = USER_TIMEZONE_ID;
-      this.news.pinned = (publish === 'true');
+      this.news.pinned = publish;
       if (postArticleMode === 'later') {
         this.news.schedulePostDate = schedulePostDate;
         this.$newsServices.scheduleNews(this.news).then((scheduleNews) => {

--- a/webapp/src/main/webapp/schedule-news-drawer/components/ExoScheduleNewsDrawer.vue
+++ b/webapp/src/main/webapp/schedule-news-drawer/components/ExoScheduleNewsDrawer.vue
@@ -29,7 +29,7 @@
           <div class="d-flex flex-row">
             <v-checkbox
               v-model="publish"
-              @click="changeSelection">
+              @click="changePublishStatus">
               <span slot="label" class="postModeText">{{ $t('news.composer.user.publish') }}</span>
             </v-checkbox>
           </div>
@@ -48,13 +48,13 @@
             <v-radio-group v-model="postArticleMode">
               <v-radio
                 value="immediate"
-                @click="changeDisable">
+                @click="changePostArticleMode">
                 <span slot="label" class="postModeText">{{ $t('news.composer.postImmediately') }}</span>
               </v-radio>
               <v-radio
                 value="later"
                 class="mt-4"
-                @click="changeDisable">
+                @click="changePostArticleMode">
                 <span slot="label" class="postModeText">{{ $t('news.composer.postLater') }}</span>
               </v-radio>
               <div v-if="showPostLaterMessage" class="mt-4">
@@ -78,7 +78,7 @@
                 v-if="allowNotPost"
                 value="notPost"
                 class="postModeText mt-4"
-                @click="changeDisable">
+                @click="changePostArticleMode">
                 <span slot="label" class="postModeText">{{ $t('news.composer.cancelPost') }}</span>
               </v-radio>
               <div v-if="showDontPostMessage" class="grey--text my-4 ms-4 scheduleInfoCursor">{{ $t('news.composer.chooseNotPost') }}</div>
@@ -246,20 +246,18 @@ export default {
     selectPostMode() {
       this.$emit('post-article', this.postArticleMode !=='later' ? null : this.$newsUtils.convertDate(this.postDate), this.postArticleMode, this.publish);
     },
-    changeDisable() {
+    changePostArticleMode() {
       const postDate = new Date(this.postDate);
       const scheduleDate = new Date(this.schedulePostDate);
-      this.disabled = this.postArticleMode === 'immediate' ? false : this.postArticleMode === 'later' && postDate.getTime() === scheduleDate.getTime() && this.selected === this.publish;
+      this.disabled = this.postArticleMode === 'immediate' ? false : this.postArticleMode === 'later' && postDate.getTime() === scheduleDate.getTime();
     },
     closeDrawer() {
       this.publish = this.news.pinned;
       this.disabled = false;
       this.$refs.postNewsDrawer.close();
     },
-    changeSelection() {
-      const postDate = new Date(this.postDate);
-      const scheduleDate = new Date(this.schedulePostDate);
-      this.disabled = this.postArticleMode === 'immediate' ? false : this.postArticleMode === 'later' && postDate.getTime() === scheduleDate.getTime() && this.selected === this.publish;
+    changePublishStatus() {
+      this.disabled = this.selected === this.publish;
       this.publish = !this.selected;
     }
   }

--- a/webapp/src/main/webapp/schedule-news-drawer/components/ExoScheduleNewsDrawer.vue
+++ b/webapp/src/main/webapp/schedule-news-drawer/components/ExoScheduleNewsDrawer.vue
@@ -28,8 +28,7 @@
           </div>
           <div class="d-flex flex-row">
             <v-checkbox
-              v-model="publish"
-              @click="changePublishStatus">
+              v-model="publish">
               <span slot="label" class="postModeText">{{ $t('news.composer.user.publish') }}</span>
             </v-checkbox>
           </div>
@@ -47,14 +46,12 @@
           <div class="d-flex flex-row">
             <v-radio-group v-model="postArticleMode">
               <v-radio
-                value="immediate"
-                @click="changePostArticleMode">
+                value="immediate">
                 <span slot="label" class="postModeText">{{ $t('news.composer.postImmediately') }}</span>
               </v-radio>
               <v-radio
                 value="later"
-                class="mt-4"
-                @click="changePostArticleMode">
+                class="mt-4">
                 <span slot="label" class="postModeText">{{ $t('news.composer.postLater') }}</span>
               </v-radio>
               <div v-if="showPostLaterMessage" class="mt-4">
@@ -77,8 +74,7 @@
               <v-radio
                 v-if="allowNotPost"
                 value="notPost"
-                class="postModeText mt-4"
-                @click="changePostArticleMode">
+                class="postModeText mt-4">
                 <span slot="label" class="postModeText">{{ $t('news.composer.cancelPost') }}</span>
               </v-radio>
               <div v-if="showDontPostMessage" class="grey--text my-4 ms-4 scheduleInfoCursor">{{ $t('news.composer.chooseNotPost') }}</div>
@@ -92,7 +88,7 @@
             :disabled="disabled"
             :loading="postingNews"
             class="btn btn-primary ms-2"
-            @click="selectPostMode">
+            @click="postArticle">
             {{ saveButtonLabel }}
           </v-btn>
         </div>
@@ -105,7 +101,7 @@
           <v-btn
             :disabled="disabled"
             class="btn btn-primary ms-2"
-            @click="selectPostMode">
+            @click="postArticle">
             {{ $t('news.composer.confirm') }}
           </v-btn>
         </div>
@@ -129,7 +125,6 @@ export default {
   },
   data: () => ({
     drawer: false,
-    disabled: false,
     postArticleMode: 'later',
     postDateTime: '8:00',
     editScheduledNews: false,
@@ -187,9 +182,11 @@ export default {
     selected() {
       return this.news && this.news.pinned;
     },
-  },
-  mounted() {
-    this.publish = this.selected;
+    disabled() {
+      const postDate = new Date(this.postDate);
+      const scheduleDate = new Date(this.schedulePostDate);
+      return (this.postArticleMode === 'immediate' ? false : this.postArticleMode === 'later' && postDate.getTime() === scheduleDate.getTime()) && this.selected === this.publish;
+    }
   },
   created() {
     this.$newsServices.canPublishNews().then(canPublishNews => {
@@ -243,23 +240,14 @@ export default {
           }
         });
     },
-    selectPostMode() {
+    postArticle() {
       this.$emit('post-article', this.postArticleMode !=='later' ? null : this.$newsUtils.convertDate(this.postDate), this.postArticleMode, this.publish);
-    },
-    changePostArticleMode() {
-      const postDate = new Date(this.postDate);
-      const scheduleDate = new Date(this.schedulePostDate);
-      this.disabled = this.postArticleMode === 'immediate' ? false : this.postArticleMode === 'later' && postDate.getTime() === scheduleDate.getTime();
     },
     closeDrawer() {
       this.publish = this.news.pinned;
       this.disabled = false;
       this.$refs.postNewsDrawer.close();
     },
-    changePublishStatus() {
-      this.disabled = this.selected === this.publish;
-      this.publish = !this.selected;
-    }
   }
 };
 </script>


### PR DESCRIPTION
Prior to this change, it is not possible to choose to publish an article when editing a schedule to be posted immediately or later.
After this change, we add the possibility to publish an article when editing a schedule. After checking publish news checkbox, the article will be published (unpublished) when posted immediately or scheduled for being posted later.