### PR TITLE
Task-47159: Add the possibility to publish an article when posting immediately or later

### DIFF
--- a/services/src/main/java/org/exoplatform/news/NewsService.java
+++ b/services/src/main/java/org/exoplatform/news/NewsService.java
@@ -96,7 +96,7 @@ public interface NewsService {
    */
   boolean canEditNews(News news, String authenticatedUser);
 
-  public boolean canPinNews();
+  public boolean canPublishNews();
   
   boolean canArchiveNews(String newsAuthor);
 

--- a/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
@@ -713,7 +713,7 @@ public class NewsServiceImpl implements NewsService {
     }
     news.setCanEdit(canEditNews(news.getAuthor(),news.getSpaceId()));
     news.setCanDelete(canDeleteNews(news.getAuthor(),news.getSpaceId()));
-    news.setCanPublish(canPinNews());
+    news.setCanPublish(canPublishNews());
     StringBuilder newsUrl = new StringBuilder("");
     if (originalNode.hasProperty("exo:activities")) {
       String strActivities = originalNode.getProperty("exo:activities").getString();
@@ -1176,11 +1176,11 @@ public class NewsServiceImpl implements NewsService {
   }
 
   /**
-   * Return a boolean that indicates if the current user can pin the news or not
+   * Return a boolean that indicates if the current user can publish the news or not
    * 
-   * @return if the news can be pinned
+   * @return if the news can be published
    */
-  public boolean canPinNews() {
+  public boolean canPublishNews() {
     // FIXME shouldn't use ConversationState in Service layer
     org.exoplatform.services.security.Identity currentIdentity = getCurrentIdentity();
     if (currentIdentity == null) {
@@ -1214,6 +1214,9 @@ public class NewsServiceImpl implements NewsService {
         startPublishedDate.setTime(format.parse(schedulePostDate));
         scheduledNewsNode.setProperty(AuthoringPublicationConstant.START_TIME_PROPERTY, startPublishedDate);
         scheduledNewsNode.setProperty(LAST_PUBLISHER, getCurrentUserId());
+        if (news.isPinned()) {
+          scheduledNewsNode.setProperty("exo:pinned", true);
+        }
         scheduledNewsNode.save();
         publicationService.changeState(scheduledNewsNode, PublicationDefaultStates.STAGED, new HashMap<>());
       }

--- a/services/src/main/java/org/exoplatform/news/rest/NewsRestResourcesV1.java
+++ b/services/src/main/java/org/exoplatform/news/rest/NewsRestResourcesV1.java
@@ -810,7 +810,27 @@ public class NewsRestResourcesV1 implements ResourceContainer, Startable {
       return Response.serverError().build();
     }
   }
-  
+
+  @GET
+  @Path("canPublishNews")
+  @Produces(MediaType.TEXT_PLAIN)
+  @RolesAllowed("users")
+  @ApiOperation(value = "check if the current user can publish a news to all users", httpMethod = "GET", response = Response.class, notes = "This checks if the current user can publish a news to all users", consumes = "application/json")
+  @ApiResponses(value = { @ApiResponse(code = 200, message = "User ability to publish a news is returned"),
+          @ApiResponse(code = 401, message = "User not authorized to publish a news")})
+  public Response canPublishNews(@Context HttpServletRequest request) {
+    try {
+      String authenticatedUser = request.getRemoteUser();
+      if (StringUtils.isBlank(authenticatedUser)) {
+        return Response.status(Response.Status.UNAUTHORIZED).build();
+      }
+      return Response.ok(String.valueOf(newsService.canPublishNews())).build();
+    } catch (Exception e) {
+      LOG.error("Error when checking if the authenticated user can publish a news to all users", e);
+      return Response.serverError().build();
+    }
+  }
+
   private NewsFilter buildFilter(List<String> spaces, String filter, String text, String author, int limit, int offset) {
     NewsFilter newsFilter = new NewsFilter();
 
@@ -875,4 +895,5 @@ public class NewsRestResourcesV1 implements ResourceContainer, Startable {
   private boolean canScheduleNews(String authenticatedUser, Space space) {
     return spaceService.isManager(space, authenticatedUser) || spaceService.isRedactor(space, authenticatedUser);
   }
+
 }

--- a/services/src/main/resources/locale/portlet/news/News_en.properties
+++ b/services/src/main/resources/locale/portlet/news/News_en.properties
@@ -38,6 +38,10 @@ news.composer.confirm=Confirm
 news.details.scheduled=Scheduled
 news.details.restricted=Restricted Access
 news.composer.warnMessage=Impossible to schedule posting in a past date.
+news.composer.modularity.publish=Publish Modularity
+news.composer.user.publish=Publish the article for all users
+news.composer.user.publish.info=This article will be visible for all internal users even if they are not members of the space
+news.composer.modularity.post=Post Modularity
 
 news.composer.attachments.header=Attach files
 news.composer.attachments.drop=Drop files here

--- a/services/src/test/java/org/exoplatform/news/NewsServiceImplTest.java
+++ b/services/src/test/java/org/exoplatform/news/NewsServiceImplTest.java
@@ -340,7 +340,7 @@ public class NewsServiceImplTest {
   }
 
   @Test
-  public void shouldCanViewPinnedNewsWhenNotSpaceMember() throws Exception {
+  public void shouldCanViewPublishedNewsWhenNotSpaceMember() throws Exception {
     NewsService newsService = buildNewsService();
     
     String spaceId = "space1";
@@ -355,7 +355,7 @@ public class NewsServiceImplTest {
   }
 
   @Test
-  public void shouldCanViewPinnedStagedNewsWhenNotSpaceMember() throws Exception {
+  public void shouldCanViewPublishedStagedNewsWhenNotSpaceMember() throws Exception {
     NewsService newsService = buildNewsService();
 
     String spaceId = "space1";
@@ -369,7 +369,7 @@ public class NewsServiceImplTest {
   }
 
   @Test
-  public void shouldCanViewNotPinnedAndPublishedNewsWhenSuperManager() throws Exception {
+  public void shouldCanViewNotPublishedAndPostedNewsWhenSuperManager() throws Exception {
     NewsService newsService = buildNewsService();
     String spaceId = "space1";
     String superUser = "mary";
@@ -383,7 +383,7 @@ public class NewsServiceImplTest {
   }
 
   @Test
-  public void shouldCantViewNotPinnedAndStagedNewsWhenSuperManager() throws Exception {
+  public void shouldCantViewNotPublishedAndStagedNewsWhenSuperManager() throws Exception {
     NewsService newsService = buildNewsService();
     String spaceId = "space1";
     String superUser = "mary";
@@ -398,7 +398,7 @@ public class NewsServiceImplTest {
   }
 
   @Test
-  public void shouldCantViewNotPinnedAndStagedNewsWhenIsMember() throws Exception {
+  public void shouldCantViewNotPublishedAndStagedNewsWhenIsMember() throws Exception {
     NewsService newsService = buildNewsService();
     String spaceId = "space1";
     String username = "mary";
@@ -413,7 +413,7 @@ public class NewsServiceImplTest {
   }
 
   @Test
-  public void shouldCanViewNotPinnedAndSpaceMember() throws Exception {
+  public void shouldCanViewNotPublishedAndSpaceMember() throws Exception {
     NewsService newsService = buildNewsService();
     String spaceId = "space1";
     String username = "mary";
@@ -428,7 +428,7 @@ public class NewsServiceImplTest {
   }
 
   @Test
-  public void shouldCanViewNotPinnedAndStagedNewsAndSpaceManager() throws Exception {
+  public void shouldCanViewNotPublishedAndStagedNewsAndSpaceManager() throws Exception {
     NewsService newsService = buildNewsService();
     String spaceId = "space1";
     String username = "mary";
@@ -442,7 +442,7 @@ public class NewsServiceImplTest {
   }
 
   @Test
-  public void shouldCanViewNotPinnedAndStagedNewsAndSpaceRedactor() throws Exception {
+  public void shouldCanViewNotPublishedAndStagedNewsAndSpaceRedactor() throws Exception {
     NewsService newsService = buildNewsService();
     String spaceId = "space1";
     String username = "mary";
@@ -457,7 +457,7 @@ public class NewsServiceImplTest {
   }
 
   @Test
-  public void shouldCanViewNotPinnedAndStagedNewsAndIsAuthor() throws Exception {
+  public void shouldCanViewNotPublishedAndStagedNewsAndIsAuthor() throws Exception {
     NewsService newsService = buildNewsService();
     String spaceId = "space1";
     String username = "mary";
@@ -1093,7 +1093,7 @@ public class NewsServiceImplTest {
   }
 
   @Test
-  public void shouldPinNews() throws Exception {
+  public void shouldPublishNews() throws Exception {
     // Given
 
     DataDistributionType dataDistributionType = mock(DataDistributionType.class);
@@ -1120,15 +1120,15 @@ public class NewsServiceImplTest {
 
     NewsServiceImpl newsServiceSpy = Mockito.spy(newsService);
     ExtendedNode newsNode = mock(ExtendedNode.class);
-    Node pinnedRootNode = mock(Node.class);
+    Node publishedRootNode = mock(Node.class);
     Node newsFolderNode = mock(Node.class);
     Node applicationDataNode = mock(Node.class);
     Node newsRootNode = mock(Node.class);
 
     News news = new News();
-    news.setTitle("pinned title");
-    news.setSummary("pinned summary");
-    news.setBody("pinned body");
+    news.setTitle("published title");
+    news.setSummary("published summary");
+    news.setBody("published body");
     news.setUploadId(null);
     String sDate1 = "22/08/2019";
     Date date1 = new SimpleDateFormat("dd/MM/yyyy").parse(sDate1);
@@ -1149,7 +1149,7 @@ public class NewsServiceImplTest {
     when(applicationDataNode.hasNode(eq("News"))).thenReturn(true);
     when(applicationDataNode.getNode(eq("News"))).thenReturn(newsRootNode);
     when(newsRootNode.hasNode(eq("Pinned"))).thenReturn(true);
-    when(newsRootNode.getNode(eq("Pinned"))).thenReturn(pinnedRootNode);
+    when(newsRootNode.getNode(eq("Pinned"))).thenReturn(publishedRootNode);
     Mockito.doNothing()
            .when(newsServiceSpy)
            .sendNotification(news, NotificationConstants.NOTIFICATION_CONTEXT.PUBLISH_IN_NEWS, session);
@@ -1166,7 +1166,7 @@ public class NewsServiceImplTest {
   }
 
   @Test
-  public void shouldCreateNewsDraftAndPinIt() throws Exception {
+  public void shouldCreateNewsDraftAndPublishIt() throws Exception {
     // Given
     DataDistributionType dataDistributionType = mock(DataDistributionType.class);
     when(dataDistributionManager.getDataDistributionType(DataDistributionMode.NONE)).thenReturn(dataDistributionType);
@@ -1189,9 +1189,9 @@ public class NewsServiceImplTest {
                                                       newsESSearchConnector,
                                                       userACL);
     News news = new News();
-    news.setTitle("new pinned news title");
-    news.setSummary("new pinned news summary");
-    news.setBody("new pinned news body");
+    news.setTitle("new published news title");
+    news.setSummary("new published news summary");
+    news.setBody("new published news body");
     news.setUploadId(null);
     String sDate1 = "22/08/2019";
     Date date1 = new SimpleDateFormat("dd/MM/yyyy").parse(sDate1);
@@ -1322,7 +1322,7 @@ public class NewsServiceImplTest {
   }
 
   @Test
-  public void shouldUnPinNews() throws Exception {
+  public void shouldUnPublishNews() throws Exception {
     // Given
 
     DataDistributionType dataDistributionType = mock(DataDistributionType.class);
@@ -1348,17 +1348,17 @@ public class NewsServiceImplTest {
 
     NewsService newsServiceSpy = Mockito.spy(newsService);
     ExtendedNode newsNode = mock(ExtendedNode.class);
-    Node pinnedRootNode = mock(Node.class);
+    Node publishRootNode = mock(Node.class);
     Node newsFolderNode = mock(Node.class);
     Node applicationDataNode = mock(Node.class);
     Node newsRootNode = mock(Node.class);
-    Node pinnedNode = mock(Node.class);
+    Node publishedNode = mock(Node.class);
     Property property = mock(Property.class);
 
     News news = new News();
-    news.setTitle("unpinned");
-    news.setSummary("unpinned summary");
-    news.setBody("unpinned body");
+    news.setTitle("unpublished");
+    news.setSummary("unpublished summary");
+    news.setBody("unpublished body");
     news.setUploadId(null);
     String sDate1 = "22/08/2019";
     Date date1 = new SimpleDateFormat("dd/MM/yyyy").parse(sDate1);
@@ -1381,8 +1381,8 @@ public class NewsServiceImplTest {
     when(applicationDataNode.hasNode(eq("News"))).thenReturn(true);
     when(applicationDataNode.getNode(eq("News"))).thenReturn(newsRootNode);
     when(newsRootNode.hasNode(eq("Pinned"))).thenReturn(true);
-    when(newsRootNode.getNode(eq("Pinned"))).thenReturn(pinnedRootNode);
-    when(newsFolderNode.getNode("unpinned")).thenReturn(pinnedNode);
+    when(newsRootNode.getNode(eq("Pinned"))).thenReturn(publishRootNode);
+    when(newsFolderNode.getNode("unpinned")).thenReturn(publishedNode);
     when(newsNode.getName()).thenReturn("unpinned");
     // When
     newsServiceSpy.unpinNews("id123");
@@ -1390,13 +1390,13 @@ public class NewsServiceImplTest {
     // Then
     verify(newsNode, times(1)).save();
     verify(newsNode, times(1)).setProperty(eq("exo:pinned"), eq(false));
-    verify(pinnedNode, times(1)).remove();
+    verify(publishedNode, times(1)).remove();
     verify(newsFolderNode, times(1)).save();
 
   }
 
   @Test
-  public void shouldNotUnPinNewsAsNewsNodeIsNull() throws Exception {
+  public void shouldNotUnPublishNewsAsNewsNodeIsNull() throws Exception {
     DataDistributionType dataDistributionType = mock(DataDistributionType.class);
     when(dataDistributionManager.getDataDistributionType(DataDistributionMode.NONE)).thenReturn(dataDistributionType);
 
@@ -1421,9 +1421,9 @@ public class NewsServiceImplTest {
 
     NewsService newsServiceSpy = Mockito.spy(newsService);
     News news = new News();
-    news.setTitle("unpinned");
-    news.setSummary("unpinned summary");
-    news.setBody("unpinned body");
+    news.setTitle("unpublished");
+    news.setSummary("unpublished summary");
+    news.setBody("unpublished body");
     news.setUploadId(null);
     String sDate1 = "22/08/2019";
     Date date1 = new SimpleDateFormat("dd/MM/yyyy").parse(sDate1);
@@ -1445,7 +1445,7 @@ public class NewsServiceImplTest {
   }
 
   @Test
-  public void shouldNotUnPinNewsAsNewsIsNull() throws Exception {
+  public void shouldNotUnPublishNewsAsNewsIsNull() throws Exception {
     DataDistributionType dataDistributionType = mock(DataDistributionType.class);
     when(dataDistributionManager.getDataDistributionType(DataDistributionMode.NONE)).thenReturn(dataDistributionType);
 
@@ -1483,7 +1483,7 @@ public class NewsServiceImplTest {
   }
 
   @Test
-  public void shouldNotUnPinNewsAsPinnedRootNodeIsNull() throws Exception {
+  public void shouldNotUnPublishNewsAsPublishedRootNodeIsNull() throws Exception {
     DataDistributionType dataDistributionType = mock(DataDistributionType.class);
     when(dataDistributionManager.getDataDistributionType(DataDistributionMode.NONE)).thenReturn(dataDistributionType);
 
@@ -1513,9 +1513,9 @@ public class NewsServiceImplTest {
     Node newsRootNode = mock(Node.class);
 
     News news = new News();
-    news.setTitle("unpinned");
-    news.setSummary("unpinned summary");
-    news.setBody("unpinned body");
+    news.setTitle("unpublished");
+    news.setSummary("unpublished summary");
+    news.setBody("unpublished body");
     news.setUploadId(null);
     String sDate1 = "22/08/2019";
     Date date1 = new SimpleDateFormat("dd/MM/yyyy").parse(sDate1);
@@ -1545,7 +1545,7 @@ public class NewsServiceImplTest {
   }
 
   @Test
-  public void shouldNotUnPinNewsAsNewsFolderNodeIsNull() throws Exception {
+  public void shouldNotUnPublishNewsAsNewsFolderNodeIsNull() throws Exception {
     DataDistributionType dataDistributionType = mock(DataDistributionType.class);
     when(dataDistributionManager.getDataDistributionType(DataDistributionMode.NONE)).thenReturn(dataDistributionType);
 
@@ -1572,12 +1572,12 @@ public class NewsServiceImplTest {
     ExtendedNode newsNode = mock(ExtendedNode.class);
     Node applicationDataNode = mock(Node.class);
     Node newsRootNode = mock(Node.class);
-    Node pinnedRootNode = mock(Node.class);
+    Node publishedRootNode = mock(Node.class);
 
     News news = new News();
-    news.setTitle("unpinned");
-    news.setSummary("unpinned summary");
-    news.setBody("unpinned body");
+    news.setTitle("unpublished");
+    news.setSummary("unpublished summary");
+    news.setBody("unpublished body");
     news.setUploadId(null);
     String sDate1 = "22/08/2019";
     Date date1 = new SimpleDateFormat("dd/MM/yyyy").parse(sDate1);
@@ -1598,7 +1598,7 @@ public class NewsServiceImplTest {
     when(applicationDataNode.hasNode(eq("News"))).thenReturn(true);
     when(applicationDataNode.getNode(eq("News"))).thenReturn(newsRootNode);
     when(newsRootNode.hasNode(eq("Pinned"))).thenReturn(true);
-    when(newsRootNode.getNode(eq("Pinned"))).thenReturn(pinnedRootNode);
+    when(newsRootNode.getNode(eq("Pinned"))).thenReturn(publishedRootNode);
     exceptionRule.expect(Exception.class);
     exceptionRule.expectMessage("Unable to find the parent node of the current pinned node");
 
@@ -1607,7 +1607,7 @@ public class NewsServiceImplTest {
   }
 
   @Test
-  public void shouldNotUnPinNewsAsPinnedNodeIsNull() throws Exception {
+  public void shouldNotUnPublishedNewsAsPublishedNodeIsNull() throws Exception {
     DataDistributionType dataDistributionType = mock(DataDistributionType.class);
     when(dataDistributionManager.getDataDistributionType(DataDistributionMode.NONE)).thenReturn(dataDistributionType);
 
@@ -1634,13 +1634,13 @@ public class NewsServiceImplTest {
     ExtendedNode newsNode = mock(ExtendedNode.class);
     Node applicationDataNode = mock(Node.class);
     Node newsRootNode = mock(Node.class);
-    Node pinnedRootNode = mock(Node.class);
+    Node publishedRootNode = mock(Node.class);
     Node newsFolderNode = mock(Node.class);
 
     News news = new News();
-    news.setTitle("unpinned");
-    news.setSummary("unpinned summary");
-    news.setBody("unpinned body");
+    news.setTitle("unpublished");
+    news.setSummary("unpublished summary");
+    news.setBody("unpublished body");
     news.setUploadId(null);
     String sDate1 = "22/08/2019";
     Date date1 = new SimpleDateFormat("dd/MM/yyyy").parse(sDate1);
@@ -1661,7 +1661,7 @@ public class NewsServiceImplTest {
     when(applicationDataNode.hasNode(eq("News"))).thenReturn(true);
     when(applicationDataNode.getNode(eq("News"))).thenReturn(newsRootNode);
     when(newsRootNode.hasNode(eq("Pinned"))).thenReturn(true);
-    when(newsRootNode.getNode(eq("Pinned"))).thenReturn(pinnedRootNode);
+    when(newsRootNode.getNode(eq("Pinned"))).thenReturn(publishedRootNode);
     when(newsFolderNode.getNode("unpinned")).thenReturn(null);
     exceptionRule.expect(Exception.class);
     exceptionRule.expectMessage("Unable to find the current pinned node");
@@ -2569,7 +2569,7 @@ public class NewsServiceImplTest {
   }
 
   @Test
-  public void shouldNotAuthorizeTheCurrentUserToPinNews() {
+  public void shouldNotAuthorizeTheCurrentUserToPublishNews() {
     // Given
     DataDistributionType dataDistributionType = mock(DataDistributionType.class);
     when(dataDistributionManager.getDataDistributionType(DataDistributionMode.NONE)).thenReturn(dataDistributionType);
@@ -2601,15 +2601,15 @@ public class NewsServiceImplTest {
     ConversationState.setCurrent(state);
 
     // When
-    boolean canPinNews = newsService.canPinNews();
+    boolean canPublishNews = newsService.canPublishNews();
 
     // Then
-    assertEquals(false, canPinNews);
+    assertEquals(false, canPublishNews);
 
   }
 
   @Test
-  public void shouldAuthorizeTheCurrentUserToPinNews() {
+  public void shouldAuthorizeTheCurrentUserToPublishNews() {
     // Given
     DataDistributionType dataDistributionType = mock(DataDistributionType.class);
     when(dataDistributionManager.getDataDistributionType(DataDistributionMode.NONE)).thenReturn(dataDistributionType);
@@ -2635,10 +2635,10 @@ public class NewsServiceImplTest {
     setCurrentIdentity();
 
     // When
-    boolean canPinNews = newsService.canPinNews();
+    boolean canPublishNews = newsService.canPublishNews();
 
     // Then
-    assertEquals(true, canPinNews);
+    assertEquals(true, canPublishNews);
 
   }
 
@@ -2902,7 +2902,7 @@ public class NewsServiceImplTest {
                                                       userACL);
 
     News news = new News();
-    news.setTitle("unpinned");
+    news.setTitle("unpublished");
     news.setAuthor("root");
     news.setSpaceId("1");
     news.setActivities("1:38");
@@ -2942,7 +2942,7 @@ public class NewsServiceImplTest {
                                                       userACL);
 
     News news = new News();
-    news.setTitle("unpinned");
+    news.setTitle("unpublished");
     news.setAuthor("root");
     news.setId("id123");
     news.setSpaceId("1");
@@ -3091,7 +3091,7 @@ public class NewsServiceImplTest {
   }
 
   @Test
-  public void shouldGetAllPinnedNewsNodesWhenExists() throws Exception {
+  public void shouldGetAllPubishedNewsNodesWhenExists() throws Exception {
     // Given
     NewsServiceImpl newsService = new NewsServiceImpl(repositoryService,
                                                       sessionProviderService,

--- a/webapp/src/main/webapp/WEB-INF/conf/news/nodetypes-templates/news/views/view1.gtmpl
+++ b/webapp/src/main/webapp/WEB-INF/conf/news/nodetypes-templates/news/views/view1.gtmpl
@@ -118,7 +118,7 @@
     def newsAttachments = news.attachments;
 
     def showEditButton = newsService.canEditNews(news.author, news.spaceId);
-    def showPinInput = newsService.canPinNews();
+    def showPinInput = newsService.canPublishNews();
     def hiddenSpace = news.hiddenSpace;
 
     def params = """ {

--- a/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
+++ b/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
@@ -556,16 +556,9 @@ export default {
         this.postNews();
       }
     },
-    postNews: function (schedulePostDate) {
-      if (this.news.pinned === true) {
-        const confirmText = this.$t('news.broadcast.confirm');
-        const captionText = this.$t('news.broadcast.action');
-        const confirmButton = this.$t('news.broadcast.btn.confirm');
-        const cancelButton = this.$t('news.edit.cancel');
-        eXo.social.PopupConfirmation.confirm('createdPinnedNews', [{action: this.doPostNews(schedulePostDate), label: confirmButton}], captionText, confirmText, cancelButton);
-      } else {
-        this.doPostNews(schedulePostDate);
-      }
+    postNews: function (schedulePostDate, postArticleMode, publish) {
+      this.news.pinned = (publish === 'true');
+      this.doPostNews(schedulePostDate);
     },
     doPostNews: function (schedulePostDate) {
       this.postingNews = true;

--- a/webapp/src/main/webapp/news-activity-composer-app/index.jsp
+++ b/webapp/src/main/webapp/news-activity-composer-app/index.jsp
@@ -3,7 +3,7 @@
 
 <%
   NewsService newsService = CommonsUtils.getService(NewsService.class);
-  boolean showPinInput = newsService.canPinNews();
+  boolean showPinInput = newsService.canPublishNews();
 %>
 <div class="VuetifyApp">
   <div id="NewsComposerApp">

--- a/webapp/src/main/webapp/news-details-app/components/ExoNewsDetailsApp.vue
+++ b/webapp/src/main/webapp/news-details-app/components/ExoNewsDetailsApp.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="newsDetail">
+  <div id="newsDetails">
     <div v-if="notFound" class="articleNotFound">
       <i class="iconNotFound"></i>
       <h3>{{ $t('news.details.restricted') }}</h3>

--- a/webapp/src/main/webapp/news-details/components/ExoNewsDetails.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsDetails.vue
@@ -396,8 +396,9 @@ export default {
       }
       return docElement.innerHTML;
     },
-    postNews(schedulePostDate, postArticleMode) {
+    postNews(schedulePostDate, postArticleMode, publish) {
       this.news.timeZoneId = USER_TIMEZONE_ID;
+      this.news.pinned = (publish === 'true');
       if (postArticleMode === 'later') {
         this.news.schedulePostDate = schedulePostDate;
         this.$newsServices.scheduleNews(this.news).then((scheduleNews) => {

--- a/webapp/src/main/webapp/schedule-news-drawer/components/ExoScheduleNewsDrawer.vue
+++ b/webapp/src/main/webapp/schedule-news-drawer/components/ExoScheduleNewsDrawer.vue
@@ -19,44 +19,72 @@
         {{ $t('news.composer.editArticle') }}
       </template>
       <template slot="content">
-        <v-radio-group v-model="postArticleMode" class="ml-2">
-          <v-radio
-            value="immediate"
-            @click="changeDisable">
-            <span slot="label" class="postModeText">{{ $t('news.composer.postImmediately') }}</span>
-          </v-radio>
-          <v-radio
-            value="later"
-            class="mt-4"
-            @click="changeDisable">
-            <span slot="label" class="postModeText">{{ $t('news.composer.postLater') }}</span>
-          </v-radio>
-          <div v-if="showPostLaterMessage" class="mt-4 ml-4">
-            <div class="grey--text my-4 scheduleInfoCursor">{{ $t('news.composer.choosePostDate') }}</div>
-            <div class="d-flex flex-row flex-grow-1">
-              <slot name="postDate"></slot>
-              <date-picker
-                v-model="postDate"
-                :min-value="minimumPostDate"
-                class="scheduleDatePicker flex-grow-1 my-auto" />
-              <div class="d-flex flex-row flex-grow-0">
-                <slot name="postDateDateTime"></slot>
-                <time-picker
-                  v-model="postDateTime"
-                  :min="minimumPostDateTime"
-                  class="me-4" />
-              </div>
-            </div>
+        <div v-if="canPublishNews" class="d-flex flex-column mt-4 ms-3">
+          <div class="d-flex flex-row">
+            <span class="text-subtitle-1 grey--text postModeText">{{ $t('news.composer.modularity.publish') }}</span>
+            <v-divider
+              inset
+              class="my-auto me-4 ms-3" />
           </div>
-          <v-radio
-            v-if="allowNotPost"
-            value="notPost"
-            class="postModeText mt-4"
-            @click="changeDisable">
-            <span slot="label" class="postModeText">{{ $t('news.composer.cancelPost') }}</span>
-          </v-radio>
-          <div v-if="showDontPostMessage" class="grey--text my-4 ml-4 scheduleInfoCursor">{{ $t('news.composer.chooseNotPost') }}</div>
-        </v-radio-group>
+          <div class="d-flex flex-row">
+            <v-checkbox
+              v-model="publish"
+              value="true">
+              <span slot="label" class="postModeText">{{ $t('news.composer.user.publish') }}</span>
+            </v-checkbox>
+          </div>
+          <div class="d-flex flex-row grey--text ms-8">
+            {{ $t('news.composer.user.publish.info') }}
+          </div>
+        </div>
+        <div class="d-flex flex-column mt-4 ms-3">
+          <div class="d-flex flex-row">
+            <span class="text-subtitle-1 grey--text postModeText">{{ $t('news.composer.modularity.post') }}</span>
+            <v-divider
+              inset
+              class="my-auto me-4 ms-3" />
+          </div>
+          <div class="d-flex flex-row">
+            <v-radio-group v-model="postArticleMode">
+              <v-radio
+                value="immediate"
+                @click="changeDisable">
+                <span slot="label" class="postModeText">{{ $t('news.composer.postImmediately') }}</span>
+              </v-radio>
+              <v-radio
+                value="later"
+                class="mt-4"
+                @click="changeDisable">
+                <span slot="label" class="postModeText">{{ $t('news.composer.postLater') }}</span>
+              </v-radio>
+              <div v-if="showPostLaterMessage" class="mt-4">
+                <div class="grey--text my-4 scheduleInfoCursor">{{ $t('news.composer.choosePostDate') }}</div>
+                <div class="d-flex flex-row flex-grow-1">
+                  <slot name="postDate"></slot>
+                  <date-picker
+                    v-model="postDate"
+                    :min-value="minimumPostDate"
+                    class="scheduleDatePicker flex-grow-1 my-auto" />
+                  <div class="d-flex flex-row flex-grow-0">
+                    <slot name="postDateDateTime"></slot>
+                    <time-picker
+                      v-model="postDateTime"
+                      :min="minimumPostDateTime"
+                      class="me-2" />
+                  </div>
+                </div>
+              </div>
+              <v-radio
+                v-if="allowNotPost"
+                value="notPost"
+                class="postModeText mt-4"
+                @click="changeDisable">
+                <span slot="label" class="postModeText">{{ $t('news.composer.cancelPost') }}</span>
+              </v-radio>
+              <div v-if="showDontPostMessage" class="grey--text my-4 ms-4 scheduleInfoCursor">{{ $t('news.composer.chooseNotPost') }}</div>
+            </v-radio-group>
+          </div>
+        </div>
       </template>
       <template slot="footer">
         <div v-if="editScheduledNews !== 'editScheduledNews'" class="d-flex justify-end">
@@ -108,6 +136,8 @@ export default {
     allowNotPost: false,
     schedulePostDate: null,
     postDate: null,
+    canPublishNews: false,
+    publish: false,
   }),
   watch: {
     postDate(newVal, oldVal) {
@@ -152,6 +182,9 @@ export default {
     }
   },
   created() {
+    this.$newsServices.canPublishNews().then(canPublishNews => {
+      this.canPublishNews = canPublishNews;
+    });
     if (this.newsId) {
       this.initializeDate();
     }
@@ -200,7 +233,7 @@ export default {
         });
     },
     selectPostMode() {
-      this.$emit('post-article', this.postArticleMode !=='later' ? null : this.$newsUtils.convertDate(this.postDate), this.postArticleMode);
+      this.$emit('post-article', this.postArticleMode !=='later' ? null : this.$newsUtils.convertDate(this.postDate), this.postArticleMode, this.publish);
     },
     changeDisable() {
       const postDate = new Date(this.postDate);

--- a/webapp/src/main/webapp/services/newsServices.js
+++ b/webapp/src/main/webapp/services/newsServices.js
@@ -254,3 +254,14 @@ export function undoDeleteNews(newsId) {
     }
   });
 }
+
+export function canPublishNews() {
+  return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/news/canPublishNews`, {
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    method: 'GET'
+  }).then((resp) => resp.json()).then(resp => {
+    return resp;
+  });
+}


### PR DESCRIPTION

Prior to this change, it is not possible to choose to publish an article when posting immediately or later.
After this change, we add the possibility to publish an article with creation. After checking publish news checkbox, the article will be published when posted immediately or scheduled for being posted later.