### PR TITLE
Task-47159: Add the possibility to publish an article when editing a schedule to be posted immediately or later.

### DIFF
--- a/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
@@ -1076,7 +1076,8 @@ public class NewsServiceImpl implements NewsService {
     Space currentSpace = spaceService.getSpaceById(spaceId);
     return authenticatedUser.equals(posterId) || spaceService.isSuperManager(authenticatedUser)
         || currentIdentity.isMemberOf(PLATFORM_WEB_CONTRIBUTORS_GROUP, PUBLISHER_MEMBERSHIP_NAME)
-        || currentIdentity.isMemberOf(currentSpace.getGroupId(), MANAGER_MEMBERSHIP_NAME);
+        || currentIdentity.isMemberOf(currentSpace.getGroupId(), MANAGER_MEMBERSHIP_NAME)
+        || currentIdentity.isMemberOf(PLATFORM_ADMINISTRATORS_GROUP, "*");
   }
 
   @Override
@@ -1214,9 +1215,7 @@ public class NewsServiceImpl implements NewsService {
         startPublishedDate.setTime(format.parse(schedulePostDate));
         scheduledNewsNode.setProperty(AuthoringPublicationConstant.START_TIME_PROPERTY, startPublishedDate);
         scheduledNewsNode.setProperty(LAST_PUBLISHER, getCurrentUserId());
-        if (news.isPinned()) {
-          scheduledNewsNode.setProperty("exo:pinned", true);
-        }
+        scheduledNewsNode.setProperty("exo:pinned", news.isPinned());
         scheduledNewsNode.save();
         publicationService.changeState(scheduledNewsNode, PublicationDefaultStates.STAGED, new HashMap<>());
       }

--- a/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
+++ b/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
@@ -13,6 +13,7 @@
       class="newsComposer">
       <schedule-news-drawer
         :posting-news="postingNews"
+        :news-id="newsId"
         @post-article="postNews" />
       <div class="newsComposerActions">
         <div class="newsFormButtons">
@@ -557,7 +558,7 @@ export default {
       }
     },
     postNews: function (schedulePostDate, postArticleMode, publish) {
-      this.news.pinned = (publish === 'true');
+      this.news.pinned = publish;
       this.doPostNews(schedulePostDate);
     },
     doPostNews: function (schedulePostDate) {

--- a/webapp/src/main/webapp/news-details/components/ExoNewsDetails.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsDetails.vue
@@ -168,7 +168,7 @@ export default {
     activityId: {
       type: String,
       required: false,
-      default: null
+      default: ''
     },
     showEditButton: {
       type: Boolean,
@@ -398,7 +398,7 @@ export default {
     },
     postNews(schedulePostDate, postArticleMode, publish) {
       this.news.timeZoneId = USER_TIMEZONE_ID;
-      this.news.pinned = (publish === 'true');
+      this.news.pinned = publish;
       if (postArticleMode === 'later') {
         this.news.schedulePostDate = schedulePostDate;
         this.$newsServices.scheduleNews(this.news).then((scheduleNews) => {


### PR DESCRIPTION
Prior to this change, it is not possible to choose to publish an article when editing a schedule to be posted immediately or later.
After this change, we add the possibility to publish an article when editing a schedule. After checking publish news checkbox, the article will be published (unpublished) when posted immediately or scheduled for being posted later.