### PR TITLE
Task-49049: Fix the content of popover when hovering from news details

### DIFF
--- a/webapp/src/main/webapp/news-details/components/ExoNewsDetails.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsDetails.vue
@@ -213,7 +213,7 @@ export default {
       return this.news && (this.news.authorFullName || this.news.authorDisplayName);
     },
     authorProfileURL() {
-      return this.news && `${eXo.env.portal.context}/${eXo.env.portal.portalName}/profile/${this.news.updater}`;
+      return this.news && `${eXo.env.portal.context}/${eXo.env.portal.portalName}/profile/${this.news.author}`;
     },
     authorAvatarURL() {
       return this.news && (this.news.profileAvatarURL || this.news.authorAvatarUrl);


### PR DESCRIPTION
Prior to this change,  in news details, when hovering the author, it displays a popover with information about the last modifier. The solution is to get the url of news author instead of news updater.