### PR TITLE
Task-48992: Allow publishers on content management to the publish and schedule news

### DIFF
--- a/services/src/main/java/org/exoplatform/news/rest/NewsRestResourcesV1.java
+++ b/services/src/main/java/org/exoplatform/news/rest/NewsRestResourcesV1.java
@@ -896,8 +896,7 @@ public class NewsRestResourcesV1 implements ResourceContainer, Startable {
 
   private boolean canScheduleNews(String authenticatedUser, Space space) {
     org.exoplatform.services.security.Identity currentIdentity = ConversationState.getCurrent().getIdentity();
-    return spaceService.isManager(space, authenticatedUser) || spaceService.isRedactor(space, authenticatedUser) || currentIdentity.isMemberOf(PLATFORM_WEB_CONTRIBUTORS_GROUP, PUBLISHER_MEMBERSHIP_NAME) ||
-           currentIdentity.isMemberOf(PLATFORM_WEB_CONTRIBUTORS_GROUP, "*");
+    return spaceService.isManager(space, authenticatedUser) || spaceService.isRedactor(space, authenticatedUser) || currentIdentity.isMemberOf(PLATFORM_WEB_CONTRIBUTORS_GROUP, PUBLISHER_MEMBERSHIP_NAME);
   }
 
 }

--- a/services/src/main/java/org/exoplatform/news/rest/NewsRestResourcesV1.java
+++ b/services/src/main/java/org/exoplatform/news/rest/NewsRestResourcesV1.java
@@ -885,9 +885,11 @@ public class NewsRestResourcesV1 implements ResourceContainer, Startable {
   }
   
   private boolean canCreateNews(String authenticatedUser, Space space) throws Exception {
+    org.exoplatform.services.security.Identity currentIdentity = ConversationState.getCurrent().getIdentity();
     return space != null && 
           (spaceService.isSuperManager(authenticatedUser) || spaceService.isManager(space, authenticatedUser) || spaceService.isRedactor(space, authenticatedUser) ||
-          spaceService.isMember(space, authenticatedUser) && ArrayUtils.isEmpty(space.getRedactors()));
+          spaceService.isMember(space, authenticatedUser) && ArrayUtils.isEmpty(space.getRedactors())) || currentIdentity.isMemberOf(PLATFORM_WEB_CONTRIBUTORS_GROUP, PUBLISHER_MEMBERSHIP_NAME) ||
+          currentIdentity.isMemberOf(PLATFORM_WEB_CONTRIBUTORS_GROUP, "*");
   }
   
   private boolean canViewNews(String authenticatedUser, Space space) throws Exception {
@@ -895,7 +897,9 @@ public class NewsRestResourcesV1 implements ResourceContainer, Startable {
   }
 
   private boolean canScheduleNews(String authenticatedUser, Space space) {
-    return spaceService.isManager(space, authenticatedUser) || spaceService.isRedactor(space, authenticatedUser);
+    org.exoplatform.services.security.Identity currentIdentity = ConversationState.getCurrent().getIdentity();
+    return spaceService.isManager(space, authenticatedUser) || spaceService.isRedactor(space, authenticatedUser) || currentIdentity.isMemberOf(PLATFORM_WEB_CONTRIBUTORS_GROUP, PUBLISHER_MEMBERSHIP_NAME) ||
+           currentIdentity.isMemberOf(PLATFORM_WEB_CONTRIBUTORS_GROUP, "*");
   }
 
 }

--- a/services/src/main/java/org/exoplatform/news/rest/NewsRestResourcesV1.java
+++ b/services/src/main/java/org/exoplatform/news/rest/NewsRestResourcesV1.java
@@ -885,11 +885,9 @@ public class NewsRestResourcesV1 implements ResourceContainer, Startable {
   }
   
   private boolean canCreateNews(String authenticatedUser, Space space) throws Exception {
-    org.exoplatform.services.security.Identity currentIdentity = ConversationState.getCurrent().getIdentity();
     return space != null && 
           (spaceService.isSuperManager(authenticatedUser) || spaceService.isManager(space, authenticatedUser) || spaceService.isRedactor(space, authenticatedUser) ||
-          spaceService.isMember(space, authenticatedUser) && ArrayUtils.isEmpty(space.getRedactors())) || currentIdentity.isMemberOf(PLATFORM_WEB_CONTRIBUTORS_GROUP, PUBLISHER_MEMBERSHIP_NAME) ||
-          currentIdentity.isMemberOf(PLATFORM_WEB_CONTRIBUTORS_GROUP, "*");
+          spaceService.isMember(space, authenticatedUser) && ArrayUtils.isEmpty(space.getRedactors()));
   }
   
   private boolean canViewNews(String authenticatedUser, Space space) throws Exception {

--- a/services/src/test/java/org/exoplatform/news/rest/NewsRestResourcesV1Test.java
+++ b/services/src/test/java/org/exoplatform/news/rest/NewsRestResourcesV1Test.java
@@ -1024,7 +1024,7 @@ public class NewsRestResourcesV1Test {
   }
 
   @Test
-  public void shouldGetNotAuthorizedWhenCreatingNewsDraftAndNewsExistsAndUserIsNotMemberOfTheSpaceNorSuperManager() throws Exception {
+  public void shouldGetOkWhenCreatingNewsDraftAndNewsExistsAndUserIsNotMemberOfTheSpaceNorSuperManager() throws Exception {
     // Given
     NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
                                                                       newsAttachmentsService,
@@ -1046,7 +1046,7 @@ public class NewsRestResourcesV1Test {
     Response response = newsRestResourcesV1.createNews(request, news);
 
     // Then
-    assertEquals(Response.Status.UNAUTHORIZED.getStatusCode(), response.getStatus());
+    assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
   }
 
   @Test

--- a/services/src/test/java/org/exoplatform/news/rest/NewsRestResourcesV1Test.java
+++ b/services/src/test/java/org/exoplatform/news/rest/NewsRestResourcesV1Test.java
@@ -1024,7 +1024,7 @@ public class NewsRestResourcesV1Test {
   }
 
   @Test
-  public void shouldGetOkWhenCreatingNewsDraftAndNewsExistsAndUserIsNotMemberOfTheSpaceNorSuperManager() throws Exception {
+  public void shouldGetNotAuthorizedWhenCreatingNewsDraftAndNewsExistsAndUserIsNotMemberOfTheSpaceNorSuperManager() throws Exception {
     // Given
     NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
                                                                       newsAttachmentsService,
@@ -1046,7 +1046,7 @@ public class NewsRestResourcesV1Test {
     Response response = newsRestResourcesV1.createNews(request, news);
 
     // Then
-    assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+    assertEquals(Response.Status.UNAUTHORIZED.getStatusCode(), response.getStatus());
   }
 
   @Test


### PR DESCRIPTION
Prior to this change, publishers on the content management group are not able to publish or schedule news since the scheduling/edit scheduling drawers are not displayed.
After this change, publishers on the content management group will have the scheduling/edit scheduling drawers in order to publish and schedule news