### PR TITLE
Task-49096: Remove the edit button from News details for platform admins not owner of the article and not space managers

### DIFF
--- a/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
@@ -1081,8 +1081,7 @@ public class NewsServiceImpl implements NewsService {
     Space currentSpace = spaceService.getSpaceById(spaceId);
     return authenticatedUser.equals(posterId) || spaceService.isSuperManager(authenticatedUser)
         || currentIdentity.isMemberOf(PLATFORM_WEB_CONTRIBUTORS_GROUP, PUBLISHER_MEMBERSHIP_NAME)
-        || currentIdentity.isMemberOf(currentSpace.getGroupId(), MANAGER_MEMBERSHIP_NAME)
-        || currentIdentity.isMemberOf(PLATFORM_ADMINISTRATORS_GROUP, "*");
+        || spaceService.isManager(currentSpace, currentIdentity.getUserId());
   }
 
   @Override

--- a/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
@@ -91,8 +91,6 @@ public class NewsServiceImpl implements NewsService {
 
   public static final String       APPLICATION_DATA_PATH           = "/Application Data";
 
-  private static final String      MANAGER_MEMBERSHIP_NAME         = "manager";
-
   private static final String      PUBLISHER_MEMBERSHIP_NAME       = "publisher";
 
   private final static String      PLATFORM_WEB_CONTRIBUTORS_GROUP = "/platform/web-contributors";

--- a/services/src/test/java/org/exoplatform/news/NewsServiceImplTest.java
+++ b/services/src/test/java/org/exoplatform/news/NewsServiceImplTest.java
@@ -2481,7 +2481,7 @@ public class NewsServiceImplTest {
   }
 
   @Test
-  public void shouldAuthorizeTheCurrentUserToEditNewsWhenCurrentUserIsManager() {
+  public void shouldNotAuthorizeTheCurrentUserToEditNewsWhenCurrentUserIsManager() {
     // Given
     DataDistributionType dataDistributionType = mock(DataDistributionType.class);
     when(dataDistributionManager.getDataDistributionType(DataDistributionMode.NONE)).thenReturn(dataDistributionType);
@@ -2522,7 +2522,7 @@ public class NewsServiceImplTest {
     boolean canEditNews = newsService.canEditNews("david", "space1");
 
     // Then
-    assertEquals(true, canEditNews);
+    assertEquals(false, canEditNews);
 
   }
 
@@ -2569,6 +2569,52 @@ public class NewsServiceImplTest {
 
     // Then
     assertEquals(false, canEditNews);
+
+  }
+
+  @Test
+  public void shouldAuthorizeSpaceMangerToEditNewsWhenCurrentUserIsManager() {
+    // Given
+    DataDistributionType dataDistributionType = mock(DataDistributionType.class);
+    when(dataDistributionManager.getDataDistributionType(DataDistributionMode.NONE)).thenReturn(dataDistributionType);
+    NewsServiceImpl newsService = new NewsServiceImpl(repositoryService,
+            sessionProviderService,
+            nodeHierarchyCreator,
+            dataDistributionManager,
+            spaceService,
+            activityManager,
+            identityManager,
+            uploadService,
+            imageProcessor,
+            linkManager,
+            publicationServiceImpl,
+            publicationManagerImpl,
+            wcmPublicationServiceImpl,
+            newsSearchConnector,
+            newsAttachmentsService,
+            indexingService,
+            newsESSearchConnector,
+            userACL);
+
+    Space currentSpace = mock(Space.class);
+    org.exoplatform.services.security.Identity currentIdentity = new org.exoplatform.services.security.Identity("user");
+    MembershipEntry membershipentry = new MembershipEntry("/platform/web-contributors", "member");
+    MembershipEntry membershipentry1 = new MembershipEntry("space1", "manager");
+    List<MembershipEntry> memberships = new ArrayList<MembershipEntry>();
+    memberships.add(membershipentry);
+    memberships.add(membershipentry1);
+    currentIdentity.setMemberships(memberships);
+    ConversationState state = new ConversationState(currentIdentity);
+    ConversationState.setCurrent(state);
+    when(spaceService.getSpaceById("space1")).thenReturn(currentSpace);
+    when(spaceService.isManager(currentSpace, "user")).thenReturn(true);
+    when(currentSpace.getGroupId()).thenReturn("space1");
+
+    // When
+    boolean canEditNews = newsService.canEditNews("david", "space1");
+
+    // Then
+    assertEquals(true, canEditNews);
 
   }
 

--- a/services/src/test/java/org/exoplatform/news/NewsServiceImplTest.java
+++ b/services/src/test/java/org/exoplatform/news/NewsServiceImplTest.java
@@ -2527,53 +2527,7 @@ public class NewsServiceImplTest {
   }
 
   @Test
-  public void shouldNotAuthorizeTheCurrentUserToEditNews() {
-    // Given
-    DataDistributionType dataDistributionType = mock(DataDistributionType.class);
-    when(dataDistributionManager.getDataDistributionType(DataDistributionMode.NONE)).thenReturn(dataDistributionType);
-    NewsServiceImpl newsService = new NewsServiceImpl(repositoryService,
-                                                      sessionProviderService,
-                                                      nodeHierarchyCreator,
-                                                      dataDistributionManager,
-                                                      spaceService,
-                                                      activityManager,
-                                                      identityManager,
-                                                      uploadService,
-                                                      imageProcessor,
-                                                      linkManager,
-                                                      publicationServiceImpl,
-                                                      publicationManagerImpl,
-                                                      wcmPublicationServiceImpl,
-                                                      newsSearchConnector,
-                                                      newsAttachmentsService,
-                                                      indexingService,
-                                                      newsESSearchConnector,
-                                                      userACL);
-
-    Space currentSpace = mock(Space.class);
-    org.exoplatform.services.security.Identity currentIdentity = new org.exoplatform.services.security.Identity("user");
-    MembershipEntry membershipentry = new MembershipEntry("/platform/web-contributors", "member");
-    MembershipEntry membershipentry1 = new MembershipEntry("space1", "member");
-    List<MembershipEntry> memberships = new ArrayList<MembershipEntry>();
-    memberships.add(membershipentry);
-    memberships.add(membershipentry1);
-    currentIdentity.setMemberships(memberships);
-    ConversationState state = new ConversationState(currentIdentity);
-    ConversationState.setCurrent(state);
-    when(spaceService.getSpaceById("space1")).thenReturn(currentSpace);
-    when(spaceService.isSuperManager("user")).thenReturn(false);
-    when(currentSpace.getGroupId()).thenReturn("space1");
-
-    // When
-    boolean canEditNews = newsService.canEditNews("david", "space1");
-
-    // Then
-    assertEquals(false, canEditNews);
-
-  }
-
-  @Test
-  public void shouldAuthorizeSpaceMangerToEditNewsWhenCurrentUserIsManager() {
+  public void shouldAuthorizeSpaceMangerToEditNews() {
     // Given
     DataDistributionType dataDistributionType = mock(DataDistributionType.class);
     when(dataDistributionManager.getDataDistributionType(DataDistributionMode.NONE)).thenReturn(dataDistributionType);


### PR DESCRIPTION
Prior to this change, a platform admin have the edit button for all posted articles but the edit doesn't work correctly.
After this change, the edit button from posted news details is displayed for the platform admin only if he is a space manager or the article owner.