### PR TITLE
Task-48992: Allow publishers on content management to the write an article on redactional space as simple members

### DIFF
--- a/services/src/main/java/org/exoplatform/news/rest/NewsRestResourcesV1.java
+++ b/services/src/main/java/org/exoplatform/news/rest/NewsRestResourcesV1.java
@@ -885,9 +885,10 @@ public class NewsRestResourcesV1 implements ResourceContainer, Startable {
   }
   
   private boolean canCreateNews(String authenticatedUser, Space space) throws Exception {
+    org.exoplatform.services.security.Identity currentIdentity = ConversationState.getCurrent().getIdentity();
     return space != null && 
           (spaceService.isSuperManager(authenticatedUser) || spaceService.isManager(space, authenticatedUser) || spaceService.isRedactor(space, authenticatedUser) ||
-          spaceService.isMember(space, authenticatedUser) && ArrayUtils.isEmpty(space.getRedactors()));
+          spaceService.isMember(space, authenticatedUser) && (ArrayUtils.isEmpty(space.getRedactors()) || currentIdentity.isMemberOf(PLATFORM_WEB_CONTRIBUTORS_GROUP, PUBLISHER_MEMBERSHIP_NAME)));
   }
   
   private boolean canViewNews(String authenticatedUser, Space space) throws Exception {

--- a/services/src/test/java/org/exoplatform/news/NewsServiceImplTest.java
+++ b/services/src/test/java/org/exoplatform/news/NewsServiceImplTest.java
@@ -2481,7 +2481,7 @@ public class NewsServiceImplTest {
   }
 
   @Test
-  public void shouldNotAuthorizeTheCurrentUserToEditNewsWhenCurrentUserIsManager() {
+  public void shouldAuthorizeTheCurrentUserToEditNewsWhenCurrentUserIsSpaceManger() {
     // Given
     DataDistributionType dataDistributionType = mock(DataDistributionType.class);
     when(dataDistributionManager.getDataDistributionType(DataDistributionMode.NONE)).thenReturn(dataDistributionType);
@@ -2507,60 +2507,13 @@ public class NewsServiceImplTest {
     Space currentSpace = mock(Space.class);
     org.exoplatform.services.security.Identity currentIdentity = new org.exoplatform.services.security.Identity("user");
     MembershipEntry membershipentry = new MembershipEntry("/platform/web-contributors", "member");
-    MembershipEntry membershipentry1 = new MembershipEntry("space1", "manager");
     List<MembershipEntry> memberships = new ArrayList<MembershipEntry>();
     memberships.add(membershipentry);
-    memberships.add(membershipentry1);
     currentIdentity.setMemberships(memberships);
     ConversationState state = new ConversationState(currentIdentity);
     ConversationState.setCurrent(state);
     when(spaceService.getSpaceById("space1")).thenReturn(currentSpace);
     when(spaceService.isSuperManager("user")).thenReturn(false);
-    when(currentSpace.getGroupId()).thenReturn("space1");
-
-    // When
-    boolean canEditNews = newsService.canEditNews("david", "space1");
-
-    // Then
-    assertEquals(false, canEditNews);
-
-  }
-
-  @Test
-  public void shouldAuthorizeSpaceMangerToEditNews() {
-    // Given
-    DataDistributionType dataDistributionType = mock(DataDistributionType.class);
-    when(dataDistributionManager.getDataDistributionType(DataDistributionMode.NONE)).thenReturn(dataDistributionType);
-    NewsServiceImpl newsService = new NewsServiceImpl(repositoryService,
-            sessionProviderService,
-            nodeHierarchyCreator,
-            dataDistributionManager,
-            spaceService,
-            activityManager,
-            identityManager,
-            uploadService,
-            imageProcessor,
-            linkManager,
-            publicationServiceImpl,
-            publicationManagerImpl,
-            wcmPublicationServiceImpl,
-            newsSearchConnector,
-            newsAttachmentsService,
-            indexingService,
-            newsESSearchConnector,
-            userACL);
-
-    Space currentSpace = mock(Space.class);
-    org.exoplatform.services.security.Identity currentIdentity = new org.exoplatform.services.security.Identity("user");
-    MembershipEntry membershipentry = new MembershipEntry("/platform/web-contributors", "member");
-    MembershipEntry membershipentry1 = new MembershipEntry("space1", "manager");
-    List<MembershipEntry> memberships = new ArrayList<MembershipEntry>();
-    memberships.add(membershipentry);
-    memberships.add(membershipentry1);
-    currentIdentity.setMemberships(memberships);
-    ConversationState state = new ConversationState(currentIdentity);
-    ConversationState.setCurrent(state);
-    when(spaceService.getSpaceById("space1")).thenReturn(currentSpace);
     when(spaceService.isManager(currentSpace, "user")).thenReturn(true);
     when(currentSpace.getGroupId()).thenReturn("space1");
 
@@ -2569,6 +2522,51 @@ public class NewsServiceImplTest {
 
     // Then
     assertEquals(true, canEditNews);
+
+  }
+
+  @Test
+  public void shouldNotAuthorizeTheCurrentUserToEditNews() {
+    // Given
+    DataDistributionType dataDistributionType = mock(DataDistributionType.class);
+    when(dataDistributionManager.getDataDistributionType(DataDistributionMode.NONE)).thenReturn(dataDistributionType);
+    NewsServiceImpl newsService = new NewsServiceImpl(repositoryService,
+                                                      sessionProviderService,
+                                                      nodeHierarchyCreator,
+                                                      dataDistributionManager,
+                                                      spaceService,
+                                                      activityManager,
+                                                      identityManager,
+                                                      uploadService,
+                                                      imageProcessor,
+                                                      linkManager,
+                                                      publicationServiceImpl,
+                                                      publicationManagerImpl,
+                                                      wcmPublicationServiceImpl,
+                                                      newsSearchConnector,
+                                                      newsAttachmentsService,
+                                                      indexingService,
+                                                      newsESSearchConnector,
+                                                      userACL);
+
+    Space currentSpace = mock(Space.class);
+    org.exoplatform.services.security.Identity currentIdentity = new org.exoplatform.services.security.Identity("user");
+    MembershipEntry membershipentry = new MembershipEntry("/platform/web-contributors", "member");
+    List<MembershipEntry> memberships = new ArrayList<MembershipEntry>();
+    memberships.add(membershipentry);
+    currentIdentity.setMemberships(memberships);
+    ConversationState state = new ConversationState(currentIdentity);
+    ConversationState.setCurrent(state);
+    when(spaceService.getSpaceById("space1")).thenReturn(currentSpace);
+    when(spaceService.isSuperManager("user")).thenReturn(false);
+    when(spaceService.isManager(currentSpace, "user")).thenReturn(false);
+    when(currentSpace.getGroupId()).thenReturn("space1");
+
+    // When
+    boolean canEditNews = newsService.canEditNews("david", "space1");
+
+    // Then
+    assertEquals(false, canEditNews);
 
   }
 

--- a/services/src/test/java/org/exoplatform/news/rest/NewsRestResourcesV1Test.java
+++ b/services/src/test/java/org/exoplatform/news/rest/NewsRestResourcesV1Test.java
@@ -944,6 +944,9 @@ public class NewsRestResourcesV1Test {
                                                                       identityManager,
                                                                       container);
     HttpServletRequest request = mock(HttpServletRequest.class);
+    org.exoplatform.services.security.Identity currentIdentity = new org.exoplatform.services.security.Identity("john");
+    ConversationState state = new ConversationState(currentIdentity);
+    ConversationState.setCurrent(state);
     lenient().when(request.getRemoteUser()).thenReturn("john");
     News news = new News();
     news.setId("1");
@@ -1033,6 +1036,9 @@ public class NewsRestResourcesV1Test {
                                                                       container);
     HttpServletRequest request = mock(HttpServletRequest.class);
     lenient().when(request.getRemoteUser()).thenReturn("john");
+    org.exoplatform.services.security.Identity currentIdentity = new org.exoplatform.services.security.Identity("john");
+    ConversationState state = new ConversationState(currentIdentity);
+    ConversationState.setCurrent(state);
     News news = new News();
     news.setId("1");
     news.setSpaceId("1");


### PR DESCRIPTION
Prior to this change, publishers on the content management group are not able to write an article on a redactional space when they are simple members.
After this change, publishers on the content management group are allowed to write an article on a redactional space when they are simple members.