### PR TITLE
Task-49368: Fix regression on edit/delete/resume articles from news app 

### DIFF
--- a/webapp/src/main/webapp/news/components/ExoNewsDetailsActionMenuApp.vue
+++ b/webapp/src/main/webapp/news/components/ExoNewsDetailsActionMenuApp.vue
@@ -1,0 +1,83 @@
+<template>
+  <v-menu
+    v-model="actionMenu"
+    eager
+    bottom
+    left
+    offset-y
+    min-width="108px"
+    class="px-0 text-right mx-2">
+    <template #activator="{ on, attrs }">
+      <v-btn
+        v-bind="attrs"
+        class="newsDetailsActionMenu pull-right"
+        icon
+        v-on="on">
+        <v-icon>mdi-dots-vertical</v-icon>
+      </v-btn>
+    </template>
+
+    <v-list>
+      <v-list-item v-if="showEditButton" @click="$emit('edit')">
+        <v-list-item-title>
+          {{ $t('news.details.header.menu.edit') }}
+        </v-list-item-title>
+      </v-list-item>
+      <v-list-item v-if="showShareButton && news.activityId" @click="$root.$emit('activity-share-drawer-open', news.activityId)">
+        <v-list-item-title>
+          {{ $t('news.details.header.menu.share') }}
+        </v-list-item-title>
+      </v-list-item>
+      <v-list-item v-if="showResumeButton" @click="$emit('edit')">
+        <v-list-item-title>
+          {{ $t('news.details.header.menu.resume') }}
+        </v-list-item-title>
+      </v-list-item>
+      <v-list-item v-if="showDeleteButton" @click="$emit('delete')">
+        <v-list-item-title>
+          {{ $t('news.details.header.menu.delete') }}
+        </v-list-item-title>
+      </v-list-item>
+    </v-list>
+  </v-menu>
+</template>
+
+<script>
+export default {
+  props: {
+    news: {
+      type: Object,
+      required: false,
+      default: null
+    },
+    showShareButton: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
+    showEditButton: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
+    showResumeButton: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
+    showDeleteButton: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
+  },
+  data: () => ({
+    actionMenu: null,
+  }),
+  mounted() {
+    $('#UIPortalApplication').parent().click(() => {
+      this.actionMenu = false;
+    });
+  },
+};
+</script>

--- a/webapp/src/main/webapp/news/components/NewsApp.vue
+++ b/webapp/src/main/webapp/news/components/NewsApp.vue
@@ -85,7 +85,7 @@
               v-if="news.activities && news.activities.split(';')[1]"
               :news-id="news.newsId"
               :activities="news.activities" />
-            <exo-news-details-action-menu
+            <exo-news-details-action-menu-app
               v-if="!news.schedulePostDate"
               :news="news"
               :show-edit-button="news.canEdit && !isDraftsFilter"

--- a/webapp/src/main/webapp/news/initComponents.js
+++ b/webapp/src/main/webapp/news/initComponents.js
@@ -5,6 +5,7 @@ import NewsFilterSpaceDrawer from './components/NewsFilterSpaceDrawer.vue';
 import NewsFilterSpaceItem from './components/NewsFilterSpaceItem.vue';
 import NewsFilterSpaceList from './components/NewsFilterSpaceList.vue';
 import NewsFilterSpaceSearch from './components/NewsFilterSpaceSearch.vue';
+import ExoNewsDetailsActionMenuApp from './components/ExoNewsDetailsActionMenuApp.vue';
 
 const components = {
   'news-app': NewsApp,
@@ -14,6 +15,7 @@ const components = {
   'news-filter-space-item': NewsFilterSpaceItem,
   'news-filter-space-list': NewsFilterSpaceList,
   'news-filter-space-search': NewsFilterSpaceSearch,
+  'exo-news-details-action-menu-app': ExoNewsDetailsActionMenuApp,
 };
 
 for (const key in components) {


### PR DESCRIPTION
Prior to this change, after refactoring done in mobile view `ExoNewsDetailsActionMenu` isn't the child component of NewsApp, the deletion and edition action doesn't work. So to make this action possible, we have created a child component `ExoNewsDetailsActionMenuApp` allowing edition and deletion.