### PR TITLE
Task-49461: Fix publish/unpublish labels and actions regressions in news details desktop and mobile

### DIFF
--- a/webapp/src/main/webapp/news-details/components/ExoNewsDetailsActionMenu.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsDetailsActionMenu.vue
@@ -95,12 +95,17 @@ export default {
       required: false,
       default: false
     },
+    newsPublished: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
   },
   data: () => ({
     actionMenu: null,
+    showPublishMessage: false,
     publishMessage: '',
     publishSuccess: true,
-    newsPublished: false,
   }),
   computed: {
     isMobile() {

--- a/webapp/src/main/webapp/news-details/components/ExoNewsPublish.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsPublish.vue
@@ -4,17 +4,17 @@
       ref="publishConfirmDialog"
       :title="confirmDialogTitle"
       :message="confirmDialogMessage"
-      :ok-label="$t('news.broadcast.btn.confirm')"
-      :cancel-label="$t('news.broadcast.btn.cancel')"
-      @ok="updatePinnedField" />
+      :ok-label="$t('news.publish.btn.confirm')"
+      :cancel-label="$t('news.publish.btn.cancel')"
+      @ok="updatePublishedField" />
     <a
-      id="newsPinButton"
-      :title="pinLabel"
-      :class="[newsArchived ? 'unauthorizedPin' : '']"
+      id="newsPublishButton"
+      :title="publishLabel"
+      :class="[newsArchived ? 'unauthorizedPublish' : '']"
       class="btn my-5"
       @click="confirmAction">
       <v-icon
-        :class="broadcastArticleClass"
+        :class="publishArticleClass"
         class="fas fa-bullhorn" />
     </a>
   </div>
@@ -46,34 +46,34 @@ export default {
   },
   data() {
     return {
-      showPinMessage: false,
-      messagePin: '',
-      successPin: true,
+      showPublishMessage: false,
+      messagePublish: '',
+      successPublish: true,
     };
   },
   computed: {
-    broadcastArticleClass() {
-      return this.newsPinned ? 'broadcastArticle' : 'unbroadcastArticle';
+    publishArticleClass() {
+      return this.newsPublished ? 'publishArticle' : 'unpublishArticle';
     },
-    pinLabel() {
-      return this.newsPinned && this.$t('news.unbroadcast.action') || this.$t('news.broadcast.action');
+    publishLabel() {
+      return this.newsPublished && this.$t('news.unpublish.action') || this.$t('news.publish.action');
     },
     confirmDialogTitle() {
-      return this.newsPinned && this.$t('news.unbroadcast.action') || this.$t('news.broadcast.action');
+      return this.newsPublished && this.$t('news.unpublish.action') || this.$t('news.publish.action');
     },
     confirmDialogMessage() {
-      return this.newsPinned && this.$t('news.unbroadcast.confirm', {0: this.newsTitle}) || this.$t('news.broadcast.confirm');
+      return this.newsPublished && this.$t('news.unpublish.confirm', {0: this.newsTitle}) || this.$t('news.publish.confirm');
     },
   },
   methods: {
     confirmAction() {
       this.$refs.publishConfirmDialog.open();
     },
-    updatePinnedField: function () {
-      const pinMessageTime = 5000;
+    updatePublishedField: function () {
+      const publishMessageTime = 5000;
       const context = this;
       let updatedNews = null;
-      if (this.newsPinned === false) {
+      if (this.newsPublished === false) {
         updatedNews = {
           pinned: true,
         };
@@ -90,34 +90,34 @@ export default {
         method: 'PATCH',
         body: JSON.stringify(updatedNews)
       }).then (function() {
-        context.showPinMessage = true;
-        if (context.newsPinned === false) {
-          context.messagePin = context.$t('news.broadcast.success');
-          context.pinLabel = context.$t('news.unbroadcast.action');
+        context.showPublishMessage = true;
+        if (context.newsPublished === false) {
+          context.messagePublish = context.$t('news.publish.success');
+          context.publishLabel = context.$t('news.unpublish.action');
           // eslint-disable-next-line vue/no-mutating-props
-          context.newsPinned = true;
+          context.newsPublished = true;
         } else {
-          context.messagePin = context.$t('news.unbroadcast.success');
-          context.pinLabel = context.$t('news.broadcast.action');
+          context.messagePublish = context.$t('news.unpublish.success');
+          context.publishLabel = context.$t('news.publish.action');
           // eslint-disable-next-line vue/no-mutating-props
-          context.newsPinned = false;
+          context.newsPublished = false;
         }
         setTimeout(function () {
-          context.showPinMessage = false;
-        }, pinMessageTime);
+          context.showPublishMessage = false;
+        }, publishMessageTime);
       })
         .catch (function() {
-          context.showPinMessage = true;
-          context.successPin = false;
-          if (context.newsPinned === false) {
-            context.messagePin = context.$t('news.broadcast.error');
+          context.showPublishMessage = true;
+          context.successPublish = false;
+          if (context.newsPublished === false) {
+            context.messagePublish = context.$t('news.publish.error');
           } else {
-            context.messagePin = context.$t('news.unbroadcast.error');
+            context.messagePublish = context.$t('news.unpublish.error');
           }
           setTimeout(function () {
-            context.successPin = true;
-            context.showPinMessage = false;
-          }, pinMessageTime);
+            context.successPublish = true;
+            context.showPublishMessage = false;
+          }, publishMessageTime);
         });
     },
   }

--- a/webapp/src/main/webapp/news-details/components/mobile/ExoNewsDetailsToolBarMobile.vue
+++ b/webapp/src/main/webapp/news-details/components/mobile/ExoNewsDetailsToolBarMobile.vue
@@ -29,7 +29,8 @@
         :news="news"
         :show-edit-button="showEditButton"
         :show-delete-button="showDeleteButton"
-        :show-publish-button="showPublishButton" />
+        :show-publish-button="showPublishButton"
+        :news-published="news.pinned" />
     </v-btn>
     <v-btn
       v-if="publicationState === 'staged'"

--- a/webapp/src/main/webapp/skin/less/news.less
+++ b/webapp/src/main/webapp/skin/less/news.less
@@ -54,7 +54,7 @@
     top: -9px;
     width: 100%;
     text-align: center;
-    #newsPinButton {
+    #newsPublishButton {
       border: none !important;
       float: right ~'; /** orientation=lt */ ';
       float: left ~'; /** orientation=rt */ ';
@@ -63,7 +63,7 @@
         font-size: 18px;
       }
     }
-    &.unauthorizedPin {
+    &.unauthorizedPublish {
       cursor: not-allowed;
     }
     .uiIconPin {
@@ -73,10 +73,10 @@
     .uiIconPin:before {
       content: "\eb54";
     }
-    .broadcastArticle {
+    .publishArticle {
       color: @primaryColorDefault;
     }
-    .unbroadcastArticle {
+    .unpublishArticle {
       color: @greyColorLighten1Default;
     }
   }
@@ -105,7 +105,7 @@
     background-color: #f9fafc;
   }
 
-  .unauthorizedPin {
+  .unauthorizedPublish {
     cursor: not-allowed;
     color: @headingColor;
     padding-left: 10px ~'; /** orientation=lt */ ';
@@ -627,14 +627,14 @@
         margin-left: 10px ~'; /** orientation=rt */ ';
         cursor: pointer;
 
-        #newsPinButton {
+        #newsPublishButton {
           float: right ~'; /** orientation=lt */ ';
           float: left ~'; /** orientation=rt */ ';
           i {
             font-size: 18px;
           }
 
-          &.unauthorizedPin {
+          &.unauthorizedPublish {
             cursor: not-allowed;
           }
 
@@ -648,11 +648,11 @@
             content: "\eb54";
           }
 
-          .broadcastArticle {
+          .publishArticle {
             color: @primaryColorDefault;
           }
 
-          .unbroadcastArticle {
+          .unpublishArticle {
             color: @greyColorLighten1Default;
           }
         }
@@ -690,7 +690,7 @@
         }
 
         #newsUpdateAndPost {
-          &.unauthorizedPin {
+          &.unauthorizedPublish {
             cursor: not-allowed;
           }
         }
@@ -1347,7 +1347,7 @@
         border-color: #fff;
         padding: 0;
 
-        &.unauthorizedPin {
+        &.unauthorizedPublish {
           cursor: not-allowed;
         }
 


### PR DESCRIPTION
Prior to change, the publish news confirmation popup labels, publish icon tooltip label are not correct and the publish/unpublish actions on desktop and mobile doesn't work. After this change, the problems are fixed. 