### PR TITLE
Backport Task-46549_49049: Implement mobile view for news detail and Fix the content of popover when hovering from news details

### DIFF
--- a/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
@@ -789,6 +789,13 @@ public class NewsServiceImpl implements NewsService {
       news.setAuthorAvatarUrl(identity.getProfile().getAvatarUrl());
     }
 
+    if(StringUtils.isNotBlank(news.getUpdater())) {
+      Identity updaterIdentity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, news.getUpdater());
+      if (updaterIdentity != null && updaterIdentity.getProfile() != null) {
+        news.setUpdaterFullName(updaterIdentity.getProfile().getFullName());
+      }
+    }
+
     Identity draftUpdaterIdentity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, news.getDraftUpdater(), true);
     if (draftUpdaterIdentity != null && draftUpdaterIdentity.getProfile() != null) {
       news.setDraftUpdaterDisplayName(draftUpdaterIdentity.getProfile().getFullName());

--- a/services/src/main/java/org/exoplatform/news/model/News.java
+++ b/services/src/main/java/org/exoplatform/news/model/News.java
@@ -23,6 +23,8 @@ public class News {
 
   private String               updater;
 
+  private String               updaterFullName;
+
   private String               draftUpdater;
 
   private String               draftUpdaterDisplayName;
@@ -403,4 +405,11 @@ public class News {
     this.timeZoneId = timeZoneId;
   }
 
+  public String getUpdaterFullName() {
+    return updaterFullName;
+  }
+
+  public void setUpdaterFullName(String updaterFullName) {
+    this.updaterFullName = updaterFullName;
+  }
 }

--- a/services/src/main/java/org/exoplatform/news/rest/NewsRestResourcesV1.java
+++ b/services/src/main/java/org/exoplatform/news/rest/NewsRestResourcesV1.java
@@ -455,6 +455,7 @@ public class NewsRestResourcesV1 implements ResourceContainer, Startable {
       news.setUploadId(updatedNews.getUploadId());
       news.setAttachments(updatedNews.getAttachments());
       news.setPublicationState(updatedNews.getPublicationState());
+      news.setUpdaterFullName(updatedNews.getUpdaterFullName());
 
       if (updatedNews.isPinned() != news.isPinned()) {
         org.exoplatform.services.security.Identity currentIdentity = ConversationState.getCurrent().getIdentity();

--- a/services/src/main/resources/locale/portlet/news/News_en.properties
+++ b/services/src/main/resources/locale/portlet/news/News_en.properties
@@ -101,13 +101,13 @@ news.share.spaces.placeholder=Search a space by name
 news.share.spaces.searchPlaceholder=Start typing to search
 news.share.spaces.noDataLabel=No space found
 
-news.broadcast.btn.confirm=Confirm
-news.broadcast.btn.cancel=Cancel
-news.broadcast.label=Publish article
-news.broadcast.action=Publish article
-news.broadcast.confirm=This article will be published on the snapshot page and made visible to everyone. Do you confirm this action?
-news.broadcast.success=The article was successfully published on the snapshot page
-news.broadcast.error=An error occurred when trying to publish this article. Try again, if the error persists, please contact your administrator.
+news.publish.btn.confirm=Confirm
+news.publish.btn.cancel=Cancel
+news.publish.label=Publish article
+news.publish.action=Publish article
+news.publish.confirm=This article will be published on the snapshot page and made visible to everyone. Do you confirm this action?
+news.publish.success=The article was successfully published on the snapshot page
+news.publish.error=An error occurred when trying to publish this article. Try again, if the error persists, please contact your administrator.
 
 news.archive.btn.confirm=Confirm
 news.archive.btn.cancel=Cancel
@@ -119,11 +119,11 @@ news.archive.label=Archived
 
 news.archive.text=Sorry, you don't have access to this article. Please contact your administrator.
 
-news.unbroadcast.action=Unpublish article
-news.unbroadcast.confirm=Are your sure you want to unpublish \u201C{0}\u201D ?
-news.unbroadcast.label=Unpublish article
-news.unbroadcast.success=The article was successfully unpublished
-news.unbroadcast.error=An error occurred while unpublishing the article. Try again, if the error persists, please contact your administrator.
+news.unpublish.action=Unpublish article
+news.unpublish.confirm=Are your sure you want to unpublish \u201C{0}\u201D ?
+news.unpublish.label=Unpublish article
+news.unpublish.success=The article was successfully unpublished
+news.unpublish.error=An error occurred while unpublishing the article. Try again, if the error persists, please contact your administrator.
 
 news.unarchive.action=Unarchive article
 news.unarchive.confirm=This article will be unarchived and become available for users.
@@ -199,6 +199,8 @@ news.details.header.menu.share=Share
 news.details.header.menu.edit=Edit
 news.details.header.menu.resume=Resume
 news.details.header.menu.delete=Delete
+news.details.header.menu.publish=Publish
+news.details.header.menu.unpublish=Unpublish
 
 news.details.undoDelete=Undo
 news.details.deleteSuccess=News deleted

--- a/webapp/src/main/webapp/news-details-app/components/ExoNewsDetailsApp.vue
+++ b/webapp/src/main/webapp/news-details-app/components/ExoNewsDetailsApp.vue
@@ -7,9 +7,11 @@
     <exo-news-details
       v-else
       id="newsFullDetails"
-      style="display: none"
       :news="news"
-      :news-id="newsId" />
+      :news-id="newsId"
+      :show-edit-button="showEditButton"
+      :show-publish-button="showPublishButton"
+      :show-delete-button="showDeleteButton" />
   </div>
 </template>
 
@@ -24,13 +26,18 @@ export default {
   data: () => ({
     news: null,
     notFound: false,
+    showEditButton: false,
+    showPublishButton: false,
+    showDeleteButton: false,
   }),
   created() {
     this.$newsServices.getNewsById(this.newsId, false)
       .then(news => {
         if (news !== null) {
-          document.getElementById('newsFullDetails').style.display = 'initial';
           this.news = news;
+          this.showEditButton = this.news.canEdit;
+          this.showPublishButton = this.news.canPublish;
+          this.showDeleteButton = this.news.canDelete;
           if (!this.news.spaceMember) {
             this.$root.$emit('restricted-space', this.news.spaceDisplayName);
           }

--- a/webapp/src/main/webapp/news-details-app/main.js
+++ b/webapp/src/main/webapp/news-details-app/main.js
@@ -24,7 +24,7 @@ export function init() {
     `${newsConstants.PORTAL}/${newsConstants.PORTAL_REST}/i18n/bundle/locale.attachmentsSelector.attachments-${lang}.json`
   ];
 
-  const appId = 'newsDetail';
+  const appId = 'newsDetailApp';
   const appElement = document.createElement('div');
   appElement.id = appId;
   // getting locale resources

--- a/webapp/src/main/webapp/news-details/components/ExoNewsDetails.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsDetails.vue
@@ -1,30 +1,22 @@
 <template>
   <div id="newsDetails">
-    <a class="backBtn" :href="backURL"><i class="uiIconBack my-4"></i></a>
-    <v-btn
-      v-if="publicationState === 'staged'"
-      class="btn newsDetailsActionMenu mt-6 mr-2 pull-right"
-      @click="$root.$emit('open-schedule-drawer','editScheduledNews')">
-      {{ $t("news.composer.btn.scheduleArticle") }}
-    </v-btn>
-    <schedule-news-drawer
-      @post-article="postNews"
-      :news-id="newsId" />
-    <exo-news-details-action-menu
-      v-if="showEditButton"
+    <exo-news-details-toolbar
+      v-if="!isMobile"
+      :news="news"
+      :news-id="newsId"
+      :activity-id="activityId"
+      :show-edit-button="showEditButton"
+      :show-delete-button="showDeleteButton"
+      :show-publish-button="showPublishButton" />
+    <exo-news-details-toolbar-mobile
+      v-if="isMobile"
       :news="news"
       :show-edit-button="showEditButton"
       :show-delete-button="showDeleteButton"
-      @delete="deleteConfirmDialog"
-      @edit="editLink" />
-    <div class="newsDetailsIcons">
-      <exo-news-pin
-        v-if="showPinButton"
-        :news-id="newsId"
-        :news-pinned="news.pinned"
-        :news-archived="archivedNews"
-        :news-title="newsTitle" />
-    </div>
+      :show-publish-button="showPublishButton" />
+    <schedule-news-drawer
+      @post-article="postNews"
+      :news-id="newsId" />
     <exo-confirm-dialog
       ref="deleteConfirmDialog"
       :message="$t('news.message.confirmDeleteNews')"
@@ -32,122 +24,14 @@
       :ok-label="$t('news.button.ok')"
       :cancel-label="$t('news.button.cancel')"
       @ok="deleteNews" />
-    <div v-if="archivedNews && !news.canArchive">
-      <div class="userNotAuthorized">
-        <div class="notAuthorizedIconDiv">
-          <img src="/news/images/notauthorized.png" class="iconNotAuthorized">
-        </div>
-        <h3>{{ $t('news.archive.text') }}</h3>
-      </div>
-    </div>
-    <div v-else class="newsDetails-description">
-      <div :class="[illustrationURL ? 'newsDetails-header' : '']" class="newsDetails-header">
-        <div v-if="illustrationURL" class="illustration">
-          <img
-            :src="illustrationURL"
-            class="newsDetailsImage illustrationPicture"
-            alt="News">
-        </div>
-        <div class="newsDetails">
-          <div class="news-top-information d-flex">
-            <div id="titleNews" class="newsTitle newsTitleMobile">
-              <a class="activityLinkColor newsTitleLink">{{ newsTitle }}</a>
-              <div v-if="archivedNews" class="newsArchived">
-                <span class="newsArchiveLabel"> ( {{ $t('news.archive.label') }} ) </span>
-              </div>
-            </div>
-          </div>
-          <div class="newsInformationBackground">
-            <div :class="[showUpdateInfo ? 'news-update-details-header' : 'news-details-header']" class="news-header-content">
-              <div :class="[ showUpdateInfo ? 'newsUpdateInfo' : '']">
-                <div class="activityAvatar avatarCircle">
-                  <a :href="authorProfileURL">
-                    <img :src="authorAvatarURL" class="avatar">
-                  </a>
-                </div>
-              </div>
-              <div id="informationNews" class="newsInformation">
-                <div class="newsAuthor">
-                  <a :href="authorProfileURL" class="newsInformationValue newsAuthorName news-details-information"> {{ authorFullName }} </a>
-                  <span v-if="!hiddenSpace" class="newsInformationLabel"> {{ $t('news.activity.in') }} </span>
-                  <div v-if="!hiddenSpace" class="newsSpace">
-                    <a :href="spaceUrl" class="newsInformationLabel news-details-information">{{ spaceDisplayName }}</a>
-                  </div>
-                  <template v-if="publicationDate">
-                    -
-                    <date-format
-                      :value="publicationDate"
-                      :format="dateFormat"
-                      class="newsInformationValue newsPostedDate news-details-information" />
-                  </template>
-                  <span v-else-if="postedDate" class="newsInformationValue newsPostedDate news-details-information">- {{ postedDate }}</span>
-                </div>
-                <div v-if="showUpdateInfo" class="newsUpdater">
-                  <div v-if="publicationState !== 'staged'">
-                    <span class="newsInformationLabel">{{ $t('news.activity.lastUpdated') }} </span>
-                  </div>
-                  <div v-else>
-                    <span class="newsInformationLabel">{{ $t('news.details.scheduled') }} </span>
-                  </div>
-                  <div>
-                    <template v-if="publicationState !== 'staged' && updatedDate">
-                      <date-format
-                        :value="updatedDate"
-                        :format="dateFormat"
-                        class="newsInformationValue newsUpdatedDate" />
-                    </template>
-                    <template v-else-if="publicationState === 'staged'">
-                      <date-format
-                        :value="scheduleDate"
-                        :format="dateFormat"
-                        class="newsInformationValue newsUpdatedDate" />
-                      <span class="newsInformationValue">-</span>
-                      <date-format
-                        :value="scheduleDate"
-                        :format="dateTimeFormat"
-                        class="newsInformationValue newsUpdatedDate ml-1 me-1" />
-                    </template>
-                    <div v-else-if="news.updatedDate" class="newsInformationValue newsUpdatedDate">{{ news.updatedDate }}</div>
-                    <div v-if="notSameUpdater">
-                      <span class="newsInformationLabel"> {{ $t('news.activity.by') }} </span>
-                      <a :href="updaterProfileURL" class="newsInformationValue newsUpdaterName">{{ updaterFullName }}</a>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <div
-            v-if="newsSummary"
-            id="newsSummary"
-            class="summary">
-            <span v-html="newsSummary"></span>
-          </div>
-
-          <div
-            id="newsBody"
-            :class="[!summary ? 'fullDetailsBodyNoSummary' : '']"
-            class="fullDetailsBody clearfix">
-            <span v-html="newsBody"></span>
-          </div>
-
-          <div v-show="attachments && attachments.length" class="newsAttachmentsTitle">
-            {{ $t('news.details.attachments.title') }} ({{ attachments ? attachments.length : 0 }})
-          </div>
-
-          <div v-show="attachments && attachments.length" class="newsAttachments">
-            <div
-              v-for="attachedFile in attachments"
-              :key="attachedFile.id"
-              class="newsAttachment"
-              @click="openPreview(attachedFile)">
-              <exo-attachment-item :file="attachedFile" />
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
+    <exo-news-details-body
+      v-if="!isMobile"
+      :news="news" />
+    <exo-news-details-body-mobile
+      v-if="isMobile"
+      :news="news"
+      :news-id="newsId"
+      :space="currentSpace" />
     <exo-news-notification-alerts />
   </div>
 </template>
@@ -175,7 +59,7 @@ export default {
       required: false,
       default: false
     },
-    showPinButton: {
+    showPublishButton: {
       type: Boolean,
       required: false,
       default: false
@@ -188,8 +72,8 @@ export default {
   },
   data() {
     return {
+      currentSpace: null,
       spaceId: null,
-      updaterIdentity: null,
       BYTES_IN_MB: 1048576,
       dateFormat: {
         year: 'numeric',
@@ -203,81 +87,18 @@ export default {
     };
   },
   computed: {
-    newsBody() {
-      return this.news && this.targetBlank(this.news.body);
-    },
-    showUpdateInfo() {
-      return this.updatedDate || (this.news && this.news.updatedDate && this.news.updatedDate  !== 'null');
-    },
-    authorFullName() {
-      return this.news && (this.news.authorFullName || this.news.authorDisplayName);
-    },
-    authorProfileURL() {
-      return this.news && `${eXo.env.portal.context}/${eXo.env.portal.portalName}/profile/${this.news.updater}`;
-    },
-    authorAvatarURL() {
-      return this.news && (this.news.profileAvatarURL || this.news.authorAvatarUrl);
-    },
-    backURL() {
-      return this.news && this.news.spaceMember ? this.news.spaceUrl : `${eXo.env.portal.context}/${eXo.env.portal.portalName}`;
-    },
-    updaterFullName() {
-      return (this.news && this.news.updaterFullName) || (this.updaterIdentity && this.updaterIdentity.profile && this.updaterIdentity.profile.fullname);
-    },
-    updaterProfileURL() {
-      return this.news && `${eXo.env.portal.context}/${eXo.env.portal.portalName}/profile/${this.news.updater}`;
-    },
-    notSameUpdater() {
-      return this.news && this.news.updater !=='__system' && (this.news.updater !== this.news.author || this.news.authorFullName !== this.news.updaterFullName);
-    },
-    publicationDate() {
-      return this.news && this.news.publicationDate && this.news.publicationDate.time && new Date(this.news.publicationDate.time);
-    },
-    updatedDate() {
-      return this.news && this.news.updateDate && this.news.updateDate.time && new Date(this.news.updateDate.time);
-    },
-    newsSummary() {
-      return this.news && this.targetBlank(this.news.summary);
-    },
-    spaceDisplayName() {
-      return this.news && this.news.spaceDisplayName;
-    },
-    spaceUrl() {
-      return this.news && this.news.spaceUrl;
-    },
-    archivedNews() {
-      return this.news && this.news.archived;
-    },    
-    illustrationURL() {
-      return this.news && this.news.illustrationURL;
-    },
-    newsTitle() {
-      return this.news && this.news.title;
-    },
-    hiddenSpace() {
-      return this.news && this.news.hiddenSpace;
-    },
-    postedDate() {
-      return this.news && this.news.postedDate;
-    },
-    summary() {
-      return this.news && this.news.summary;
-    },
-    attachments() {
-      return this.news && this.news.attachments;
-    },
-    publicationState() {
-      return this.news && this.news.publicationState;
-    },
-    scheduleDate() {
-      return this.news && this.news.schedulePostDate;
+    isMobile() {
+      return this.$vuetify.breakpoint.name === 'xs' || this.$vuetify.breakpoint.name === 'sm';
     },
   },
   created() {
+    this.$root.$on('delete-news', this.deleteConfirmDialog);
+    this.$root.$on('edit-news', this.editLink);
     if (!this.news || !this.news.spaceId) {
       this.$newsServices.getNewsById(this.newsId)
         .then(news => {
           this.spaceId = news.spaceId;
+          this.getSpaceById(this.spaceId);
           if (!this.news) {
             this.news = news;
           }
@@ -289,16 +110,14 @@ export default {
           return this.$nextTick();
         })
         .finally(() => {
+          document.title = this.$t('news.window.title', {0: this.news.title});
           this.$root.$emit('application-loaded');
         });
     } else {
       this.spaceId = this.news.spaceId;
+      this.getSpaceById(this.spaceId );
       if (!this.news.newsId) {
         this.news.newsId = this.newsId;
-      }
-      if (this.notSameUpdater && this.news && this.news.updater) {
-        this.$identityService.getIdentityByProviderIdAndRemoteId('organization', this.news.updater)
-          .then(identity => this.updaterIdentity = identity);
       }
       this.$root.$emit('application-loaded');
     }
@@ -323,40 +142,13 @@ export default {
     }
   },
   methods: {
-    openPreview(attachedFile) {
-      const self = this;
-      window.require(['SHARED/documentPreview'], function(documentPreview) {
-        documentPreview.init({
-          doc: {
-            id: attachedFile.id,
-            repository: 'repository',
-            workspace: 'collaboration',
-            title: attachedFile.name,
-            downloadUrl: `/portal/rest/v1/news/attachments/${attachedFile.id}/file`,
-            openUrl: `/portal/rest/v1/news/attachments/${attachedFile.id}/open`
-          },
-          showComments: false
+    getSpaceById(spaceId) {
+      this.$spaceService.getSpaceById(spaceId, 'identity')
+        .then((space) => {
+          if (space && space.identity && space.identity.id) {
+            this.currentSpace = space;
+          }
         });
-        self.hideDocPreviewComments();
-      });
-    },
-    /**
-     * Hack to hide the document preview comments panel because the document preview component
-     * does not allow to hide it through its API
-     * @returns {void} when the comments panel appeared and has been hidden
-     */
-    hideDocPreviewComments() {
-      const intervalCheck = 100;
-
-      const commentsPanel = document.querySelector('.uiDocumentPreview .commentArea');
-      const collapsedCommentsButton = document.querySelector('.uiDocumentPreview .resizeButton');
-      if (commentsPanel != null && collapsedCommentsButton != null) {
-        commentsPanel.style.display = 'none';
-        collapsedCommentsButton.style.display = 'none';
-        document.querySelector('.uiDocumentPreview').classList += ' collapsed';
-      } else {
-        setTimeout(this.hideDocPreviewComments, intervalCheck);
-      }
     },
     editLink() {
       const editUrl = `${eXo.env.portal.context}/${eXo.env.portal.portalName}/news/editor?spaceId=${this.spaceId}&newsId=${this.newsId}&activityId=${this.activityId}`;
@@ -378,23 +170,6 @@ export default {
           window.location.href = this.news.spaceUrl;
         }
       }, redirectionTime);
-    },
-    targetBlank: function (content) {
-      const internal = location.host + eXo.env.portal.context;
-      const domParser = new DOMParser();
-      const docElement = domParser.parseFromString(content, 'text/html').documentElement;
-      const links = docElement.getElementsByTagName('a');
-      for (let i=0; i < links.length ; i++) {
-        let href = links[i].href.replace(/(^\w+:|^)\/\//, '');
-        if (href.endsWith('/')) {
-          href = href.slice(0, -1);
-        }
-        if (href !== location.host && !href.startsWith(internal)) {
-          links[i].setAttribute('target', '_blank');
-          links[i].setAttribute('rel', 'noopener noreferrer');
-        }
-      }
-      return docElement.innerHTML;
     },
     postNews(schedulePostDate, postArticleMode, publish) {
       this.news.timeZoneId = USER_TIMEZONE_ID;

--- a/webapp/src/main/webapp/news-details/components/ExoNewsDetailsActionMenu.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsDetailsActionMenu.vue
@@ -95,12 +95,17 @@ export default {
       required: false,
       default: false
     },
+    newsPublished: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
   },
   data: () => ({
     actionMenu: null,
+    showPublishMessage: false,
     publishMessage: '',
     publishSuccess: true,
-    newsPublished: false,
   }),
   computed: {
     isMobile() {

--- a/webapp/src/main/webapp/news-details/components/ExoNewsDetailsActionMenu.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsDetailsActionMenu.vue
@@ -1,45 +1,59 @@
 <template>
-  <v-menu
-    v-model="actionMenu"
-    eager
-    bottom
-    left
-    offset-y
-    min-width="108px"
-    class="px-0 text-right mx-2">
-    <template #activator="{ on, attrs }">
-      <v-btn
-        v-bind="attrs"
-        class="newsDetailsActionMenu pull-right"
-        icon
-        v-on="on">
-        <v-icon>mdi-dots-vertical</v-icon>
-      </v-btn>
-    </template>
+  <div>
+    <v-menu
+      v-model="actionMenu"
+      eager
+      bottom
+      left
+      offset-y
+      min-width="108px"
+      class="px-0 text-right mx-2">
+      <template #activator="{ on, attrs }">
+        <v-btn
+          v-bind="attrs"
+          class="newsDetailsActionMenu pull-right"
+          icon
+          v-on="on">
+          <v-icon>mdi-dots-vertical</v-icon>
+        </v-btn>
+      </template>
 
-    <v-list>
-      <v-list-item v-if="showEditButton" @click="$emit('edit')">
-        <v-list-item-title>
-          {{ $t('news.details.header.menu.edit') }}
-        </v-list-item-title>
-      </v-list-item>
-      <v-list-item v-if="showShareButton && news.activityId" @click="$root.$emit('activity-share-drawer-open', news.activityId)">
-        <v-list-item-title>
-          {{ $t('news.details.header.menu.share') }}
-        </v-list-item-title>
-      </v-list-item>
-      <v-list-item v-if="showResumeButton" @click="$emit('edit')">
-        <v-list-item-title>
-          {{ $t('news.details.header.menu.resume') }}
-        </v-list-item-title>
-      </v-list-item>
-      <v-list-item v-if="showDeleteButton" @click="$emit('delete')">
-        <v-list-item-title>
-          {{ $t('news.details.header.menu.delete') }}
-        </v-list-item-title>
-      </v-list-item>
-    </v-list>
-  </v-menu>
+      <v-list>
+        <v-list-item v-if="showEditButton" @click="$root.$emit('edit-news')">
+          <v-list-item-title>
+            {{ $t('news.details.header.menu.edit') }}
+          </v-list-item-title>
+        </v-list-item>
+        <v-list-item v-if="showShareButton && news.activityId" @click="$root.$emit('activity-share-drawer-open', news.activityId)">
+          <v-list-item-title>
+            {{ $t('news.details.header.menu.share') }}
+          </v-list-item-title>
+        </v-list-item>
+        <v-list-item v-if="showResumeButton" @click="$root.$emit('edit-news')">
+          <v-list-item-title>
+            {{ $t('news.details.header.menu.resume') }}
+          </v-list-item-title>
+        </v-list-item>
+        <v-list-item v-if="showDeleteButton" @click="$root.$emit('delete-news')">
+          <v-list-item-title>
+            {{ $t('news.details.header.menu.delete') }}
+          </v-list-item-title>
+        </v-list-item>
+        <v-list-item v-if="isMobile && showPublishButton" @click="confirmAction">
+          <v-list-item-title>
+            {{ publishLabel }}
+          </v-list-item-title>
+        </v-list-item>
+      </v-list>
+    </v-menu>
+    <exo-confirm-dialog
+      ref="publishConfirmDialog"
+      :title="confirmDialogTitle"
+      :message="confirmDialogMessage"
+      :ok-label="$t('news.publish.btn.confirm')"
+      :cancel-label="$t('news.publish.btn.cancel')"
+      @ok="updatePublishedField" />
+  </div>
 </template>
 
 <script>
@@ -50,6 +64,11 @@ export default {
       type: Object,
       required: false,
       default: null
+    },
+    newsArchived: {
+      type: Boolean,
+      required: true,
+      default: false
     },
     showShareButton: {
       type: Boolean,
@@ -71,15 +90,91 @@ export default {
       required: false,
       default: false
     },
+    showPublishButton: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
   },
   data: () => ({
     actionMenu: null,
+    publishMessage: '',
+    publishSuccess: true,
+    newsPublished: false,
   }),
+  computed: {
+    isMobile() {
+      return this.$vuetify.breakpoint.name === 'xs' || this.$vuetify.breakpoint.name === 'sm';
+    },
+    confirmDialogTitle() {
+      return this.newsPublished && this.$t('news.unpublish.action') || this.$t('news.publish.action');
+    },
+    confirmDialogMessage() {
+      return this.newsPublished && this.$t('news.unpublish.confirm', {0: this.news.title}) || this.$t('news.publish.confirm');
+    },
+    publishLabel() {
+      return this.newsPublished ? this.$t('news.details.header.menu.unpublish'): this.$t('news.details.header.menu.publish');
+    },
+  },
   mounted() {
     $('#UIPortalApplication').parent().click(() => {
       this.actionMenu = false;
     });
   },
+  methods: {
+    confirmAction() {
+      this.$refs.publishConfirmDialog.open();
+    },
+    updatePublishedField() {
+      const publishMessageTime = 5000;
+      const context = this;
+      let updatedNews = null;
+      if (this.newsPublished === false) {
+        updatedNews = {
+          pinned: true,
+        };
+      } else {
+        updatedNews = {
+          pinned: false,
+        };
+      }
+      fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/news/${this.news.newsId}`,{
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        credentials: 'include',
+        method: 'PATCH',
+        body: JSON.stringify(updatedNews)
+      }).then (function() {
+        context.showPublishMessage = true;
+        if (context.newsPublished === false) {
+          context.publishMessage = context.$t('news.publish.success');
+          // eslint-disable-next-line vue/no-mutating-props
+          context.newsPublished = true;
+        } else {
+          context.publishMessage = context.$t('news.unpublish.success');
+          // eslint-disable-next-line vue/no-mutating-props
+          context.newsPublished = false;
+        }
+        setTimeout(function () {
+          context.showPublishMessage = false;
+        }, publishMessageTime);
+      })
+        .catch (function() {
+          context.showPublishMessage = true;
+          context.publishSuccess = false;
+          if (context.newsPublished === false) {
+            context.publishMessage = context.$t('news.publish.error');
+          } else {
+            context.publishMessage = context.$t('news.unpublish.error');
+          }
+          setTimeout(function () {
+            context.publishSuccess = true;
+            context.showPublishMessage = false;
+          }, publishMessageTime);
+        });
+    },
+  }
 };
 </script>
 

--- a/webapp/src/main/webapp/news-details/components/ExoNewsDetailsActivity.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsDetailsActivity.vue
@@ -5,7 +5,7 @@
     :news-id="newsId || sharedNewsId"
     :activity-id="activityId"
     :show-edit-button="showEditButton"
-    :show-pin-button="showPinButton"
+    :show-publish-button="showPublishButton"
     :show-delete-button="showDeleteButton" />
 </template>
 
@@ -45,7 +45,7 @@ export default {
     showEditButton() {
       return this.news && this.news.canEdit;
     },
-    showPinButton() {
+    showPublishButton() {
       return this.news && this.news.canPublish;
     },
   },

--- a/webapp/src/main/webapp/news-details/components/ExoNewsDetailsBody.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsDetailsBody.vue
@@ -156,7 +156,7 @@ export default {
       return this.news && (this.news.authorFullName || this.news.authorDisplayName);
     },
     authorProfileURL() {
-      return this.news && `${eXo.env.portal.context}/${eXo.env.portal.portalName}/profile/${this.news.updater}`;
+      return this.news && `${eXo.env.portal.context}/${eXo.env.portal.portalName}/profile/${this.news.author}`;
     },
     authorAvatarURL() {
       return this.news && (this.news.profileAvatarURL || this.news.authorAvatarUrl);

--- a/webapp/src/main/webapp/news-details/components/ExoNewsDetailsBody.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsDetailsBody.vue
@@ -1,0 +1,265 @@
+<template>
+  <div>
+    <div v-if="archivedNews && !news.canArchive">
+      <div class="userNotAuthorized">
+        <div class="notAuthorizedIconDiv">
+          <img src="/news/images/notauthorized.png" class="iconNotAuthorized">
+        </div>
+        <h3>{{ $t('news.archive.text') }}</h3>
+      </div>
+    </div>
+    <div class="newsDetails-description">
+      <div :class="[illustrationURL ? 'newsDetails-header' : '']" class="newsDetails-header">
+        <div v-if="illustrationURL" class="illustration">
+          <img
+            :src="illustrationURL"
+            class="newsDetailsImage illustrationPicture"
+            alt="News">
+        </div>
+        <div class="newsDetails">
+          <div class="news-top-information d-flex">
+            <div id="titleNews" class="newsTitle newsTitleMobile">
+              <a class="activityLinkColor newsTitleLink">{{ newsTitle }}</a>
+              <div v-if="archivedNews" class="newsArchived">
+                <span class="newsArchiveLabel"> ( {{ $t('news.archive.label') }} ) </span>
+              </div>
+            </div>
+          </div>
+          <div class="newsInformationBackground">
+            <div :class="[showUpdateInfo ? 'news-update-details-header' : 'news-details-header']" class="news-header-content">
+              <div :class="[ showUpdateInfo ? 'newsUpdateInfo' : '']">
+                <div class="activityAvatar avatarCircle">
+                  <a :href="authorProfileURL">
+                    <img :src="authorAvatarURL" class="avatar">
+                  </a>
+                </div>
+              </div>
+              <div id="informationNews" class="newsInformation">
+                <div class="newsAuthor">
+                  <a :href="authorProfileURL" class="newsInformationValue newsAuthorName news-details-information"> {{ authorFullName }} </a>
+                  <span v-if="!hiddenSpace" class="newsInformationLabel"> {{ $t('news.activity.in') }} </span>
+                  <div v-if="!hiddenSpace" class="newsSpace">
+                    <a :href="spaceUrl" class="newsInformationLabel news-details-information">{{ spaceDisplayName }}</a>
+                  </div>
+                  <template v-if="publicationDate">
+                    -
+                    <date-format
+                      :value="publicationDate"
+                      :format="dateFormat"
+                      class="newsInformationValue newsPostedDate news-details-information" />
+                  </template>
+                  <span v-else-if="postedDate" class="newsInformationValue newsPostedDate news-details-information">- {{ postedDate }}</span>
+                </div>
+                <div v-if="showUpdateInfo" class="newsUpdater">
+                  <div v-if="publicationState !== 'staged'">
+                    <span class="newsInformationLabel">{{ $t('news.activity.lastUpdated') }} </span>
+                  </div>
+                  <div v-else>
+                    <span class="newsInformationLabel">{{ $t('news.details.scheduled') }} </span>
+                  </div>
+                  <div>
+                    <template v-if="publicationState !== 'staged' && updatedDate">
+                      <date-format
+                        :value="updatedDate"
+                        :format="dateFormat"
+                        class="newsInformationValue newsUpdatedDate" />
+                    </template>
+                    <template v-else-if="publicationState === 'staged'">
+                      <date-format
+                        :value="scheduleDate"
+                        :format="dateFormat"
+                        class="newsInformationValue newsUpdatedDate" />
+                      <span class="newsInformationValue">-</span>
+                      <date-format
+                        :value="scheduleDate"
+                        :format="dateTimeFormat"
+                        class="newsInformationValue newsUpdatedDate ml-1 me-1" />
+                    </template>
+                    <div v-else-if="news.updatedDate" class="newsInformationValue newsUpdatedDate">{{ news.updatedDate }}</div>
+                    <div v-if="notSameUpdater">
+                      <span class="newsInformationLabel"> {{ $t('news.activity.by') }} </span>
+                      <a :href="updaterProfileURL" class="newsInformationValue newsUpdaterName">{{ updaterFullName }}</a>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div
+            v-if="newsSummary"
+            id="newsSummary"
+            class="summary">
+            <span v-html="newsSummary"></span>
+          </div>
+
+          <div
+            id="newsBody"
+            :class="[!summary ? 'fullDetailsBodyNoSummary' : '']"
+            class="fullDetailsBody clearfix">
+            <span v-html="newsBody"></span>
+          </div>
+
+          <div v-show="attachments && attachments.length" class="newsAttachmentsTitle">
+            {{ $t('news.details.attachments.title') }} ({{ attachments ? attachments.length : 0 }})
+          </div>
+
+          <div v-show="attachments && attachments.length" class="newsAttachments">
+            <div
+              v-for="attachedFile in attachments"
+              :key="attachedFile.id"
+              class="newsAttachment"
+              @click="openPreview(attachedFile)">
+              <exo-attachment-item :file="attachedFile" />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    news: {
+      type: Object,
+      required: false,
+      default: null
+    },
+  },
+  data: () => ({
+    dateFormat: {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    },
+    dateTimeFormat: {
+      hour: '2-digit',
+      minute: '2-digit',
+    },
+  }),
+  computed: {
+    archivedNews() {
+      return this.news && this.news.archived;
+    },
+    illustrationURL() {
+      return this.news && this.news.illustrationURL;
+    },
+    newsTitle() {
+      return this.news && this.news.title;
+    },
+    showUpdateInfo() {
+      return this.updatedDate || (this.news && this.news.updatedDate && this.news.updatedDate  !== 'null');
+    },
+    authorFullName() {
+      return this.news && (this.news.authorFullName || this.news.authorDisplayName);
+    },
+    authorProfileURL() {
+      return this.news && `${eXo.env.portal.context}/${eXo.env.portal.portalName}/profile/${this.news.updater}`;
+    },
+    authorAvatarURL() {
+      return this.news && (this.news.profileAvatarURL || this.news.authorAvatarUrl);
+    },
+    hiddenSpace() {
+      return this.news && this.news.hiddenSpace;
+    },
+    newsBody() {
+      return this.news && this.targetBlank(this.news.body);
+    },
+    updaterFullName() {
+      return this.news && this.news.updater !=='__system' ? this.news.updaterFullName : this.news.authorFullName;
+    },
+    updaterProfileURL() {
+      return this.news && `${eXo.env.portal.context}/${eXo.env.portal.portalName}/profile/${this.news.updater}`;
+    },
+    publicationDate() {
+      return this.news && this.news.publicationDate && this.news.publicationDate.time && new Date(this.news.publicationDate.time);
+    },
+    updatedDate() {
+      return this.news && this.news.updateDate && this.news.updateDate.time && new Date(this.news.updateDate.time);
+    },
+    newsSummary() {
+      return this.news && this.targetBlank(this.news.summary);
+    },
+    spaceDisplayName() {
+      return this.news && this.news.spaceDisplayName;
+    },
+    spaceUrl() {
+      return this.news && this.news.spaceUrl;
+    },
+    postedDate() {
+      return this.news && this.news.postedDate;
+    },
+    summary() {
+      return this.news && this.news.summary;
+    },
+    attachments() {
+      return this.news && this.news.attachments;
+    },
+    publicationState() {
+      return this.news && this.news.publicationState;
+    },
+    notSameUpdater() {
+      return this.news && this.news.updater !=='__system' && this.news.updater !== this.news.author;
+    },
+    scheduleDate() {
+      return this.news && this.news.schedulePostDate;
+    },
+  },
+  methods: {
+    openPreview(attachedFile) {
+      const self = this;
+      window.require(['SHARED/documentPreview'], function(documentPreview) {
+        documentPreview.init({
+          doc: {
+            id: attachedFile.id,
+            repository: 'repository',
+            workspace: 'collaboration',
+            title: attachedFile.name,
+            downloadUrl: `/portal/rest/v1/news/attachments/${attachedFile.id}/file`,
+            openUrl: `/portal/rest/v1/news/attachments/${attachedFile.id}/open`
+          },
+          showComments: false
+        });
+        self.hideDocPreviewComments();
+      });
+    },
+    /**
+     * Hack to hide the document preview comments panel because the document preview component
+     * does not allow to hide it through its API
+     * @returns {void} when the comments panel appeared and has been hidden
+     */
+    hideDocPreviewComments() {
+      const intervalCheck = 100;
+
+      const commentsPanel = document.querySelector('.uiDocumentPreview .commentArea');
+      const collapsedCommentsButton = document.querySelector('.uiDocumentPreview .resizeButton');
+      if (commentsPanel != null && collapsedCommentsButton != null) {
+        commentsPanel.style.display = 'none';
+        collapsedCommentsButton.style.display = 'none';
+        document.querySelector('.uiDocumentPreview').classList += ' collapsed';
+      } else {
+        setTimeout(this.hideDocPreviewComments, intervalCheck);
+      }
+    },
+    targetBlank: function (content) {
+      const internal = location.host + eXo.env.portal.context;
+      const domParser = new DOMParser();
+      const docElement = domParser.parseFromString(content, 'text/html').documentElement;
+      const links = docElement.getElementsByTagName('a');
+      for (const link of links) {
+        let href = link.href.replace(/(^\w+:|^)\/\//, '');
+        if (href.endsWith('/')) {
+          href = href.slice(0, -1);
+        }
+        if (href !== location.host && !href.startsWith(internal)) {
+          link.setAttribute('target', '_blank');
+          link.setAttribute('rel', 'noopener noreferrer');
+        }
+      }
+      return docElement.innerHTML;
+    },
+  }
+};
+</script>

--- a/webapp/src/main/webapp/news-details/components/ExoNewsDetailsTime.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsDetailsTime.vue
@@ -1,0 +1,85 @@
+<template>
+  <div v-if="news" class="d-flex flex-row">
+    <div class="flex-column my-auto">
+      <v-icon x-small class="ms-4 me-1">far fa-clock</v-icon>
+    </div>
+    <div class="flex-column me-1 my-auto">
+      <span>{{ postModeLabel }} </span>
+    </div>
+    <template v-if="publicationDate" class="flex-column my-auto">
+      <date-format
+        :value="publicationDate"
+        :format="dateFormat" />
+    </template>
+    <span v-else-if="postedDate" class="flex-column my-auto">- {{ postedDate }}</span>
+    <template v-else-if="publicationState === 'staged'" class="flex-column my-auto">
+      <date-format
+        :value="scheduleDate"
+        :format="dateFormat" />
+      <span>-</span>
+      <date-format
+        :value="scheduleDate"
+        :format="dateTimeFormat" />
+    </template>
+    <div v-else-if="updatedDate" class="flex-column my-auto">{{ updatedDate }}</div>
+    <div v-if="notSameUpdater" class="ms-1 flex-column me-1 my-auto"> {{ $t('news.activity.by') }}</div>
+    <div v-if="notSameUpdater" class="flex-column my-auto">
+      <a :href="updaterProfileURL">{{ updaterFullName }}</a>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    news: {
+      type: Object,
+      required: false,
+      default: null
+    },
+  },
+  data: () => ({
+    dateFormat: {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    },
+    dateTimeFormat: {
+      hour: '2-digit',
+      minute: '2-digit',
+    },
+  }),
+  computed: {
+    publicationDate() {
+      return this.news && this.news.publicationDate && this.news.publicationDate.time && new Date(this.news.publicationDate.time);
+    },
+    updatedDate() {
+      return this.news && this.news.updateDate && this.news.updateDate.time && new Date(this.news.updateDate.time);
+    },
+    postedDate() {
+      return this.news && this.news.postedDate;
+    },
+    publicationState() {
+      return this.news && this.news.publicationState;
+    },
+    scheduleDate() {
+      return this.news && this.news.schedulePostDate;
+    },
+    notSameUpdater() {
+      return this.news && this.news.updater !=='__system' && this.news.updater !== this.news.author;
+    },
+    updaterProfileURL() {
+      return this.news && `${eXo.env.portal.context}/${eXo.env.portal.portalName}/profile/${this.news.updater}`;
+    },
+    showUpdateInfo() {
+      return this.updatedDate || (this.news && this.news.updatedDate && this.news.updatedDate  !== 'null');
+    },
+    postModeLabel() {
+      return this.publicationState === 'staged' && this.updatedDate ? this.$t('news.details.scheduled') :this.$t('news.activity.lastUpdated');
+    },
+    updaterFullName() {
+      return this.news && this.news.updater !=='__system' ? this.news.updaterFullName : this.news.authorFullName;
+    },
+  }
+};
+</script>

--- a/webapp/src/main/webapp/news-details/components/ExoNewsDetailsToolBar.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsDetailsToolBar.vue
@@ -1,0 +1,89 @@
+<template>
+  <div class="newsDetailsTopBar">
+    <a class="backBtn" :href="backURL"><i class="uiIconBack my-4"></i></a>
+    <v-btn
+      v-if="publicationState === 'staged'"
+      class="btn newsDetailsActionMenu mt-6 mr-2 pull-right"
+      @click="$root.$emit('open-schedule-drawer','editScheduledNews')">
+      {{ $t("news.composer.btn.scheduleArticle") }}
+    </v-btn>
+    <exo-news-details-action-menu
+      v-if="showEditButton && publicationState !== 'staged'"
+      :news="news"
+      :show-edit-button="showEditButton"
+      :show-delete-button="showDeleteButton" />
+    <exo-news-publish
+      v-if="showPublishButton && publicationState !== 'staged'"
+      :news-id="news.newsId"
+      :news-published="news.pinned"
+      :news-archived="archivedNews"
+      :news-title="newsTitle" />
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    news: {
+      type: Object,
+      required: false,
+      default: function() { return new Object(); }
+    },
+    newsId: {
+      type: String,
+      required: false,
+      default: null
+    },
+    activityId: {
+      type: String,
+      required: false,
+      default: null
+    },
+    showEditButton: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
+    showPublishButton: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
+    showDeleteButton: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
+  },
+  data() {
+    return {
+      spaceId: null,
+      updaterIdentity: null,
+      BYTES_IN_MB: 1048576,
+      dateFormat: {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+      },
+      dateTimeFormat: {
+        hour: '2-digit',
+        minute: '2-digit',
+      },
+    };
+  },
+  computed: {
+    backURL() {
+      return this.news && this.news.spaceMember ? this.news.spaceUrl : `${eXo.env.portal.context}/${eXo.env.portal.portalName}`;
+    },
+    archivedNews() {
+      return this.news && this.news.archived;
+    },
+    publicationState() {
+      return this.news && this.news.publicationState;
+    },
+    newsTitle() {
+      return this.news && this.news.title;
+    }
+  },
+};
+</script>

--- a/webapp/src/main/webapp/news-details/components/ExoNewsPublish.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsPublish.vue
@@ -4,17 +4,17 @@
       ref="publishConfirmDialog"
       :title="confirmDialogTitle"
       :message="confirmDialogMessage"
-      :ok-label="$t('news.broadcast.btn.confirm')"
-      :cancel-label="$t('news.broadcast.btn.cancel')"
-      @ok="updatePinnedField" />
+      :ok-label="$t('news.publish.btn.confirm')"
+      :cancel-label="$t('news.publish.btn.cancel')"
+      @ok="updatePublishedField" />
     <a
-      id="newsPinButton"
-      :title="pinLabel"
-      :class="[newsArchived ? 'unauthorizedPin' : '']"
+      id="newsPublishButton"
+      :title="publishLabel"
+      :class="[newsArchived ? 'unauthorizedPublish' : '']"
       class="btn my-5"
       @click="confirmAction">
       <v-icon
-        :class="broadcastArticleClass"
+        :class="publishArticleClass"
         class="fas fa-bullhorn" />
     </a>
   </div>
@@ -46,34 +46,34 @@ export default {
   },
   data() {
     return {
-      showPinMessage: false,
-      messagePin: '',
-      successPin: true,
+      showPublishMessage: false,
+      messagePublish: '',
+      successPublish: true,
     };
   },
   computed: {
-    broadcastArticleClass() {
-      return this.newsPinned ? 'broadcastArticle' : 'unbroadcastArticle';
+    publishArticleClass() {
+      return this.newsPublished ? 'publishArticle' : 'unpublishArticle';
     },
-    pinLabel() {
-      return this.newsPinned && this.$t('news.unbroadcast.action') || this.$t('news.broadcast.action');
+    publishLabel() {
+      return this.newsPublished && this.$t('news.unpublish.action') || this.$t('news.publish.action');
     },
     confirmDialogTitle() {
-      return this.newsPinned && this.$t('news.unbroadcast.action') || this.$t('news.broadcast.action');
+      return this.newsPublished && this.$t('news.unpublish.action') || this.$t('news.publish.action');
     },
     confirmDialogMessage() {
-      return this.newsPinned && this.$t('news.unbroadcast.confirm', {0: this.newsTitle}) || this.$t('news.broadcast.confirm');
+      return this.newsPublished && this.$t('news.unpublish.confirm', {0: this.newsTitle}) || this.$t('news.publish.confirm');
     },
   },
   methods: {
     confirmAction() {
       this.$refs.publishConfirmDialog.open();
     },
-    updatePinnedField: function () {
-      const pinMessageTime = 5000;
+    updatePublishedField: function () {
+      const publishMessageTime = 5000;
       const context = this;
       let updatedNews = null;
-      if (this.newsPinned === false) {
+      if (this.newsPublished === false) {
         updatedNews = {
           pinned: true,
         };
@@ -90,34 +90,34 @@ export default {
         method: 'PATCH',
         body: JSON.stringify(updatedNews)
       }).then (function() {
-        context.showPinMessage = true;
-        if (context.newsPinned === false) {
-          context.messagePin = context.$t('news.broadcast.success');
-          context.pinLabel = context.$t('news.unbroadcast.action');
+        context.showPublishMessage = true;
+        if (context.newsPublished === false) {
+          context.messagePublish = context.$t('news.publish.success');
+          context.publishLabel = context.$t('news.unpublish.action');
           // eslint-disable-next-line vue/no-mutating-props
-          context.newsPinned = true;
+          context.newsPublished = true;
         } else {
-          context.messagePin = context.$t('news.unbroadcast.success');
-          context.pinLabel = context.$t('news.broadcast.action');
+          context.messagePublish = context.$t('news.unpublish.success');
+          context.publishLabel = context.$t('news.publish.action');
           // eslint-disable-next-line vue/no-mutating-props
-          context.newsPinned = false;
+          context.newsPublished = false;
         }
         setTimeout(function () {
-          context.showPinMessage = false;
-        }, pinMessageTime);
+          context.showPublishMessage = false;
+        }, publishMessageTime);
       })
         .catch (function() {
-          context.showPinMessage = true;
-          context.successPin = false;
-          if (context.newsPinned === false) {
-            context.messagePin = context.$t('news.broadcast.error');
+          context.showPublishMessage = true;
+          context.successPublish = false;
+          if (context.newsPublished === false) {
+            context.messagePublish = context.$t('news.publish.error');
           } else {
-            context.messagePin = context.$t('news.unbroadcast.error');
+            context.messagePublish = context.$t('news.unpublish.error');
           }
           setTimeout(function () {
-            context.successPin = true;
-            context.showPinMessage = false;
-          }, pinMessageTime);
+            context.successPublish = true;
+            context.showPublishMessage = false;
+          }, publishMessageTime);
         });
     },
   }

--- a/webapp/src/main/webapp/news-details/components/ExoNewsPublish.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsPublish.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="pinNewsActivity">
+  <div id="publishNewsActivity" class="newsDetailsIcons">
     <exo-confirm-dialog
       ref="publishConfirmDialog"
       :title="confirmDialogTitle"
@@ -33,7 +33,7 @@ export default {
       required: true,
       default: null
     },
-    newsPinned: {
+    newsPublished: {
       type: Boolean,
       required: true,
       default: false

--- a/webapp/src/main/webapp/news-details/components/mobile/ExoNewsDetailsBodyMobile.vue
+++ b/webapp/src/main/webapp/news-details/components/mobile/ExoNewsDetailsBodyMobile.vue
@@ -1,0 +1,129 @@
+<template>
+  <div class="newsContent">
+    <div :title="newsTitle" class="newsDetailsTitle mt-2 pl-2 pr-2 ms-2 font-weight-bold subtitle-1">
+      {{ newsTitle }}
+    </div>
+    <div class="d-flex flex-row pa-2 ms-2">
+      <div v-if="news" class="flex-column">
+        <exo-user-avatar
+          :username="newsAuthor"
+          :fullname="authorFullName"
+          :size="32"
+          :title="newsAuthor"
+          :retrieve-extra-information="false"
+          :labels="labels"
+          class="align-center my-auto text-truncate flex-grow-0 flex" />
+      </div>
+      <v-icon>
+        mdi-chevron-right
+      </v-icon>
+      <div class="flex-column">
+      </div>
+      <div v-if="space" class="flex-column">
+        <exo-space-avatar
+          :space="space"
+          :size="32"
+          :labels="labels"
+          class="align-center my-auto text-truncate flex-grow-0 flex" />
+      </div>
+    </div>
+    <div class="d-flex flex-row caption text-light-color">
+      <exo-news-details-time :news="news" />
+    </div>
+    <div class="d-flex flex-row caption font-italic grey--text text-darken-1 pa-4">
+      <span v-html="newsSummary"></span>
+    </div>
+    <v-divider class="mx-4" />
+    <div class="d-flex flex-row pa-4">
+      <span v-html="newsBody"></span>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    news: {
+      type: Object,
+      required: false,
+      default: null
+    },
+    newsId: {
+      type: String,
+      required: false,
+      default: null
+    },
+    space: {
+      type: Object,
+      required: false,
+      default: null
+    },
+  },
+  data: () => ({
+    dateFormat: {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    },
+    dateTimeFormat: {
+      hour: '2-digit',
+      minute: '2-digit',
+    },
+  }),
+  computed: {
+    newsTitle() {
+      return this.news && this.news.title;
+    },
+    spaceUrl() {
+      return this.news && this.news.spaceAvatarUrl;
+    },
+    labels() {
+      return {
+        CancelRequest: this.$t('profile.CancelRequest'),
+        Confirm: this.$t('profile.Confirm'),
+        Connect: this.$t('profile.Connect'),
+        Ignore: this.$t('profile.Ignore'),
+        RemoveConnection: this.$t('profile.RemoveConnection'),
+        StatusTitle: this.$t('profile.StatusTitle'),
+        join: this.$t('space.join'),
+        leave: this.$t('space.leave'),
+        members: this.$t('space.members'),
+      };
+    },
+    publicationState() {
+      return this.news && this.news.publicationState;
+    },
+    newsSummary() {
+      return this.news && this.targetBlank(this.news.summary);
+    },
+    newsBody() {
+      return this.news && this.targetBlank(this.news.body);
+    },
+    authorFullName() {
+      return this.news && (this.news.authorFullName || this.news.authorDisplayName);
+    },
+    newsAuthor() {
+      return this.news && this.news.author;
+    },
+  },
+  methods: {
+    targetBlank: function (content) {
+      const internal = location.host + eXo.env.portal.context;
+      const domParser = new DOMParser();
+      const docElement = domParser.parseFromString(content, 'text/html').documentElement;
+      const links = docElement.getElementsByTagName('a');
+      for (const link of links) {
+        let href = link.href.replace(/(^\w+:|^)\/\//, '');
+        if (href.endsWith('/')) {
+          href = href.slice(0, -1);
+        }
+        if (href !== location.host && !href.startsWith(internal)) {
+          link.setAttribute('target', '_blank');
+          link.setAttribute('rel', 'noopener noreferrer');
+        }
+      }
+      return docElement.innerHTML;
+    },
+  }
+};
+</script>

--- a/webapp/src/main/webapp/news-details/components/mobile/ExoNewsDetailsToolBarMobile.vue
+++ b/webapp/src/main/webapp/news-details/components/mobile/ExoNewsDetailsToolBarMobile.vue
@@ -29,7 +29,8 @@
         :news="news"
         :show-edit-button="showEditButton"
         :show-delete-button="showDeleteButton"
-        :show-publish-button="showPublishButton" />
+        :show-publish-button="showPublishButton"
+        :news-published="news.pinned" />
     </v-btn>
     <v-btn
       v-if="publicationState === 'staged'"

--- a/webapp/src/main/webapp/news-details/components/mobile/ExoNewsDetailsToolBarMobile.vue
+++ b/webapp/src/main/webapp/news-details/components/mobile/ExoNewsDetailsToolBarMobile.vue
@@ -1,0 +1,78 @@
+<template>
+  <v-app-bar
+    absolute
+    flat
+    :src="illustrationUrl"
+    prominent
+    class="news-details-toolbar">
+    <v-app-bar-nav-icon>
+      <v-btn
+        class="newsDetailsMenuBtn my-2"
+        fab
+        dark
+        x-small
+        :href="backURL">
+        <v-btn icon>
+          <v-icon>mdi-arrow-left</v-icon>
+        </v-btn>
+      </v-btn>
+    </v-app-bar-nav-icon>
+    <v-spacer />
+    <v-btn
+      v-if="publicationState !== 'staged'"
+      class="newsDetailsMenuBtn my-2"
+      fab
+      dark
+      x-small>
+      <exo-news-details-action-menu
+        v-if="showEditButton"
+        :news="news"
+        :show-edit-button="showEditButton"
+        :show-delete-button="showDeleteButton"
+        :show-publish-button="showPublishButton" />
+    </v-btn>
+    <v-btn
+      v-if="publicationState === 'staged'"
+      class="btn newsDetailsActionMenu my-2 pull-right"
+      @click="$root.$emit('open-schedule-drawer','editScheduledNews')">
+      {{ $t("news.composer.btn.scheduleArticle") }}
+    </v-btn>
+  </v-app-bar>
+</template>
+<script>
+export default {
+  props: {
+    news: {
+      type: Object,
+      required: false,
+      default: null
+    },
+    showEditButton: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
+    showPublishButton: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
+    showDeleteButton: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
+  },
+  computed: {
+    backURL() {
+      return this.news && this.news.spaceMember ? this.news.spaceUrl : `${eXo.env.portal.context}/${eXo.env.portal.portalName}`;
+    },
+    illustrationUrl() {
+      return this.news && this.news.illustrationURL ? this.news.illustrationURL : '/news/images/news.png';
+    },
+    publicationState() {
+      return this.news && this.news.publicationState;
+    },
+  },
+};
+</script>

--- a/webapp/src/main/webapp/news-details/initComponents.js
+++ b/webapp/src/main/webapp/news-details/initComponents.js
@@ -1,15 +1,25 @@
 import ExoNewsArchive  from './components/ExoNewsArchive.vue';
 import ExoNewsDetails  from './components/ExoNewsDetails.vue';
 import ExoNewsDetailsActionMenu from './components/ExoNewsDetailsActionMenu.vue';
-import ExoNewsPin from './components/ExoNewsPin.vue';
+import ExoNewsPublish from './components/ExoNewsPublish.vue';
 import ExoNewsDetailsActivity from './components/ExoNewsDetailsActivity.vue';
+import ExoNewsDetailsToolBar from './components/ExoNewsDetailsToolBar.vue';
+import ExoNewsDetailsToolBarMobile from './components/mobile/ExoNewsDetailsToolBarMobile.vue';
+import ExoNewsDetailsBodyMobile from './components/mobile/ExoNewsDetailsBodyMobile.vue';
+import ExoNewsDetailsBody from './components/ExoNewsDetailsBody.vue';
+import ExoNewsDetailsTime from './components/ExoNewsDetailsTime.vue';
 
 const components = {
   'exo-news-archive': ExoNewsArchive,
   'exo-news-details': ExoNewsDetails,
   'exo-news-details-activity': ExoNewsDetailsActivity,
   'exo-news-details-action-menu': ExoNewsDetailsActionMenu,
-  'exo-news-pin': ExoNewsPin,
+  'exo-news-publish': ExoNewsPublish,
+  'exo-news-details-toolbar': ExoNewsDetailsToolBar,
+  'exo-news-details-toolbar-mobile': ExoNewsDetailsToolBarMobile,
+  'exo-news-details-body-mobile': ExoNewsDetailsBodyMobile,
+  'exo-news-details-body': ExoNewsDetailsBody,
+  'exo-news-details-time': ExoNewsDetailsTime,
 };
 
 for (const key in components) {

--- a/webapp/src/main/webapp/news-details/main.js
+++ b/webapp/src/main/webapp/news-details/main.js
@@ -40,7 +40,7 @@ export function init(params) {
           newsId: params.news.newsId,
           activityId: params.activityId,
           showEditButton: params.showEditButton,
-          showPinButton: params.showPinInput,
+          showPublishButton: params.showPinInput,
           showDeleteButton: params.news.canDelete,
         };
       },
@@ -50,7 +50,7 @@ export function init(params) {
                     :news-id="newsId"
                     :activity-id="activityId"
                     :show-edit-button="showEditButton"
-                    :show-pin-button="showPinButton"
+                    :show-publish-button="showPublishButton"
                     :show-delete-button="showDeleteButton"/>
                  </v-app>`,
       i18n,

--- a/webapp/src/main/webapp/news/components/ExoNewsDetailsActionMenuApp.vue
+++ b/webapp/src/main/webapp/news/components/ExoNewsDetailsActionMenuApp.vue
@@ -1,0 +1,83 @@
+<template>
+  <v-menu
+    v-model="actionMenu"
+    eager
+    bottom
+    left
+    offset-y
+    min-width="108px"
+    class="px-0 text-right mx-2">
+    <template #activator="{ on, attrs }">
+      <v-btn
+        v-bind="attrs"
+        class="newsDetailsActionMenu pull-right"
+        icon
+        v-on="on">
+        <v-icon>mdi-dots-vertical</v-icon>
+      </v-btn>
+    </template>
+
+    <v-list>
+      <v-list-item v-if="showEditButton" @click="$emit('edit')">
+        <v-list-item-title>
+          {{ $t('news.details.header.menu.edit') }}
+        </v-list-item-title>
+      </v-list-item>
+      <v-list-item v-if="showShareButton && news.activityId" @click="$root.$emit('activity-share-drawer-open', news.activityId)">
+        <v-list-item-title>
+          {{ $t('news.details.header.menu.share') }}
+        </v-list-item-title>
+      </v-list-item>
+      <v-list-item v-if="showResumeButton" @click="$emit('edit')">
+        <v-list-item-title>
+          {{ $t('news.details.header.menu.resume') }}
+        </v-list-item-title>
+      </v-list-item>
+      <v-list-item v-if="showDeleteButton" @click="$emit('delete')">
+        <v-list-item-title>
+          {{ $t('news.details.header.menu.delete') }}
+        </v-list-item-title>
+      </v-list-item>
+    </v-list>
+  </v-menu>
+</template>
+
+<script>
+export default {
+  props: {
+    news: {
+      type: Object,
+      required: false,
+      default: null
+    },
+    showShareButton: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
+    showEditButton: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
+    showResumeButton: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
+    showDeleteButton: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
+  },
+  data: () => ({
+    actionMenu: null,
+  }),
+  mounted() {
+    $('#UIPortalApplication').parent().click(() => {
+      this.actionMenu = false;
+    });
+  },
+};
+</script>

--- a/webapp/src/main/webapp/news/components/NewsApp.vue
+++ b/webapp/src/main/webapp/news/components/NewsApp.vue
@@ -85,7 +85,7 @@
               v-if="news.activities && news.activities.split(';')[1]"
               :news-id="news.newsId"
               :activities="news.activities" />
-            <exo-news-details-action-menu
+            <exo-news-details-action-menu-app
               v-if="!news.schedulePostDate"
               :news="news"
               :show-edit-button="news.canEdit && !isDraftsFilter"

--- a/webapp/src/main/webapp/news/initComponents.js
+++ b/webapp/src/main/webapp/news/initComponents.js
@@ -5,6 +5,7 @@ import NewsFilterSpaceDrawer from './components/NewsFilterSpaceDrawer.vue';
 import NewsFilterSpaceItem from './components/NewsFilterSpaceItem.vue';
 import NewsFilterSpaceList from './components/NewsFilterSpaceList.vue';
 import NewsFilterSpaceSearch from './components/NewsFilterSpaceSearch.vue';
+import ExoNewsDetailsActionMenuApp from './components/ExoNewsDetailsActionMenuApp.vue';
 
 const components = {
   'news-app': NewsApp,
@@ -14,6 +15,7 @@ const components = {
   'news-filter-space-item': NewsFilterSpaceItem,
   'news-filter-space-list': NewsFilterSpaceList,
   'news-filter-space-search': NewsFilterSpaceSearch,
+  'exo-news-details-action-menu-app': ExoNewsDetailsActionMenuApp,
 };
 
 for (const key in components) {

--- a/webapp/src/main/webapp/skin/less/news.less
+++ b/webapp/src/main/webapp/skin/less/news.less
@@ -12,7 +12,7 @@
 /*============== Activity News ====================*/
 
 .VuetifyApp {
-  #newsDetail {
+  #newsDetailApp {
     padding: 10px 8%;
     .articleNotFound {
       text-align: center;
@@ -29,8 +29,26 @@
       }
     }
   }
-  #newsDetails .newsDetailsActionMenu {
-    margin: 20px 20px 13px 0;
+  #newsDetails {
+    .newsDetailsTitle {
+      display: -webkit-box;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+      word-break: break-word;
+    }
+    #newsFullDetails {
+      .newsContent {
+        background-color: @baseBackground;
+      }
+    }
+    .newsDetailsActionMenu {
+      margin: 20px 20px 13px 0;
+    }
+    .newsDetailsMenuBtn {
+      color: @grayDark;
+      opacity: 0.7;
+    }
   }
   .newsDetailsIcons {
     top: -9px;
@@ -308,7 +326,7 @@
           font-size: 12px;
 
           .newsAuthor {
-            display: inline-flex;
+            display: flex;
 
             .newsAuthorName {
               color: black !important;
@@ -2872,6 +2890,10 @@
   margin-top: 21px;
 }
 
+.news-details-toolbar {
+  position: inherit!important;
+}
+
 /*====================== Responsive ==========================*/
 
 @media screen and (max-width: 480px) {
@@ -3028,10 +3050,6 @@
     max-height: 100% !important;
   }
 
-  .illustration {
-    margin-top: 50px;
-  }
-
   #newsDetails {
     .newsInformation {
       margin-left: 13px ~'; /** orientation=lt */ ';
@@ -3115,10 +3133,6 @@
     position: absolute;
     top: 0;
     width: 100%;
-  }
-
-  .newsDetails-header {
-    margin-top: 10%;
   }
 
   #newsDetails {
@@ -3851,6 +3865,16 @@ p.caption-title:after {
   }
   .noNewsImage {
     display: none;
+  }
+}
+@media (max-width: 959px) {
+  .VuetifyApp {
+    #newsDetailApp {
+      padding: 0;
+    }
+    #newsDetails .newsDetailsActionMenu {
+      margin: 0;
+    }
   }
 }
 input.ignore-vuetify-classes.datePickerText.flex-grow-0 {

--- a/webapp/src/main/webapp/skin/less/news.less
+++ b/webapp/src/main/webapp/skin/less/news.less
@@ -54,7 +54,7 @@
     top: -9px;
     width: 100%;
     text-align: center;
-    #newsPinButton {
+    #newsPublishButton {
       border: none !important;
       float: right ~'; /** orientation=lt */ ';
       float: left ~'; /** orientation=rt */ ';
@@ -62,7 +62,7 @@
         font-size: 18px;
       }
     }
-    &.unauthorizedPin {
+    &.unauthorizedPublish {
       cursor: not-allowed;
     }
     .uiIconPin {
@@ -72,10 +72,10 @@
     .uiIconPin:before {
       content: "\eb54";
     }
-    .broadcastArticle {
+    .publishArticle {
       color: @primaryColorDefault;
     }
-    .unbroadcastArticle {
+    .unpublishArticle {
       color: @greyColorLighten1Default;
     }
   }
@@ -104,7 +104,7 @@
     background-color: #f9fafc;
   }
 
-  .unauthorizedPin {
+  .unauthorizedPublish {
     cursor: not-allowed;
     color: @headingColor;
     padding-left: 10px ~'; /** orientation=lt */ ';
@@ -624,14 +624,14 @@
         margin-left: 10px ~'; /** orientation=rt */ ';
         cursor: pointer;
 
-        #newsPinButton {
+        #newsPublishButton {
           float: right ~'; /** orientation=lt */ ';
           float: left ~'; /** orientation=rt */ ';
           i {
             font-size: 18px;
           }
 
-          &.unauthorizedPin {
+          &.unauthorizedPublish {
             cursor: not-allowed;
           }
 
@@ -645,11 +645,11 @@
             content: "\eb54";
           }
 
-          .broadcastArticle {
+          .publishArticle {
             color: @primaryColorDefault;
           }
 
-          .unbroadcastArticle {
+          .unpublishArticle {
             color: @greyColorLighten1Default;
           }
         }
@@ -687,7 +687,7 @@
         }
 
         #newsUpdateAndPost {
-          &.unauthorizedPin {
+          &.unauthorizedPublish {
             cursor: not-allowed;
           }
         }
@@ -1344,7 +1344,7 @@
         border-color: #fff;
         padding: 0;
 
-        &.unauthorizedPin {
+        &.unauthorizedPublish {
           cursor: not-allowed;
         }
 


### PR DESCRIPTION

Prior to change, news details was created in one component and when hovering the author, it displays a popover with information about the last modifier. After this change, in order to make code more maintainable and to implement mobile view, we refactor the code by splitting into components specific to mobile view, others specific to desktop view and other common components to mobile and desktop views. We have also fixed the popover problem.
