### PR TITLE
Task-49272: Fix the insert video and image in popup option

### DIFF
--- a/webapp/src/main/webapp/js/ckeditor/plugins/video/dialogs/videoDialog.js
+++ b/webapp/src/main/webapp/js/ckeditor/plugins/video/dialogs/videoDialog.js
@@ -41,7 +41,7 @@ CKEDITOR.dialog.add( 'videoDialog', function( editor ) {
         onLoad: function() {
           const parentElement = this.getElement();
 
-          parentElement.addClass('videoDialog').addClass('uiPopup');
+          parentElement.addClass('videoDialog').addClass('uiPopupNews');
           parentElement.removeClass('cke_reset_all');
           parentElement.findOne('.cke_dialog_title').$.className += ' popupHeader';
           parentElement.findOne('.cke_dialog_close_button').$.className = 'uiIconClose cke_dialog_close_button';
@@ -52,7 +52,8 @@ CKEDITOR.dialog.add( 'videoDialog', function( editor ) {
           parentElement.findOne('.videoURL').$.placeholder = editor.lang.video.dialogURLInputPlaceholder;
 
           const backgroundMask = document.querySelector('.cke_dialog_background_cover');
-          backgroundMask.classList.add('uiPopupWrapper');
+          backgroundMask.classList.remove('uiPopupWrapper');
+          backgroundMask.classList.add('uiPopupWrapperNews');
           backgroundMask.style.backgroundColor = '';
           backgroundMask.style.opacity = '';
         },

--- a/webapp/src/main/webapp/skin/less/news.less
+++ b/webapp/src/main/webapp/skin/less/news.less
@@ -968,11 +968,7 @@
       }
 
       .uiIconClose {
-        top: 15px;
-        right: 15px ~'; /** orientation=lt */ ';
-        left: 15px ~'; /** orientation=rt */ ';
-        width: 30px;
-        height: 30px;
+        display: none;
       }
 
       .uiIconClose:before {
@@ -3975,4 +3971,37 @@ input.ignore-vuetify-classes.datePickerText.flex-grow-0 {
     line-height: 1.2;
     color: @grayDark;
   }
+}
+
+.videoDialog {
+  .uiPopupNews {
+    left: auto!important;
+    right: auto!important;
+    bottom: auto!important;
+    z-index: 10000!important;
+    position: fixed!important;
+    border: @tabNormalLinkHoverBorderBottom;
+  }
+  .cke_dialog .cke_dialog_body .cke_dialog_title {
+    background-color: @baseBackgroundDefault;
+    -webkit-box-shadow: none;
+    -moz-box-shadow: none;
+    box-shadow: none;
+    border-bottom: @baseBackgroundDefault;
+    margin-bottom: 7px;
+    -webkit-border-radius: 4px 4px 0 0;
+    -moz-border-radius: 4px 4px 0 0;
+    border-radius: 4px 4px 0 0;
+    padding: 8px 10px 8px 15px;
+    font-size: 18px;
+    font-weight: bold;
+
+  }
+}
+
+.cke_dialog_background_cover.uiPopupWrapperNews {
+  overflow-y: auto;
+  background: @baseColorDefault;
+  opacity: 0.2;
+  z-index: 0!important;
 }

--- a/webapp/src/main/webapp/skin/less/news.less
+++ b/webapp/src/main/webapp/skin/less/news.less
@@ -3995,7 +3995,6 @@ input.ignore-vuetify-classes.datePickerText.flex-grow-0 {
     padding: 8px 10px 8px 15px;
     font-size: 18px;
     font-weight: bold;
-
   }
 }
 

--- a/webapp/src/main/webapp/skin/less/news.less
+++ b/webapp/src/main/webapp/skin/less/news.less
@@ -1004,8 +1004,8 @@
             line-height: 35px;
             position: absolute;
             top: 0px;
-            right: 8px ~'; /** orientation=lt */ ';
-            left: 8px ~'; /** orientation=rt */ ';
+            right: -2px ~'; /** orientation=lt */ ';
+            left: -2px ~'; /** orientation=rt */ ';
           }
 
           .uiIconVideoURLOk:before {


### PR DESCRIPTION
Prior to this change, the ckeditor dialog isn't displayed well, this is due to overriding styles from `core.css`.
In order to solve this problem, we add a specific style to dialog to override previous styling from (core and enterprise).