### PR TITLE
Task-49413: Remove Semantic Media Embed plugin from news editor 

### DIFF
--- a/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
+++ b/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
@@ -409,7 +409,7 @@ export default {
       $('textarea#newsContent').ckeditor({
         customConfig: '/commons-extension/ckeditorCustom/config.js',
         extraPlugins: extraPlugins,
-        removePlugins: 'image,confirmBeforeReload,maximize,resize',
+        removePlugins: 'image,confirmBeforeReload,maximize,resize,embedsemantic',
         allowedContent: true,
         typeOfRelation: 'mention_activity_stream',
         spaceURL: self.spaceURL,


### PR DESCRIPTION
We need to Remove Semantic Media Embed plugin and keep only the inserting image and video options in news editor.