### PR TITLE
Task-49591: The mention updated is displayed in the article's details even if not updated.

### DIFF
--- a/webapp/src/main/webapp/news-details/components/ExoNewsDetailsBody.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsDetailsBody.vue
@@ -50,15 +50,15 @@
                   </template>
                   <span v-else-if="postedDate" class="newsInformationValue newsPostedDate news-details-information">- {{ postedDate }}</span>
                 </div>
-                <div v-if="showUpdateInfo" class="newsUpdater">
-                  <div v-if="publicationState !== 'staged'">
+                <div class="newsUpdater">
+                  <div v-if="publicationState !== 'staged' && showUpdateInfo">
                     <span class="newsInformationLabel">{{ $t('news.activity.lastUpdated') }} </span>
                   </div>
-                  <div v-else>
+                  <div v-else-if="publicationState === 'staged'">
                     <span class="newsInformationLabel">{{ $t('news.details.scheduled') }} </span>
                   </div>
                   <div>
-                    <template v-if="publicationState !== 'staged' && updatedDate">
+                    <template v-if="publicationState !== 'staged' && updatedDate && showUpdateInfo">
                       <date-format
                         :value="updatedDate"
                         :format="dateFormat"
@@ -150,7 +150,7 @@ export default {
       return this.news && this.news.title;
     },
     showUpdateInfo() {
-      return this.updatedDate || (this.news && this.news.updatedDate && this.news.updatedDate  !== 'null');
+      return this.news && this.news.updateDate && this.news.updateDate !== 'null' && this.news.publicationDate && this.news.publicationDate!== 'null' && this.news.updateDate.time > this.news.publicationDate.time;
     },
     authorFullName() {
       return this.news && (this.news.authorFullName || this.news.authorDisplayName);

--- a/webapp/src/main/webapp/news-details/components/ExoNewsDetailsTime.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsDetailsTime.vue
@@ -75,9 +75,6 @@ export default {
     updaterProfileURL() {
       return this.news && `${eXo.env.portal.context}/${eXo.env.portal.portalName}/profile/${this.news.updater}`;
     },
-    showUpdateInfo() {
-      return this.updatedDate || (this.news && this.news.updatedDate && this.news.updatedDate  !== 'null');
-    },
     postModeLabel() {
       return this.publicationState === 'staged' && this.updatedDate ? this.$t('news.details.scheduled') :this.$t('news.activity.lastUpdated');
     },


### PR DESCRIPTION
Before this fix, even if the news isn't yet updated or modified, the mention updated date is displayed in the article's details.
This fix will ensure that the mention updated date is displayed only if the news is updated.