### PR TITLE
Task-47951: Update News Editor, CKeditor toolbar and placeholder colors

### DIFF
--- a/webapp/src/main/webapp/skin/less/news.less
+++ b/webapp/src/main/webapp/skin/less/news.less
@@ -726,6 +726,7 @@
     display: block;
     box-shadow: 0 3px 5px hsla(0, 1%, 43%, 0.8);
     z-index: 10;
+    filter: opacity(0.5);
 
     .cke_top {
       height: auto;
@@ -881,6 +882,9 @@
             font-family: Helvetica, regular, sans-serif;
             font-size: 16pt;
             color: @grayLight;
+            &::placeholder{
+              color: @greyColorLighten1Default!important;
+            }
           }
         }
 
@@ -893,6 +897,14 @@
           font-family: Helvetica, regular, sans-serif;
           font-size: 21pt;
           color: @grayDark;
+          &::placeholder{
+            color: @greyColorLighten1Default!important;
+          }
+        }
+        #newsContent {
+          &::placeholder{
+            color: @greyColorLighten1Default!important;
+          }
         }
       }
 


### PR DESCRIPTION
Prior to this change, News Editor, CKeditor toolbar and placeholder colors are too ugly and not comfortable on the eyes. After this change these colors are updated.