### PR TITLE
Task-48609: Add the possibility to share a draft with redactors and space managers.

### DIFF
--- a/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
@@ -97,6 +97,10 @@ public class NewsServiceImpl implements NewsService {
 
   private final static String      PLATFORM_ADMINISTRATORS_GROUP   = "/platform/administrators";
 
+  public static final String       NEWS_DRAFT_VISIBILITY_MIXIN_TYPE              = "mix:draftVisibility";
+
+  public static final String       NEWS_DRAFT_VISIBILE_MIXIN_PROP         = "exo:draftVisible";
+
   public static final String       MIX_NEWS_MODIFIERS              = "mix:newsModifiers";
 
   public static final String       MIX_NEWS_MODIFIERS_PROP         = "exo:newsModifiersIds";
@@ -358,6 +362,10 @@ public class NewsServiceImpl implements NewsService {
         attachIllustration(newsNode, news.getUploadId());
       } else if ("".equals(news.getUploadId())) {
         removeIllustration(newsNode);
+      }
+      //draft visible
+      if (newsNode.hasProperty(NEWS_DRAFT_VISIBILE_MIXIN_PROP)) {
+        newsNode.setProperty(NEWS_DRAFT_VISIBILE_MIXIN_PROP, String.valueOf(news.isDraftVisible()));
       }
 
       // attachments
@@ -713,6 +721,11 @@ public class NewsServiceImpl implements NewsService {
     if (originalNode.hasProperty("exo:spaceId")) {
       news.setSpaceId(node.getProperty("exo:spaceId").getString());
     }
+    if (originalNode.hasProperty(NEWS_DRAFT_VISIBILE_MIXIN_PROP)) {
+      news.setDraftVisible(Boolean.valueOf(node.getProperty(NEWS_DRAFT_VISIBILE_MIXIN_PROP).getString()));
+    } else {
+      news.setDraftVisible(false);
+    }
     news.setCanEdit(canEditNews(news.getAuthor(),news.getSpaceId()));
     news.setCanDelete(canDeleteNews(news.getAuthor(),news.getSpaceId()));
     news.setCanPublish(canPublishNews());
@@ -960,6 +973,10 @@ public class NewsServiceImpl implements NewsService {
     newsDraftNode.setProperty("exo:pinned", false);
     newsDraftNode.setProperty("exo:archived", false);
     newsDraftNode.setProperty("exo:spaceId", news.getSpaceId());
+    if (newsDraftNode.canAddMixin(NEWS_DRAFT_VISIBILITY_MIXIN_TYPE) && !newsDraftNode.hasProperty(NEWS_DRAFT_VISIBILE_MIXIN_PROP)) {
+      newsDraftNode.addMixin(NEWS_DRAFT_VISIBILITY_MIXIN_TYPE);
+    }
+    newsDraftNode.setProperty(NEWS_DRAFT_VISIBILE_MIXIN_PROP, String.valueOf(news.isDraftVisible()));
 
     Lifecycle lifecycle = publicationManager.getLifecycle("newsLifecycle");
     String lifecycleName = wCMPublicationService.getWebpagePublicationPlugins()

--- a/services/src/main/java/org/exoplatform/news/model/News.java
+++ b/services/src/main/java/org/exoplatform/news/model/News.java
@@ -75,6 +75,8 @@ public class News {
 
   private String               authorAvatarUrl;
 
+  private boolean              draftVisible;
+
   private boolean              canEdit;
 
   private boolean              canDelete;
@@ -355,6 +357,14 @@ public class News {
 
   public void setCanEdit(boolean canEdit) {
     this.canEdit = canEdit;
+  }
+
+  public boolean isDraftVisible() {
+    return draftVisible;
+  }
+
+  public void setDraftVisible(boolean draftVisible) {
+    this.draftVisible = draftVisible;
   }
 
   public boolean isCanDelete() {

--- a/services/src/main/java/org/exoplatform/news/rest/NewsRestResourcesV1.java
+++ b/services/src/main/java/org/exoplatform/news/rest/NewsRestResourcesV1.java
@@ -458,6 +458,7 @@ public class NewsRestResourcesV1 implements ResourceContainer, Startable {
       news.setAttachments(updatedNews.getAttachments());
       news.setPublicationState(updatedNews.getPublicationState());
       news.setUpdaterFullName(updatedNews.getUpdaterFullName());
+      news.setDraftVisible(updatedNews.isDraftVisible());
 
       if (updatedNews.isPinned() != news.isPinned()) {
         org.exoplatform.services.security.Identity currentIdentity = ConversationState.getCurrent().getIdentity();

--- a/services/src/main/resources/locale/portlet/news/News_en.properties
+++ b/services/src/main/resources/locale/portlet/news/News_en.properties
@@ -43,6 +43,10 @@ news.composer.modularity.publish=Publishing options
 news.composer.user.publish=Publish the article for all users
 news.composer.user.publish.info=This article will be visible for all internal users even if they are not members of the space
 news.composer.modularity.post=Scheduling options
+news.composer.shared= Shared
+news.composer.private=Private
+news.composer.alert.share.draft.success=The draft is shared with the space's managers and redactors.
+news.composer.alert.unshare.draft.success=This draft is no longer shared with the space managers and redactors.
 
 news.composer.attachments.header=Attach files
 news.composer.attachments.drop=Drop files here

--- a/services/src/main/resources/locale/portlet/news/News_fr.properties
+++ b/services/src/main/resources/locale/portlet/news/News_fr.properties
@@ -43,6 +43,10 @@ news.composer.modularity.publish=Modalit\u00E9s de diffusion
 news.composer.user.publish=Diffuser l'article \u00E0 tous les utilisateurs
 news.composer.user.publish.info=Cet article sera visible \u00E0 tous les utilisateurs internes m\u00EAme s'ils ne sont pas membres de l'espace
 news.composer.modularity.post=Modalit\u00E9s de publication
+news.composer.shared=Partag\u00E9
+news.composer.private=Priv\u00E9
+news.composer.alert.share.draft.success=Le brouillon est partag\u00E9 avec les gestionnaires et les r\u00E9dacteurs de l'espace.
+news.composer.alert.unshare.draft.success=Ce brouillon n'est plus partag\u00E9 avec les responsables et les r\u00E9dacteurs de l'espace.
 
 news.composer.attachments.header=Attacher un fichier
 news.composer.attachments.drop=D\u00E9posez vos fichiers ici

--- a/webapp/src/main/webapp/WEB-INF/conf/news/jcr/news-nodetypes.xml
+++ b/webapp/src/main/webapp/WEB-INF/conf/news/jcr/news-nodetypes.xml
@@ -56,4 +56,11 @@
     </propertyDefinition>
     </propertyDefinitions>
   </nodeType>
+  <nodeType name="mix:draftVisibility" isMixin="true" hasOrderableChildNodes="false" primaryItemName="">
+    <propertyDefinitions>
+      <propertyDefinition name="exo:draftVisible" requiredType="String" autoCreated="false" mandatory="false" onParentVersion="COPY" protected="false" multiple="false">
+        <valueConstraints/>
+      </propertyDefinition>
+    </propertyDefinitions>
+  </nodeType>
 </nodeTypes>

--- a/webapp/src/main/webapp/components/snackbar/ExoNewsNotificationAlerts.vue
+++ b/webapp/src/main/webapp/components/snackbar/ExoNewsNotificationAlerts.vue
@@ -44,6 +44,21 @@ export default {
         });
       }
     });
+    this.$root.$on('update-draft-visibility', status => {
+      if (status) {
+        const message = this.$t('news.composer.alert.share.draft.success');
+        this.$root.$emit('news-notification-alert', {
+          message,
+          type: 'info',
+        });
+      } else {
+        const message = this.$t('news.composer.alert.unshare.draft.success');
+        this.$root.$emit('news-notification-alert', {
+          message,
+          type: 'info',
+        });
+      }
+    });
     this.$root.$on('activity-shared', (activityId, spaces) => {
       if (activityId && spaces && spaces.length > 0) {
         const spacesList = spaces.map(space => space.displayName);

--- a/webapp/src/main/webapp/skin/less/news.less
+++ b/webapp/src/main/webapp/skin/less/news.less
@@ -614,6 +614,23 @@
     width: 100%;
     z-index: 10;
     background-color: #FFFFFF;
+
+    .selectMenuClass{
+      width: 110px;
+      padding-top: 5px;
+      .v-menu__content{
+        top: 40px!important;
+      }
+      .v-input__control{
+        .v-input__slot {
+          box-shadow: none!important;
+        }
+      }
+    }
+    .DraftVisibleInput{
+      max-width: 80px;
+      color: @grayDark;
+    }
     .newsFormButtons {
       display: inline-flex;
       flex-wrap: wrap;


### PR DESCRIPTION
Prior to this change, it is not possible to share a draft article with anyone before posting it, the article is private and visible only for the author.
After this change, will ensure that the current author of the draft can select an option (shared or private):
- The share option makes the draft article accessible from news app for all redactors and managers of spaces if the space is redactional, so they can edit the shared draft article.
- The private option makes the draft visible only for the author.
- Only the draft article author is able to change the draft visibility, others can just see the current state.