### PR TITLE
Task-49006_49602: Make publish option editable when the news.publishTargeting feature flag is disabled

### DIFF
--- a/webapp/src/main/webapp/schedule-news-drawer/components/ExoScheduleNewsDrawer.vue
+++ b/webapp/src/main/webapp/schedule-news-drawer/components/ExoScheduleNewsDrawer.vue
@@ -72,7 +72,6 @@
               <div class="d-flex flex-row">
                 <v-switch
                   v-model="publish"
-                  :disabled="!allowPublishTargeting"
                   inset
                   dense
                   class="my-0 ms-3" />
@@ -107,7 +106,7 @@
                 <v-btn
                   class="btn btn-primary me-4"
                   outlined
-                  :disabled="disableTargetOption"
+                  :disabled="allowPublishTargeting && disableTargetOption"
                   @click="nextStep">
                   {{ $t('news.composer.stepper.continue') }}
                   <v-icon size="18" class="ms-2">


### PR DESCRIPTION

Prior to this change, when the news.publishTargeting feature flag is disabled, we can't change the publish option. After this change, we make the publish option edition possible regardless the news.publishTargeting feature flag value.