### PR TITLE
MAINT-50429: Fix updating inserted images when editing an article (#322)

### DIFF
--- a/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
+++ b/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
@@ -893,7 +893,7 @@ export default {
         updatedNews.uploadId = '';
       }
 
-      return this.$newsServices.updateNews(updatedNews).then((createdNews) => {
+      return this.$newsServices.updateNews(updatedNews, post).then((createdNews) => {
         if (this.news.body !== createdNews.body) {
           this.imagesURLs = this.extractImagesURLsDiffs(this.news.body, createdNews.body);
         }

--- a/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
+++ b/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
@@ -890,7 +890,12 @@ export default {
         updatedNews.uploadId = '';
       }
 
-      return this.$newsServices.updateNews(updatedNews, post).then(() => this.draftSavingStatus = this.$t('news.composer.draft.savedDraftStatus'));
+      return this.$newsServices.updateNews(updatedNews).then((createdNews) => {
+        if (this.news.body !== createdNews.body) {
+          this.imagesURLs = this.extractImagesURLsDiffs(this.news.body, createdNews.body);
+        }
+      }).then(() => this.$emit('draftUpdated'))
+        .then(() => this.draftSavingStatus = this.$t('news.composer.draft.savedDraftStatus'));
     },
     goBack() {
       if ( history.length > 1) {


### PR DESCRIPTION
ISSUE: When editing the news body there was no save of images urls diff and were always set to the default composer url image
before processing the images.
FIX: Updating the images Urls diff when editing an article and processing the images.