### PR TITLE
Task-50717: Fix exceptions when creating news

### DIFF
--- a/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
@@ -517,7 +517,7 @@ public class NewsServiceImpl implements NewsService {
 
     newsNode.setProperty("exo:pinned", true);
     newsNode.save();
-    NewsUtils.broadcastEvent(NewsUtils.PUBLISH_NEWS, news.getId(), getCurrentUserId());
+    NewsUtils.broadcastEvent(NewsUtils.PUBLISH_NEWS, news.getId(), news);
     sendNotification(news, NotificationConstants.NOTIFICATION_CONTEXT.PUBLISH_IN_NEWS, session);
   }
 

--- a/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
@@ -115,6 +115,8 @@ public class NewsServiceImpl implements NewsService {
 
   private static final String      LAST_PUBLISHER                   = "publication:lastUser";
 
+  private static final String      USER_SYSTEM                      = "__system";
+
   private RepositoryService        repositoryService;
 
   private SessionProviderService   sessionProviderService;
@@ -223,7 +225,7 @@ public class NewsServiceImpl implements NewsService {
     if (news.isPinned()) {
       pinNews(news.getId());
     }
-    NewsUtils.broadcastEvent(NewsUtils.POST_NEWS, news.getId(), news.getAuthor());
+    NewsUtils.broadcastEvent(NewsUtils.POST_NEWS_ARTICLE, news.getId(), news);
     return news;
   }
 
@@ -239,6 +241,7 @@ public class NewsServiceImpl implements NewsService {
     if (news.isPinned()) {
       pinNews(news.getId());
     }
+    NewsUtils.broadcastEvent(NewsUtils.POST_NEWS_ARTICLE, news.getId(), news);
     return news;
   }
 
@@ -860,9 +863,14 @@ public class NewsServiceImpl implements NewsService {
     activity.setTemplateParams(templateParams);
 
     activityManager.saveActivityNoReturn(spaceIdentity, activity);
-
     updateNewsActivities(activity, news, session);
-    NewsUtils.broadcastEvent(NewsUtils.POST_NEWS, getCurrentUserId(), news);
+    String username = null;
+    if (StringUtils.equals(session.getUserID(), USER_SYSTEM)) {
+      username = news.getAuthor();
+    } else {
+      username = getCurrentUserId();
+    }
+    NewsUtils.broadcastEvent(NewsUtils.POST_NEWS, username, news);
   }
 
   private String getNodeRelativePath(Calendar now) {

--- a/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
@@ -1221,11 +1221,13 @@ public class NewsServiceImpl implements NewsService {
   @Override
   public void updateNewsActivity(News news, boolean post) {
     ExoSocialActivity activity = activityManager.getActivity(news.getActivityId());
-    if(post) {
-      activity.setUpdated(System.currentTimeMillis());
+    if(activity != null) {
+      if (post) {
+        activity.setUpdated(System.currentTimeMillis());
+      }
+      activity.isHidden(news.isActivityPosted());
+      activityManager.updateActivity(activity, true);
     }
-    activity.isHidden(news.isActivityPosted());
-    activityManager.updateActivity(activity, true);
   }
 
   /**

--- a/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
@@ -864,13 +864,13 @@ public class NewsServiceImpl implements NewsService {
 
     activityManager.saveActivityNoReturn(spaceIdentity, activity);
     updateNewsActivities(activity, news, session);
-    String username = null;
+    String newsPoster = null;
     if (StringUtils.equals(session.getUserID(), USER_SYSTEM)) {
-      username = news.getAuthor();
+      newsPoster = news.getAuthor();
     } else {
-      username = getCurrentUserId();
+      newsPoster = getCurrentUserId();
     }
-    NewsUtils.broadcastEvent(NewsUtils.POST_NEWS, username, news);
+    NewsUtils.broadcastEvent(NewsUtils.POST_NEWS, newsPoster, news);
   }
 
   private String getNodeRelativePath(Calendar now) {

--- a/services/src/main/java/org/exoplatform/news/NewsUtils.java
+++ b/services/src/main/java/org/exoplatform/news/NewsUtils.java
@@ -22,23 +22,25 @@ import org.exoplatform.social.core.space.spi.SpaceService;
 
 public class NewsUtils {
 
-  private static final Log   LOG          = ExoLogger.getLogger(NewsUtils.class);
+  private static final Log   LOG               = ExoLogger.getLogger(NewsUtils.class);
 
-  public static final String POST_NEWS    = "exo.news.postArticle";
+  public static final String POST_NEWS         = "exo.news.postArticle";
 
-  public static final String PUBLISH_NEWS = "exo.news.PublishArticle";
+  public static final String POST_NEWS_ARTICLE = "exo.news.gamification.postArticle";
 
-  public static final String VIEW_NEWS    = "exo.news.viewArticle";
+  public static final String PUBLISH_NEWS      = "exo.news.gamification.PublishArticle";
 
-  public static final String SHARE_NEWS   = "exo.news.shareArticle";
+  public static final String VIEW_NEWS         = "exo.news.viewArticle";
 
-  public static final String COMMENT_NEWS = "exo.news.commentArticle";
+  public static final String SHARE_NEWS        = "exo.news.shareArticle";
 
-  public static final String LIKE_NEWS    = "exo.news.likeArticle";
+  public static final String COMMENT_NEWS      = "exo.news.commentArticle";
 
-  public static final String DELETE_NEWS  = "exo.news.deleteArticle";
+  public static final String LIKE_NEWS         = "exo.news.likeArticle";
 
-  public static final String UPDATE_NEWS  = "exo.news.updateArticle";
+  public static final String DELETE_NEWS       = "exo.news.deleteArticle";
+
+  public static final String UPDATE_NEWS       = "exo.news.updateArticle";
 
   public static void broadcastEvent(String eventName, Object source, Object data) {
     try {

--- a/services/src/main/java/org/exoplatform/news/listener/NewsGamificationIntegrationListener.java
+++ b/services/src/main/java/org/exoplatform/news/listener/NewsGamificationIntegrationListener.java
@@ -42,7 +42,7 @@ public class NewsGamificationIntegrationListener extends Listener<String, News> 
       String eventName = event.getEventName();
       News news = event.getData();
       String ruleTitle = "";
-      if (StringUtils.equals(eventName, NewsUtils.POST_NEWS)) {
+      if (StringUtils.equals(eventName, NewsUtils.POST_NEWS_ARTICLE)) {
         ruleTitle = GAMIFICATION_POST_NEWS_ARTICLE_RULE_TITLE;
       } else if (StringUtils.equals(eventName, NewsUtils.PUBLISH_NEWS)) {
         ruleTitle = GAMIFICATION_PUBLISH_NEWS_ARTICLE_RULE_TITLE;

--- a/services/src/main/java/org/exoplatform/news/rest/NewsRestResourcesV1.java
+++ b/services/src/main/java/org/exoplatform/news/rest/NewsRestResourcesV1.java
@@ -480,7 +480,9 @@ public class NewsRestResourcesV1 implements ResourceContainer, Startable {
 
       news = newsService.updateNews(news);
 
-      newsService.updateNewsActivity(news, post);
+      if (StringUtils.isNotBlank(news.getActivityId())) {
+        newsService.updateNewsActivity(news, post);
+      }
 
       return Response.ok(news).build();
     } catch (Exception e) {

--- a/services/src/main/java/org/exoplatform/news/rest/NewsRestResourcesV1.java
+++ b/services/src/main/java/org/exoplatform/news/rest/NewsRestResourcesV1.java
@@ -480,9 +480,7 @@ public class NewsRestResourcesV1 implements ResourceContainer, Startable {
 
       news = newsService.updateNews(news);
 
-      if (StringUtils.isNotBlank(news.getActivityId())) {
-        newsService.updateNewsActivity(news, post);
-      }
+      newsService.updateNewsActivity(news, post);
 
       return Response.ok(news).build();
     } catch (Exception e) {

--- a/webapp/src/main/webapp/WEB-INF/conf/news/gamification-configuration.xml
+++ b/webapp/src/main/webapp/WEB-INF/conf/news/gamification-configuration.xml
@@ -16,12 +16,12 @@
   <external-component-plugins>
     <target-component>org.exoplatform.services.listener.ListenerService</target-component>
     <component-plugin>
-      <name>exo.news.postArticle</name>
+      <name>exo.news.gamification.postArticle</name>
       <set-method>addListener</set-method>
       <type>org.exoplatform.news.listener.NewsGamificationIntegrationListener</type>
     </component-plugin>
     <component-plugin>
-      <name>exo.news.PublishArticle</name>
+      <name>exo.news.gamification.PublishArticle</name>
       <set-method>addListener</set-method>
       <type>org.exoplatform.news.listener.NewsGamificationIntegrationListener</type>
     </component-plugin>


### PR DESCRIPTION
Prior to this change, before creating news we have a null pointer exception due to a null value of activity. In addition, after posting news, we have some exceptions related to gamification and analytics due to problem of the wrong type of variable used in `broadcastEvent` and the use the same key for gamification rule and analytics rule. Also, when scheduling a news, we get a null value for the username when broadcasting the analytics event so we will send the author of news.