### PR TITLE
Task-50376_50599: News publisher and externals shouldn't receive published news notification (#327)

### DIFF
--- a/services/src/main/java/org/exoplatform/news/notification/plugin/PublishNewsNotificationPlugin.java
+++ b/services/src/main/java/org/exoplatform/news/notification/plugin/PublishNewsNotificationPlugin.java
@@ -56,7 +56,8 @@ public class PublishNewsNotificationPlugin extends BaseNotificationPlugin {
 
     return NotificationInfo.instance()
                            .setFrom(currentUserName)
-                           .setSendAll(true)
+                           .setSendAllInternals(true)
+                           .exclude(currentUserName)
                            .with(NotificationConstants.CONTENT_TITLE, contentTitle)
                            .with(NotificationConstants.CONTENT_AUTHOR, contentAuthor)
                            .with(NotificationConstants.CURRENT_USER, currentUserFullName)


### PR DESCRIPTION
Prior to this change, news publishers and externals receive published news notifications. After this change, only users except news publishers should receive published news notifications.

(cherry picked from commit 1e599de9f18c4637fd4d5b52ace73fc15eb02224)