### PR TITLE
Task-50098: The article is not raised to the top of the space when it is edited by a non owner with the option update and post. (#318)

### DIFF
--- a/services/src/main/java/org/exoplatform/news/NewsService.java
+++ b/services/src/main/java/org/exoplatform/news/NewsService.java
@@ -82,6 +82,8 @@ public interface NewsService {
 
   public boolean canEditNews(String posterId, String spaceId);
 
+  void updateNewsActivity(News news, boolean post);
+
   /**
    * @param news {@link News} to check
    * @param authenticatedUser authenticated username

--- a/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
@@ -1183,6 +1183,15 @@ public class NewsServiceImpl implements NewsService {
     return authenticatedSecurityIdentity.isMemberOf(PLATFORM_WEB_CONTRIBUTORS_GROUP, PUBLISHER_MEMBERSHIP_NAME);
   }
 
+  @Override
+  public void updateNewsActivity(News news, boolean post) {
+    ExoSocialActivity activity = activityManager.getActivity(news.getActivityId());
+    if(post) {
+      activity.setUpdated(System.currentTimeMillis());
+    }
+    activityManager.updateActivity(activity, true);
+  }
+
   /**
    * Return a boolean that indicates if the current user can publish the news or not
    * 

--- a/services/src/main/java/org/exoplatform/news/rest/NewsRestResourcesV1.java
+++ b/services/src/main/java/org/exoplatform/news/rest/NewsRestResourcesV1.java
@@ -436,6 +436,7 @@ public class NewsRestResourcesV1 implements ResourceContainer, Startable {
       @ApiResponse(code = 500, message = "Internal server error") })
   public Response updateNews(@Context HttpServletRequest request,
                              @ApiParam(value = "News id", required = true) @PathParam("id") String id,
+                             @ApiParam(value = "Post news", required = false) @QueryParam("post") boolean post,
                              @ApiParam(value = "News", required = true) News updatedNews) {
 
     if (updatedNews == null) {
@@ -477,6 +478,8 @@ public class NewsRestResourcesV1 implements ResourceContainer, Startable {
       }
 
       news = newsService.updateNews(news);
+
+      newsService.updateNewsActivity(news, post);
 
       return Response.ok(news).build();
     } catch (Exception e) {

--- a/services/src/test/java/org/exoplatform/news/rest/NewsRestResourcesV1Test.java
+++ b/services/src/test/java/org/exoplatform/news/rest/NewsRestResourcesV1Test.java
@@ -340,7 +340,7 @@ public class NewsRestResourcesV1Test {
     lenient().when(newsService.updateNews(any())).then(returnsFirstArg());
 
     // When
-    Response response = newsRestResourcesV1.updateNews(request, "1", updatedNews);
+    Response response = newsRestResourcesV1.updateNews(request, "1",false, updatedNews);
 
     // Then
     assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
@@ -367,7 +367,7 @@ public class NewsRestResourcesV1Test {
     lenient().when(newsService.getNewsById(anyString(), anyBoolean())).thenReturn(news);
 
     // When
-    Response response = newsRestResourcesV1.updateNews(request, "1", new News());
+    Response response = newsRestResourcesV1.updateNews(request, "1",false, new News());
 
     // Then
     assertEquals(Response.Status.UNAUTHORIZED.getStatusCode(), response.getStatus());
@@ -386,7 +386,7 @@ public class NewsRestResourcesV1Test {
     lenient().when(newsService.getNewsById(anyString(), anyBoolean())).thenReturn(null);
 
     // When
-    Response response = newsRestResourcesV1.updateNews(request, "1", new News());
+    Response response = newsRestResourcesV1.updateNews(request, "1",false, new News());
 
     // Then
     assertEquals(Response.Status.NOT_FOUND.getStatusCode(), response.getStatus());
@@ -622,7 +622,7 @@ public class NewsRestResourcesV1Test {
     lenient().when(newsService.updateNews(any())).then(returnsFirstArg());
 
     // When
-    Response response = newsRestResourcesV1.updateNews(request, "id123", updatedNews);
+    Response response = newsRestResourcesV1.updateNews(request, "id123", false, updatedNews);
 
     // Then
     assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
@@ -672,7 +672,7 @@ public class NewsRestResourcesV1Test {
     lenient().when(newsService.getNewsById("id123", false)).thenReturn(oldnews);
     
     // When
-    Response response = newsRestResourcesV1.updateNews(request, "id123", updatedNews);
+    Response response = newsRestResourcesV1.updateNews(request, "id123",false, updatedNews);
 
     // Then
     assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
@@ -713,7 +713,7 @@ public class NewsRestResourcesV1Test {
     lenient().when(newsService.getNewsById("id123", false)).thenReturn(oldnews);
 
     // When
-    Response response = newsRestResourcesV1.updateNews(request, "id123", updatedNews);
+    Response response = newsRestResourcesV1.updateNews(request, "id123",false, updatedNews);
 
     // Then
     assertEquals(Response.Status.UNAUTHORIZED.getStatusCode(), response.getStatus());
@@ -889,7 +889,7 @@ public class NewsRestResourcesV1Test {
     lenient().when(request.getRemoteUser()).thenReturn("john");
 
     // When
-    Response response = newsRestResourcesV1.updateNews(request, "1", null);
+    Response response = newsRestResourcesV1.updateNews(request, "1",false, null);
 
     // Then
     assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());

--- a/webapp/src/main/webapp/services/newsServices.js
+++ b/webapp/src/main/webapp/services/newsServices.js
@@ -103,8 +103,8 @@ export function importFileFromUrl(url) {
   });
 }
 
-export function updateNews(news) {
-  return fetch(`${newsConstants.NEWS_API}/${news.id}`, {
+export function updateNews(news, post) {
+  return fetch(`${newsConstants.NEWS_API}/${news.id}?post=${post}`, {
     headers: {
       'Content-Type': 'application/json'
     },
@@ -112,17 +112,6 @@ export function updateNews(news) {
     method: 'PUT',
     body: JSON.stringify(news)
   }).then(resp => resp.json());
-}
-
-export function updateAndPostNewsActivity(activity) {
-  return fetch(`${newsConstants.SOCIAL_ACTIVITY_API}/${activity.id}`, {
-    headers: {
-      'Content-Type': 'application/json'
-    },
-    credentials: 'include',
-    method: 'PUT',
-    body: JSON.stringify(activity)
-  });
 }
 
 export function clickOnEditButton(id) {


### PR DESCRIPTION
Prior to this change, when editing news by someone else not the owner with updates and posts, the related activity is not raised to the top of the activity stream. After this fix, we will ensure that when editing news with updates and posts, the activity is updated and raised to the top of the activity stream.

(cherry picked from commit 8cdb15458c25fb8fde00e5d64d388c86eeb7f075)