### PR TITLE
Task-51092: Don't display posted article edited draft warning alert message for current user.

### DIFF
--- a/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
+++ b/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
@@ -215,7 +215,7 @@
             </textarea>
           </div>
           <v-alert
-            v-if="news.draftUpdaterDisplayName !== currentUser && news.publicationState === 'draft' && activityId"
+            v-if="news.draftUpdaterUserName !== currentUser && news.publicationState === 'draft' && activityId"
             dismissible
             border="left"
             elevation="2"


### PR DESCRIPTION
Prior to this fix, a warning alert message is displayed when editing the posted article and the current user is its last modifier.
This fix will ensure that the warning alert message is displayed only when the last modifier is not the current user.