### PR TITLE
Task-51207: Fix performance problem of displaying news activities on activity stream

### DIFF
--- a/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
@@ -753,10 +753,6 @@ public class NewsServiceImpl implements NewsService {
         org.exoplatform.services.security.Identity currentIdentity = getCurrentIdentity();
         String currentUsername = currentIdentity == null ? null : currentIdentity.getUserId();
         String newsActivityId = activities[0].split(":")[1];
-        ExoSocialActivity activity = activityManager.getActivity(newsActivityId);
-        if (activity != null) {
-          news.setActivityPosted(activity.isHidden());
-        }
         news.setActivityId(newsActivityId);
         Space newsPostedInSpace = spaceService.getSpaceById(activities[0].split(":")[0]);
         if (currentUsername != null && spaceService.isMember(newsPostedInSpace, currentUsername)) {


### PR DESCRIPTION
Before this fix, getNewsByActivityId method of newsService calls activityManager.getActivity and getNewsById which calls itself also activityManager.getActivity whithin convertNodeToNews. This makes a cyclic call and causes a performance problem when displaying news activities on activity stream. 
After this change, we will remove the useless call of activityManager.getActivity used to set activityPosted information to news object since this information can be retrieved directly from the news node property.