### PR TITLE
Task-51112: Enable confirm button in edit scheduling for each step

### DIFF
--- a/webapp/src/main/webapp/news-details/components/ExoNewsEditPublishingDrawer.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsEditPublishingDrawer.vue
@@ -115,18 +115,14 @@ export default {
       this.publish = this.selected;
     },
     isActivityPosted() {
-      if (this.isHiddenActivity === !this.isActivityPosted && !this.publish) {
-        this.disabled = true;
-      } else if (this.publish && this.selectedTargets && this.selectedTargets.length === 0) {
+      if ((this.isHiddenActivity === !this.isActivityPosted && !this.publish) ||(this.publish && this.selectedTargets && this.selectedTargets.length === 0)) {
         this.disabled = true;
       } else {
         this.disabled = false;
       }
     },
     publish() {
-      if (this.publish !== this.selected && !this.publish) {
-        this.disabled = false;
-      } else if (this.publish && this.selectedTargets && this.selectedTargets.length === 0) {
+      if (this.publish && this.selectedTargets && this.selectedTargets.length === 0) {
         this.disabled = true;
       } else {
         this.disabled = false;

--- a/webapp/src/main/webapp/news-details/components/ExoNewsEditPublishingDrawer.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsEditPublishingDrawer.vue
@@ -186,11 +186,10 @@ export default {
     openDrawer() {
       if (this.news) {
         this.publish = this.news.pinned;
+        this.isActivityPosted = !this.news.activityPosted;
       }
       if (this.$refs.postNewsDrawer) {
         this.disabled = true;
-        this.publish = this.news.pinned;
-        this.isActivityPosted = !this.news.activityPosted;
         this.$refs.postNewsDrawer.open();
       }
     },

--- a/webapp/src/main/webapp/schedule-news-drawer/components/ExoScheduleNewsDrawer.vue
+++ b/webapp/src/main/webapp/schedule-news-drawer/components/ExoScheduleNewsDrawer.vue
@@ -349,9 +349,7 @@ export default {
     postArticleMode() {
       const postDate = new Date(this.postDate);
       const scheduleDate = new Date(this.schedulePostDate);
-      if (this.postArticleMode === 'immediate') {
-        this.disabled = false;
-      } else if (this.postArticleMode === 'later'){
+      if (this.postArticleMode === 'later') {
         this.disabled = postDate.getTime() === scheduleDate.getTime();
       } else {
         this.disabled = false;

--- a/webapp/src/main/webapp/schedule-news-drawer/components/ExoScheduleNewsDrawer.vue
+++ b/webapp/src/main/webapp/schedule-news-drawer/components/ExoScheduleNewsDrawer.vue
@@ -302,9 +302,7 @@ export default {
     },
     publish() {
       if (this.editScheduledNews ==='editScheduledNews') {
-        if (this.publish === this.selected && !this.publish) {
-          this.disabled = true;
-        } else if (this.publish && this.selectedTargets && this.selectedTargets.length === 0) {
+        if ((this.publish === this.selected && !this.publish) || (this.publish && this.selectedTargets && this.selectedTargets.length === 0) ) {
           this.disabled = true;
         } else {
           this.disabled = false;
@@ -315,9 +313,7 @@ export default {
     },
     selectedTargets(newVal, oldVal) {
       if (this.editScheduledNews ==='editScheduledNews' && this.publish) {
-        if (newVal.length === 0) {
-          this.disabled = true;
-        } else if (newVal.length !== oldVal.length) {
+        if (newVal.length !== oldVal.length) {
           this.disabled = false;
         } else {
           this.disabled = true;

--- a/webapp/src/main/webapp/schedule-news-drawer/components/ExoScheduleNewsDrawer.vue
+++ b/webapp/src/main/webapp/schedule-news-drawer/components/ExoScheduleNewsDrawer.vue
@@ -300,6 +300,63 @@ export default {
     selected() {
       this.publish = this.selected;
     },
+    publish() {
+      if (this.editScheduledNews ==='editScheduledNews') {
+        if (this.publish === this.selected && !this.publish) {
+          this.disabled = true;
+        } else if (this.publish && this.selectedTargets && this.selectedTargets.length === 0) {
+          this.disabled = true;
+        } else {
+          this.disabled = false;
+        }
+      } else {
+        this.disabled = true;
+      }
+    },
+    selectedTargets(newVal, oldVal) {
+      if (this.editScheduledNews ==='editScheduledNews' && this.publish) {
+        if (newVal.length === 0) {
+          this.disabled = true;
+        } else if (newVal.length !== oldVal.length) {
+          this.disabled = false;
+        } else {
+          this.disabled = true;
+        }
+      } else {
+        this.disabled = true;
+      }
+    },
+    isActivityPosted() {
+      if (this.editScheduledNews ==='editScheduledNews') {
+        if (this.visibilityActivity === !this.isActivityPosted) {
+          this.disabled = true;
+        } else {
+          this.disabled = false;
+        }
+      } else {
+        this.disabled = true;
+      }
+    },
+    stepper() {
+      if ((this.stepper === 1 || this.stepper === 2) && this.editScheduledNews !=='editScheduledNews') {
+        this.disabled = true;
+      } else if ((this.stepper === 2) && this.editScheduledNews !=='editScheduledNews'){
+        this.disabled = (this.visibilityActivity === !this.isActivityPosted) || this.selected === this.publish;
+      } else if (this.stepper === 3 && this.editScheduledNews !=='editScheduledNews') {
+        this.disabled = false;
+      }
+    },
+    postArticleMode() {
+      const postDate = new Date(this.postDate);
+      const scheduleDate = new Date(this.schedulePostDate);
+      if (this.postArticleMode === 'immediate') {
+        this.disabled = false;
+      } else if (this.postArticleMode === 'later'){
+        this.disabled = postDate.getTime() === scheduleDate.getTime();
+      } else {
+        this.disabled = false;
+      }
+    }
   },
   computed: {
     saveButtonLabel() {
@@ -324,20 +381,12 @@ export default {
     visibilityActivity() {
       return this.news && this.news.activityPosted;
     },
-    disabled() {
-      const postDate = new Date(this.postDate);
-      const scheduleDate = new Date(this.schedulePostDate);
-      if (this.canPublishNews) {
-        return (this.postArticleMode === 'immediate' ? false : this.postArticleMode === 'later' && postDate.getTime() === scheduleDate.getTime()) && this.selected === this.publish && this.visibilityActivity === !this.isActivityPosted || this.stepper < 3;
-      } else {
-        return (this.postArticleMode === 'immediate' ? false : this.postArticleMode === 'later' && postDate.getTime() === scheduleDate.getTime()) && this.selected === this.publish;
-      }
-    },
     disableTargetOption() {
       return this.publish ? this.allowPublishTargeting && this.selectedTargets && this.selectedTargets.length === 0 : false;
     },
   },
   created() {
+    this.disabled = true;
     this.$featureService.isFeatureEnabled('news.publishTargeting')
       .then(enabled => this.allowPublishTargeting = enabled);
     this.$newsServices.canPublishNews().then(canPublishNews => {
@@ -365,7 +414,6 @@ export default {
       }
       if (this.$refs.postNewsDrawer) {
         if (this.editScheduledNews ==='editScheduledNews') {
-          this.disabled = true;
           this.postDateTime = new Date(this.schedulePostDate);
           this.postDate = this.postDateTime;
           this.postDateTime.setHours(new Date(this.schedulePostDate).getHours());


### PR DESCRIPTION
Prior to this change, in scheduling drawer, we should follow all the steps to make update. After this change, we have the possibility to save changes for each step.