### PR TITLE
Task-49412: Ensure to refresh the news application after deleting an article.

### DIFF
--- a/webapp/src/main/webapp/news/components/NewsApp.vue
+++ b/webapp/src/main/webapp/news/components/NewsApp.vue
@@ -305,7 +305,7 @@ export default {
     },
     deleteNews(news) {
       const deleteDelay = 6;
-      const redirectionTime = 6100;
+      const redirectionTime = 8100;
       this.$newsServices.deleteNews(news.newsId, this.newsFilter === 'drafts', deleteDelay)
         .then(() => {
           this.$root.$emit('confirm-news-deletion', news, this.isDraftsFilter);


### PR DESCRIPTION
Prior to this change, when we delete an article from news application, the news list isn't well refreshed. The problem occurs with a big number of articles since the delete isn't done yet from the database. With this fix, we have increased the redirectionTime to make sure the news list refresh is done after article deletion.
