### PR TITLE
Task-51509: Fix post button status for post drawer

### DIFF
--- a/webapp/src/main/webapp/news-details/components/ExoNewsEditPublishingDrawer.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsEditPublishingDrawer.vue
@@ -115,14 +115,14 @@ export default {
       this.publish = this.selected;
     },
     isActivityPosted() {
-      if ((this.isHiddenActivity === !this.isActivityPosted && ((this.publish === this.selected) || (this.allowPublishTargeting && this.publish && this.selectedTargets && this.selectedTargets.length === 0)))) {
+      if (this.isHiddenActivity === !this.isActivityPosted && (this.publish === this.selected || (this.allowPublishTargeting && this.publish && this.selectedTargets && this.selectedTargets.length === 0))) {
         this.disabled = true;
       } else {
         this.disabled = false;
       }
     },
     publish() {
-      if ((!this.allowPublishTargeting && this.publish === this.selected && this.isHiddenActivity === !this.isActivityPosted) || (this.isHiddenActivity === !this.isActivityPosted && this.allowPublishTargeting && ((this.publish === this.selected) || (this.publish && this.selectedTargets && this.selectedTargets.length === 0)))) {
+      if ((!this.allowPublishTargeting && this.publish === this.selected && this.isHiddenActivity === !this.isActivityPosted) || (this.isHiddenActivity === !this.isActivityPosted && this.allowPublishTargeting && (this.publish === this.selected || (this.publish && this.selectedTargets && this.selectedTargets.length === 0)))) {
         this.disabled = true;
       } else {
         this.disabled = false;

--- a/webapp/src/main/webapp/news-details/components/ExoNewsEditPublishingDrawer.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsEditPublishingDrawer.vue
@@ -115,14 +115,14 @@ export default {
       this.publish = this.selected;
     },
     isActivityPosted() {
-      if ((this.isHiddenActivity === !this.isActivityPosted && !this.publish) ||(this.publish && this.selectedTargets && this.selectedTargets.length === 0)) {
+      if ((this.isHiddenActivity === !this.isActivityPosted && ((this.publish === this.selected) || (this.allowPublishTargeting && this.publish && this.selectedTargets && this.selectedTargets.length === 0)))) {
         this.disabled = true;
       } else {
         this.disabled = false;
       }
     },
     publish() {
-      if (this.publish && this.selectedTargets && this.selectedTargets.length === 0) {
+      if ((!this.allowPublishTargeting && this.publish === this.selected && this.isHiddenActivity === !this.isActivityPosted) || (this.isHiddenActivity === !this.isActivityPosted && this.allowPublishTargeting && ((this.publish === this.selected) || (this.publish && this.selectedTargets && this.selectedTargets.length === 0)))) {
         this.disabled = true;
       } else {
         this.disabled = false;

--- a/webapp/src/main/webapp/schedule-news-drawer/components/ExoScheduleNewsDrawer.vue
+++ b/webapp/src/main/webapp/schedule-news-drawer/components/ExoScheduleNewsDrawer.vue
@@ -334,11 +334,11 @@ export default {
       }
     },
     stepper() {
-      if ((this.stepper === 1 || this.stepper === 2) && this.editScheduledNews !=='editScheduledNews') {
+      if (this.canPublishNews && (this.stepper === 1 || this.stepper === 2) && this.editScheduledNews !=='editScheduledNews') {
         this.disabled = true;
-      } else if ((this.stepper === 2) && this.editScheduledNews !=='editScheduledNews'){
+      } else if (this.canPublishNews && (this.stepper === 2) && this.editScheduledNews !=='editScheduledNews'){
         this.disabled = (this.visibilityActivity === !this.isActivityPosted) || this.selected === this.publish;
-      } else if (this.stepper === 3 && this.editScheduledNews !=='editScheduledNews') {
+      } else if (this.canPublishNews && this.stepper === 3 && this.editScheduledNews !=='editScheduledNews') {
         this.disabled = false;
       }
     },


### PR DESCRIPTION
Prior to this change, when a space redactor or a space manager not publishers try to write an article, the post button of posting drawer is disabled.
To fix this problem, we check enabling/disabling post button status only for publishers in post/publish stepper.