### PR TITLE
MAINT-50208: Unindex deleted news (#347)

### DIFF
--- a/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
@@ -630,6 +630,7 @@ public class NewsServiceImpl implements NewsService {
                                                  repositoryService.getCurrentRepository());
 
     Node node = session.getNodeByUUID(newsId);
+    News news = convertNodeToNews(node, false);
     if (node.hasProperty("exo:activities")) {
       String newActivities = node.getProperty("exo:activities").getString();
       if (StringUtils.isNotEmpty(newActivities)) {
@@ -652,6 +653,7 @@ public class NewsServiceImpl implements NewsService {
                 .forEach(newsActivityId -> activityManager.deleteActivity(newsActivityId));
       }
     }
+    indexingService.unindex(NewsIndexingServiceConnector.TYPE, String.valueOf(news.getId()));
     Utils.removeDeadSymlinks(node, false);
     node.remove();
     session.save();

--- a/services/src/test/java/org/exoplatform/news/NewsServiceImplTest.java
+++ b/services/src/test/java/org/exoplatform/news/NewsServiceImplTest.java
@@ -1820,6 +1820,9 @@ public class NewsServiceImplTest {
     when(sessionProvider.getSession(any(), any())).thenReturn(session);
     when(session.getItem(nullable(String.class))).thenReturn(applicationDataNode);
     when(session.getNodeByUUID(nullable(String.class))).thenReturn(newsNode);
+    Property prop = mock(Property.class);
+    when(prop.getString()).thenReturn("");
+    when(newsNode.getProperty("publication:currentState")).thenReturn(prop);
     when(newsNode.hasProperty("exo:activities")).thenReturn(true);
     when(newsNode.getProperty("exo:activities")).thenReturn(exoActivitiesProperty);
     when(exoActivitiesProperty.getString()).thenReturn("1:1;2:2;2:3");


### PR DESCRIPTION
* MAINT-50208: Reindex deleted news
ISSUE: news articles are searchable in es after being deleted
FIX: Reindex the news when its deleted