### PR TITLE
MAINT-50208: Unindex deleted news (#347)

### DIFF
--- a/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
@@ -673,6 +673,7 @@ public class NewsServiceImpl implements NewsService {
       }
     }
     NewsUtils.broadcastEvent(NewsUtils.DELETE_NEWS, currentUser, news);
+    indexingService.unindex(NewsIndexingServiceConnector.TYPE, String.valueOf(news.getId()));
     Utils.removeDeadSymlinks(node, false);
     node.remove();
     session.save();


### PR DESCRIPTION
* MAINT-50208: Reindex deleted news
ISSUE: news articles are searchable in es after being deleted
FIX: Reindex the news when its deleted