### PR TITLE
Task-51649: Don't post news activity when editing an unposted article

### DIFF
--- a/services/src/main/resources/locale/portlet/news/News_en.properties
+++ b/services/src/main/resources/locale/portlet/news/News_en.properties
@@ -93,6 +93,7 @@ news.edit.update=Update
 news.edit.edit=Edit
 news.edit.update.post=Update and post
 news.edit.cancel=Cancel
+news.edit.disable.update.postButton=This option is unavailable for unposted article
 
 news.activity.readMore=Read more
 news.activity.postedBy=Posted by

--- a/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
+++ b/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
@@ -152,12 +152,12 @@
                   @click.prevent="updateNews(false)">
                   {{ $t("news.edit.update") }}
                 </v-btn>
-                <v-tooltip bottom :disabled="!disableUpdatePostButton">
+                <v-tooltip bottom :disabled="!news.activityPosted">
                   <template v-slot:activator="{ on, attrs }">
                     <span v-on="on">
                       <v-btn
                         id="newsUpdateAndPost"
-                        :disabled="disableUpdatePostButton"
+                        :disabled="news.archived || news.activityPosted ? true: updateDisabled"
                         :class="[news.archived ? 'unauthorizedPublish' : '']"
                         class="btn ms-2 me-2"
                         v-bind="attrs"
@@ -372,7 +372,6 @@ export default {
       scheduleMode: '',
       switchView: false,
       spaceDisplayName: '',
-      disableUpdatePostButton: true,
     };
   },
   computed: {
@@ -423,36 +422,18 @@ export default {
     'news.title': function() {
       if (this.news.title !== this.originalNews.title) {
         this.autoSave();
-      }
-      if ((this.news && this.news.archived) || (this.news && this.news.activityPosted) || this.updateDisabled) {
-        this.disableUpdatePostButton = true;
-      } else {
-        this.disableUpdatePostButton = false;
-      }
-    },
+      } },
     'news.draftVisible': function() {
       this.autoSave();
     },
     'news.summary': function() {
       if (this.news.summary !== this.originalNews.summary) {
         this.autoSave();
-      }
-      if ((this.news && this.news.archived) || (this.news && this.news.activityPosted) || this.updateDisabled) {
-        this.disableUpdatePostButton = true;
-      } else {
-        this.disableUpdatePostButton = false;
-      }
-    },
+      } },
     'news.body': function() {
       if (this.getContent(this.news.body) !== this.getContent(this.originalNews.body)) {
         this.autoSave();
-      }
-      if ((this.news && this.news.archived) || (this.news && this.news.activityPosted) || this.updateDisabled) {
-        this.disableUpdatePostButton = true;
-      } else {
-        this.disableUpdatePostButton = false;
-      }
-    },
+      } },
     'news.attachments': function() {
       if (this.initDone && this.news.attachments !== this.originalNews.attachments) {
         this.attachmentsChanged = true;

--- a/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
+++ b/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
@@ -915,7 +915,8 @@ export default {
         attachments: this.news.attachments,
         pinned: this.news.pinned,
         publicationState: publicationState,
-        draftVisible: this.draftVisible
+        draftVisible: this.draftVisible,
+        activityPosted: this.news.activityPosted,
       };
       if (this.news.illustration != null && this.news.illustration.length > 0) {
         updatedNews.uploadId = this.news.illustration[0].uploadId;

--- a/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
+++ b/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
@@ -152,14 +152,23 @@
                   @click.prevent="updateNews(false)">
                   {{ $t("news.edit.update") }}
                 </v-btn>
-                <v-btn
-                  id="newsUpdateAndPost"
-                  :disabled="news.archived ? true: updateDisabled"
-                  :class="[news.archived ? 'unauthorizedPublish' : '']"
-                  class="btn ms-2 me-2"
-                  @click.prevent="updateNews(true)">
-                  {{ $t("news.edit.update.post") }}
-                </v-btn>
+                <v-tooltip bottom :disabled="!disableUpdatePostButton">
+                  <template v-slot:activator="{ on, attrs }">
+                    <span v-on="on">
+                      <v-btn
+                        id="newsUpdateAndPost"
+                        :disabled="disableUpdatePostButton"
+                        :class="[news.archived ? 'unauthorizedPublish' : '']"
+                        class="btn ms-2 me-2"
+                        v-bind="attrs"
+                        v-on="on"
+                        @click.prevent="updateNews(true)">
+                        {{ $t("news.edit.update.post") }}
+                      </v-btn>
+                    </span>
+                  </template>
+                  <span>{{ $t("news.edit.disable.update.postButton") }}</span>
+                </v-tooltip>
                 <v-btn class="btn me-2" @click="goBack">
                   {{ $t("news.composer.btn.cancel") }}
                 </v-btn>
@@ -363,6 +372,7 @@ export default {
       scheduleMode: '',
       switchView: false,
       spaceDisplayName: '',
+      disableUpdatePostButton: true,
     };
   },
   computed: {
@@ -413,18 +423,36 @@ export default {
     'news.title': function() {
       if (this.news.title !== this.originalNews.title) {
         this.autoSave();
-      } },
+      }
+      if ((this.news && this.news.archived) || (this.news && this.news.activityPosted) || this.updateDisabled) {
+        this.disableUpdatePostButton = true;
+      } else {
+        this.disableUpdatePostButton = false;
+      }
+    },
     'news.draftVisible': function() {
       this.autoSave();
     },
     'news.summary': function() {
       if (this.news.summary !== this.originalNews.summary) {
         this.autoSave();
-      } },
+      }
+      if ((this.news && this.news.archived) || (this.news && this.news.activityPosted) || this.updateDisabled) {
+        this.disableUpdatePostButton = true;
+      } else {
+        this.disableUpdatePostButton = false;
+      }
+    },
     'news.body': function() {
       if (this.getContent(this.news.body) !== this.getContent(this.originalNews.body)) {
         this.autoSave();
-      } },
+      }
+      if ((this.news && this.news.archived) || (this.news && this.news.activityPosted) || this.updateDisabled) {
+        this.disableUpdatePostButton = true;
+      } else {
+        this.disableUpdatePostButton = false;
+      }
+    },
     'news.attachments': function() {
       if (this.initDone && this.news.attachments !== this.originalNews.attachments) {
         this.attachmentsChanged = true;


### PR DESCRIPTION
Prior to this change when updating an unposted article, an activity is created. After this change we add the status postedActivity to keep the status of activity.