### PR TITLE
Task-49372: Display a restricted access page when no permission to edit a draft of posted or not posted article

### DIFF
--- a/services/src/main/java/org/exoplatform/news/service/impl/NewsServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/service/impl/NewsServiceImpl.java
@@ -566,11 +566,11 @@ public class NewsServiceImpl implements NewsService {
     if (authenticatedUser.equals(posterUsername) || spaceService.isSuperManager(authenticatedUser)) {
       return true;
     }
-    Space currentSpace = spaceService.getSpaceById(spaceId);
-    if (spaceService.isManager(currentSpace, authenticatedUser)) {
+    boolean spaceHasARedactor = space != null && space.getRedactors() != null && space.getRedactors().length > 0;
+    if (spaceService.isManager(space, authenticatedUser) && spaceHasARedactor) {
       return true;
     }
-    if (spaceService.isRedactor(currentSpace, authenticatedUser) && news.isDraftVisible() && news.getActivities() == null) {
+    if (spaceService.isRedactor(space, authenticatedUser) && news.isDraftVisible()) {
       return true;
     }
     org.exoplatform.services.security.Identity authenticatedSecurityIdentity = NewsUtils.getUserIdentity(authenticatedUser);

--- a/services/src/main/java/org/exoplatform/news/service/impl/NewsServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/service/impl/NewsServiceImpl.java
@@ -192,17 +192,19 @@ public class NewsServiceImpl implements NewsService {
     } catch (Exception e) {
       LOG.error("An error occurred while retrieving news with id " + newsId, e);
     }
-    if (editMode) {
-      if (!canEditNews(news, currentIdentity.getUserId())) {
-        throw new IllegalAccessException("User " + currentIdentity.getUserId() + " is not authorized to edit News");
+    if (news != null) {
+      if (editMode) {
+        if (!canEditNews(news, currentIdentity.getUserId())) {
+          throw new IllegalAccessException("User " + currentIdentity.getUserId() + " is not authorized to edit News");
+        }
+      } else if (!canViewNews(news, currentIdentity.getUserId())) {
+        throw new IllegalAccessException("User " + currentIdentity.getUserId() + " is not authorized to view News");
       }
-    } else if (!canViewNews(news, currentIdentity.getUserId())) {
-      throw new IllegalAccessException("User " + currentIdentity.getUserId() + " is not authorized to view News");
+      news.setCanEdit(canEditNews(news, currentIdentity.getUserId()));
+      news.setCanDelete(canDeleteNews(currentIdentity, news.getAuthor(), news.getSpaceId()));
+      news.setCanPublish(canPublishNews(currentIdentity));
+      news.setCanArchive(canArchiveNews(currentIdentity, news.getAuthor()));
     }
-    news.setCanEdit(canEditNews(news, currentIdentity.getUserId()));
-    news.setCanDelete(canDeleteNews(currentIdentity, news.getAuthor(), news.getSpaceId()));
-    news.setCanPublish(canPublishNews(currentIdentity));
-    news.setCanArchive(canArchiveNews(currentIdentity, news.getAuthor()));
     return news;
   }
   

--- a/services/src/main/java/org/exoplatform/news/service/impl/NewsServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/service/impl/NewsServiceImpl.java
@@ -43,6 +43,8 @@ import org.exoplatform.social.core.space.spi.SpaceService;
 import org.exoplatform.social.notification.LinkProviderUtils;
 import org.exoplatform.upload.UploadService;
 
+import javax.ws.rs.core.Response;
+
 /**
  * Service managing News and storing them in ECMS
  */
@@ -200,6 +202,8 @@ public class NewsServiceImpl implements NewsService {
       news.setCanPublish(canPublishNews(currentIdentity));
       news.setCanArchive(canArchiveNews(currentIdentity, news.getAuthor()));
       return news;
+    } catch (IllegalAccessException e) {
+      throw new IllegalAccessException("User " + currentIdentity.getUserId()+ " attempt to access unauthorized news with id {}" + newsId);
     } catch (Exception e) {
       throw new IllegalStateException("An error occurred while retrieving news with id " + newsId, e);
     }

--- a/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
+++ b/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
@@ -279,23 +279,13 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         ref="selectVisibilityDialog"
         :items="items" />
     </div>
-    
-    <div v-show="!canCreatNews && !loading" class="newsComposer">
-      <div id="form_msg_error" class="alert alert-error">
-        <span data-dismiss="alert">
-          <i class="uiIconColorError pull-left"></i>
-        </span>
-        <div class="msg_error">
-          <div>
-            <span class="msg_permission_denied">{{ $t("news.permission.denied") }}</span>
-          </div>
-          <div>
-            <span class="msg_permission">{{ $t("news.permission.msg") }}</span>
-          </div>
-        </div>
+
+    <div v-show="(!canCreatNews && !loading) || unAuthorizedAccess" class="newsComposer">
+      <div class="articleNotFound">
+        <i class="iconNotFound"></i>
+        <h3>{{ $t('news.details.restricted') }}</h3>
       </div>
-    </div>
-  </v-app>
+    </div>  </v-app>
 </template>
 
 <script>
@@ -389,6 +379,7 @@ export default {
       scheduleMode: '',
       switchView: false,
       spaceDisplayName: '',
+      unAuthorizedAccess: false,
     };
   },
   computed: {
@@ -663,7 +654,7 @@ export default {
       const self = this;
       this.$newsServices.getNewsById(newsId, true)
         .then(fetchedNode => {
-          if (fetchedNode){
+          if (fetchedNode && fetchedNode.id){
             this.news.id = fetchedNode.id;
             this.news.title = fetchedNode.title;
             this.news.summary = fetchedNode.summary;
@@ -712,6 +703,7 @@ export default {
               self.initDone = true;
             });
           } else {
+            this.unAuthorizedAccess = true;
             self.initDone = true;
           }
         });

--- a/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
+++ b/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
@@ -283,14 +283,16 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
     <div v-show="(!canCreatNews && !loading) || unAuthorizedAccess" class="newsComposer">
       <div class="articleNotFound">
         <i class="iconNotFound"></i>
-        <h3>{{ $t('news.details.restricted') }}</h3>
+        <h3 class="restrictedAction">{{ $t('news.details.restricted') }}</h3>
       </div>
-    </div>  </v-app>
+    </div>
+  </v-app>
 </template>
 
 <script>
 import autosize from 'autosize';
 const USER_TIMEZONE_ID = new window.Intl.DateTimeFormat().resolvedOptions().timeZone;
+const UNAUTHORIZED_CODE = 401;
 export default {
   props: {
     newsId: {
@@ -654,7 +656,10 @@ export default {
       const self = this;
       this.$newsServices.getNewsById(newsId, true)
         .then(fetchedNode => {
-          if (fetchedNode && fetchedNode.id){
+          if (fetchedNode === UNAUTHORIZED_CODE){
+            this.unAuthorizedAccess = true;
+            self.initDone = true;
+          } else {
             this.news.id = fetchedNode.id;
             this.news.title = fetchedNode.title;
             this.news.summary = fetchedNode.summary;
@@ -702,9 +707,6 @@ export default {
               autosize.update(document.querySelector('#newsSummary'));
               self.initDone = true;
             });
-          } else {
-            this.unAuthorizedAccess = true;
-            self.initDone = true;
           }
         });
     },
@@ -933,7 +935,7 @@ export default {
         attachments: this.news.attachments,
         published: this.news.published,
         publicationState: publicationState,
-        draftVisible: this.draftVisible,
+        draftVisible: this.news.draftVisible,
         activityPosted: this.news.activityPosted,
       };
       if (this.news.illustration != null && this.news.illustration.length > 0) {

--- a/webapp/src/main/webapp/services/newsServices.js
+++ b/webapp/src/main/webapp/services/newsServices.js
@@ -5,13 +5,15 @@ export function getNewsById(id, editMode) {
     credentials: 'include',
     method: 'GET',
   }).then((resp) => {
-    if ((resp && resp.ok) || resp.status === 401) {
-      return resp.ok ? resp.json() : resp.status;
-    } else {
-      throw new Error('Response code indicates a server error');
+    if ((resp && resp.ok)) {
+      return resp.json();
+    } else if ( resp.status === 401) {
+      return resp.status;
     }
   }).then(resp => {
     return resp;
+  }).catch((error) => {
+    return error;
   });
 }
 

--- a/webapp/src/main/webapp/services/newsServices.js
+++ b/webapp/src/main/webapp/services/newsServices.js
@@ -7,8 +7,9 @@ export function getNewsById(id, editMode) {
   }).then((resp) => {
     if (resp && resp.ok) {
       return resp.json();
+    } else {
+      return resp.status;
     }
-    return null;
   }).then(resp => {
     return resp;
   });

--- a/webapp/src/main/webapp/services/newsServices.js
+++ b/webapp/src/main/webapp/services/newsServices.js
@@ -5,10 +5,10 @@ export function getNewsById(id, editMode) {
     credentials: 'include',
     method: 'GET',
   }).then((resp) => {
-    if (resp && resp.ok) {
-      return resp.json();
+    if ((resp && resp.ok) || resp.status === 401) {
+      return resp.ok ? resp.json() : resp.status;
     } else {
-      return resp.status;
+      throw new Error('Response code indicates a server error');
     }
   }).then(resp => {
     return resp;

--- a/webapp/src/main/webapp/skin/less/news.less
+++ b/webapp/src/main/webapp/skin/less/news.less
@@ -1018,21 +1018,21 @@
     .v-navigation-drawer {
       z-index: 20;
     }
-  .articleNotFound {
-    .iconNotFound {
-      background: url("@{images-path}/notfound.png") no-repeat center top;
-      display: block;
-      height: 85px;
-      margin: 3% auto;
-      text-align: center;
-      width: 160px;
-    }
+    .articleNotFound {
+      .iconNotFound {
+        background: url("@{images-path}/notfound.png") no-repeat center top;
+        display: block;
+        height: 85px;
+        margin: 3% auto;
+        text-align: center;
+        width: 160px;
+      }
 
-    .restrictedAction {
-      text-align: center;
-      color: @textLightColor;
+      .restrictedAction {
+        text-align: center;
+        color: @textLightColor;
+      }
     }
-  }
 }
 
 .videoDialog {

--- a/webapp/src/main/webapp/skin/less/news.less
+++ b/webapp/src/main/webapp/skin/less/news.less
@@ -1018,6 +1018,21 @@
     .v-navigation-drawer {
       z-index: 20;
     }
+  .articleNotFound {
+    .iconNotFound {
+      background: url("@{images-path}/notfound.png") no-repeat center top;
+      display: block;
+      height: 85px;
+      margin: 3% auto;
+      text-align: center;
+      width: 160px;
+    }
+
+    h3 {
+      text-align: center;
+      color: @textLightColor;
+    }
+  }
 }
 
 .videoDialog {

--- a/webapp/src/main/webapp/skin/less/news.less
+++ b/webapp/src/main/webapp/skin/less/news.less
@@ -1028,7 +1028,7 @@
       width: 160px;
     }
 
-    h3 {
+    .restrictedAction {
       text-align: center;
       color: @textLightColor;
     }


### PR DESCRIPTION
Prior to this change, when trying to edit a draft (of posted or not yet posted article) using the url, a non space member has a restricted access red alert text is displayed and a space member not allowed to edit the article has an empty news editor. After this change, for all above case, we will display a same restricted access page.