### PR TITLE
Task-51620 : Add aria-label on publish news button

### DIFF
--- a/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
+++ b/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
@@ -138,6 +138,7 @@
               id="newsPost"
               :loading="postingNews"
               :disabled="postDisabled || postingNews"
+              :aria-label="$t('news.composer.post')"
               elevation="0"
               class="btn btn-primary my-auto me-4"
               @click="newsActions">

--- a/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
+++ b/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
@@ -1,3 +1,19 @@
+<!--
+Copyright (C) 2021 eXo Platform SAS.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+-->
 <template>
   <v-app>
     <div v-show="loading">


### PR DESCRIPTION
Before this fix, the publish news button does not respect RGAA Criteria 11.9 :
https://www.numerique.gouv.fr/publications/rgaa-accessibilite/methode-rgaa/criteres/#crit-11-9
This commit add the aria-label attribute on this button to make it compliant