### PR TITLE
Task-52255: Restore missed notification plugins labels

### DIFF
--- a/services/src/main/resources/locale/portlet/news/News_en.properties
+++ b/services/src/main/resources/locale/portlet/news/News_en.properties
@@ -105,6 +105,18 @@ UINotification.label.postCreateNews=New article
 UINotification.label.news=News Notifications
 UINotification.label.mentionInArticle=Mentions in article
 UINotification.label.PublishArticle=Article published
+UINotification.title.PostNewsNotificationPlugin=Someone posts a news in a space
+UINotification.title.MentionInNewsNotificationPlugin=Someone mentions me in an article
+UINotification.title.PublishNewsNotificationPlugin=Someone has published an article
+
+Notification.subject.PostNewsNotificationPlugin=$CONTENT_AUTHOR has posted an article on $CONTENT_SPACE space
+Notification.subject.MentionInNewsNotificationPlugin=$CURRENT_USER mentioned you in the article $CONTENT_TITLE
+Notification.subject.PublishNewsNotificationPlugin=$CONTENT_TITLE has been published
+
+# For Digest
+Notification.digest.one.PostNewsNotificationPlugin=$USER <span style="color:#333333">have posted</span> $CONTENT_TITLE <span style="color:#333333">in</span> $SPACE_TITLE.
+Notification.digest.one.MentionInNewsNotificationPlugin=<span style="color:#333333">You have been mentioned in the article</span> $CONTENT_TITLE.
+Notification.digest.one.PublishNewsNotificationPlugin=$USER <span style="color:#333333">have published</span> $CONTENT_TITLE.
 
 news.app.views=Views
 news.app.searchPlaceholder=Search in News

--- a/services/src/main/resources/locale/portlet/news/News_fr.properties
+++ b/services/src/main/resources/locale/portlet/news/News_fr.properties
@@ -105,6 +105,18 @@ UINotification.label.postCreateNews=Nouvel article
 UINotification.label.news=Notifications de news
 UINotification.label.mentionInArticle=Mentions dans l'article
 UINotification.label.PublishArticle=Article diffus\u00E9
+UINotification.title.PostNewsNotificationPlugin=Quelqu'un a post\u00E9 un article dans un espace
+UINotification.title.MentionInNewsNotificationPlugin=Quelqu'un me mentionne dans un article
+UINotification.title.PublishNewsNotificationPlugin=Quelqu'un a diffus\u00E9 un article
+
+Notification.subject.PostNewsNotificationPlugin=$CONTENT_AUTHOR a publi\u00E9 un article dans l'espace $CONTENT_SPACE
+Notification.subject.MentionInNewsNotificationPlugin=$CURRENT_USER vous a mentionn\u00E9(e) dans l'article $CONTENT_TITLE
+Notification.subject.PublishNewsNotificationPlugin=$CONTENT_TITLE a \u00E9t\u00E9 diffus\u00E9
+
+# For Digest
+Notification.digest.one.PostNewsNotificationPlugin=$USER <span style="color:#333333">a post\u00E9</span> $CONTENT_TITLE <span style="color:#333333">dans</span> $SPACE_TITLE.
+Notification.digest.one.MentionInNewsNotificationPlugin=<span style="color:#333333">Vous avez \u00E9t\u00E9 mentionn\u00E9 dans l'article</span> $CONTENT_TITLE.
+Notification.digest.one.PublishNewsNotificationPlugin=$USER <span style="color:#333333">a diffus\u00E9</span> $CONTENT_TITLE.
 
 news.app.views=Affichages
 news.app.searchPlaceholder=Filtrer par titre, contenu ou auteur


### PR DESCRIPTION
Prior to this change and after cleaning useless news labels, the notification plugins labels are wrongly removed. With this PR, we will restore the missed notification plugins labels.