### PR TITLE
Task-52295: Add longdesc attribute to the principal image of the news

### DIFF
--- a/webapp/src/main/webapp/news-details/components/ExoNewsDetailsBody.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsDetailsBody.vue
@@ -14,7 +14,8 @@
           <img
             :src="illustrationURL"
             class="newsDetailsImage illustrationPicture"
-            alt="News">
+            alt="News"
+            longdesc="#newsSummary">
         </div>
         <div class="newsDetails">
           <div class="news-top-information d-flex">
@@ -30,7 +31,9 @@
               <div :class="[ showUpdateInfo ? 'newsUpdateInfo' : '']">
                 <div class="activityAvatar avatarCircle">
                   <a :href="authorProfileURL">
-                    <img :src="authorAvatarURL" class="avatar">
+                    <img
+                      :src="authorAvatarURL"
+                      class="avatar">
                   </a>
                 </div>
               </div>

--- a/webapp/src/main/webapp/news-details/components/ExoNewsDetailsBody.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsDetailsBody.vue
@@ -31,9 +31,7 @@
               <div :class="[ showUpdateInfo ? 'newsUpdateInfo' : '']">
                 <div class="activityAvatar avatarCircle">
                   <a :href="authorProfileURL">
-                    <img
-                      :src="authorAvatarURL"
-                      class="avatar">
+                    <img :src="authorAvatarURL" class="avatar">
                   </a>
                 </div>
               </div>


### PR DESCRIPTION
Before this fix principal image in the top of news detail page missing **longdesc** attribute
This fix adds **longdesc** attribute to refer to the news summary section and long description for the news