### PR TITLE
TASK-52070: Add role presentation for decorative images in news detail page

### DIFF
--- a/webapp/src/main/webapp/news-details/components/ExoNewsDetailsBody.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsDetailsBody.vue
@@ -31,7 +31,10 @@
               <div :class="[ showUpdateInfo ? 'newsUpdateInfo' : '']">
                 <div class="activityAvatar avatarCircle">
                   <a :href="authorProfileURL">
-                    <img :src="authorAvatarURL" class="avatar">
+                    <img
+                      :src="authorAvatarURL"
+                      class="avatar"
+                      role="presentation">
                   </a>
                 </div>
               </div>


### PR DESCRIPTION
In this PR we add role presentation for all user and space avatar, because we consider them as decorative images.