### PR TITLE
Task-52286: Fix shared news activity link

### DIFF
--- a/webapp/src/main/webapp/news-extensions/extensions.js
+++ b/webapp/src/main/webapp/news-extensions/extensions.js
@@ -70,7 +70,7 @@ const newsActivityTypeExtensionOptions = {
     }
     return '';
   },
-  getSourceLink: (activity) => `${eXo.env.portal.context}/${eXo.env.portal.portalName}/activity?id=${activity.id}`,
+  getSourceLink: (activity) => `${eXo.env.portal.context}/${eXo.env.portal.portalName}/activity?id=${!activity.parentActivity ? activity.id : activity.parentActivity.id}`,
   getSummary: (activity) => {
     const news = activity && activity.news;
     if (news && news.summary) {


### PR DESCRIPTION
Prior to this change, when a user is not member of a the space from which the news or news activity has been shared, from the stream, the shared article points to the original shared activity on which the user has not access. To solve this problem, we point the shared article instead to the share generated activity and not the original shared activity allowing the user to react on it.