### PR TITLE
Task-52348: Fix displaying shared article for sharedIn spaces members

### DIFF
--- a/services/src/main/java/org/exoplatform/news/service/impl/NewsServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/service/impl/NewsServiceImpl.java
@@ -264,7 +264,7 @@ public class NewsServiceImpl implements NewsService {
       throw new IllegalAccessException("User " + currentIdentity.getUserId() + " isn't allowed to access activity with id " + activityId);
     }
     Map<String, String> templateParams = activity.getTemplateParams();
-    if (templateParams == null || !activity.getTemplateParams().containsKey(NEWS_ID)) {
+    if (templateParams == null) {
       throw new ObjectNotFoundException("Activity with id " + activityId + " isn't of type news nor a shared news");
     }
     String newsId = templateParams.get(NEWS_ID);
@@ -423,7 +423,8 @@ public class NewsServiceImpl implements NewsService {
       if (!news.isPublished()
           && StringUtils.equals(news.getPublicationState(), PublicationDefaultStates.PUBLISHED)
           && !(spaceService.isSuperManager(username)
-              || spaceService.isMember(space, username))) {
+              || spaceService.isMember(space, username)
+              || isMemberOfsharedInSpaces(news, username))) {
         return false;
       }
       if (StringUtils.equals(news.getPublicationState(), PublicationDefaultStates.STAGED)
@@ -585,5 +586,14 @@ public class NewsServiceImpl implements NewsService {
     Space currentSpace = spaceService.getSpaceById(spaceId);
     return authenticatedUser.equals(posterId) || userACL.isSuperUser() || spaceService.isSuperManager(authenticatedUser)
         || spaceService.isManager(currentSpace, authenticatedUser);
+  }
+  
+  private boolean isMemberOfsharedInSpaces(News news, String username) {
+    for (Space space : news.getSharedInSpacesList()) {
+      if(spaceService.isMember(space, username)) {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/services/src/main/java/org/exoplatform/news/storage/jcr/JcrNewsStorage.java
+++ b/services/src/main/java/org/exoplatform/news/storage/jcr/JcrNewsStorage.java
@@ -454,7 +454,7 @@ public class JcrNewsStorage implements NewsStorage {
           news.setUrl(newsUrl.toString());
         }
         memberSpaceActivities.append(activities[0]).append(";");
-        Set<Space> sharedInSpacesList = new HashSet<Space>();
+        Set<Space> sharedInSpacesList = new HashSet<>();
         for (int i = 1; i < activities.length; i++) {
           Space space = spaceService.getSpaceById(activities[i].split(":")[0]);
           sharedInSpacesList.add(space);

--- a/services/src/main/java/org/exoplatform/news/storage/jcr/JcrNewsStorage.java
+++ b/services/src/main/java/org/exoplatform/news/storage/jcr/JcrNewsStorage.java
@@ -12,8 +12,10 @@ import java.util.Calendar;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
@@ -452,14 +454,17 @@ public class JcrNewsStorage implements NewsStorage {
           news.setUrl(newsUrl.toString());
         }
         memberSpaceActivities.append(activities[0]).append(";");
+        Set<Space> sharedInSpacesList = new HashSet<Space>();
         for (int i = 1; i < activities.length; i++) {
           Space space = spaceService.getSpaceById(activities[i].split(":")[0]);
+          sharedInSpacesList.add(space);
           String activityId = activities[i].split(":")[1];
           if (space != null && currentUsername != null && spaceService.isMember(space, currentUsername) && activityManager.isActivityExists(activityId)) {
             memberSpaceActivities.append(activities[i]).append(";");
           }
         }
         news.setActivities(memberSpaceActivities.toString());
+        news.setSharedInSpacesList(sharedInSpacesList);
       } 
       else {
         newsUrl.append("/").append(portalName).append("/").append(portalOwner).append("/news/detail?newsId=").append(news.getId());


### PR DESCRIPTION
Prior to this fix, when a sharedIn space member try to access the shared article:
-/ from news app, the article illustration and the article detail are broken. Also, the sharedIn spaces drawer showing the shared activities is empty
-/ from steam, the article illustration is broken when access to the shared activity from space stream or from its detail.
The view access rights was not possible for sharedIn spaces members, with this commit, we ensure that sharedIn spaces members are able to view the shared article.