### PR TITLE
Task-52417: Fix shared articles attachments preview by the shared in space members

### DIFF
--- a/services/src/main/java/org/exoplatform/news/storage/NewsAttachmentsStorage.java
+++ b/services/src/main/java/org/exoplatform/news/storage/NewsAttachmentsStorage.java
@@ -2,6 +2,7 @@ package org.exoplatform.news.storage;
 
 import org.exoplatform.news.model.News;
 import org.exoplatform.news.model.NewsAttachment;
+import org.exoplatform.social.core.space.model.Space;
 
 import javax.jcr.Node;
 import java.io.InputStream;
@@ -28,4 +29,6 @@ public interface NewsAttachmentsStorage {
   void unmakeAttachmentsPublic(Node newsNode) throws Exception;
 
   void removeAttachment(Node newsNode, String attachmentId);
+
+  void makeAttachmentsShareable(Node newsNode, Space space) throws Exception;
 }

--- a/services/src/main/java/org/exoplatform/news/storage/NewsAttachmentsStorage.java
+++ b/services/src/main/java/org/exoplatform/news/storage/NewsAttachmentsStorage.java
@@ -30,5 +30,5 @@ public interface NewsAttachmentsStorage {
 
   void removeAttachment(Node newsNode, String attachmentId);
 
-  void makeAttachmentsShareable(Node newsNode, Space space) throws Exception;
+  void makeAttachmentsShareable(Node newsNode, Space space);
 }

--- a/services/src/main/java/org/exoplatform/news/storage/NewsAttachmentsStorage.java
+++ b/services/src/main/java/org/exoplatform/news/storage/NewsAttachmentsStorage.java
@@ -30,5 +30,5 @@ public interface NewsAttachmentsStorage {
 
   void removeAttachment(Node newsNode, String attachmentId);
 
-  void makeAttachmentsShareable(Node newsNode, Space space);
+  void shareAttachments(Node newsNode, Space space);
 }

--- a/services/src/main/java/org/exoplatform/news/storage/jcr/JcrNewsAttachmentsStorage.java
+++ b/services/src/main/java/org/exoplatform/news/storage/jcr/JcrNewsAttachmentsStorage.java
@@ -324,7 +324,7 @@ public class JcrNewsAttachmentsStorage implements NewsAttachmentsStorage {
   }
 
   @Override
-  public void makeAttachmentsShareable(Node newsNode, Space space) {
+  public void shareAttachments(Node newsNode, Space space) {
     try {
       for (Node attachmentNode : getAttachmentsNodesOfNews(newsNode)) {
         if (attachmentNode.canAddMixin("exo:privilegeable")) {
@@ -334,7 +334,7 @@ public class JcrNewsAttachmentsStorage implements NewsAttachmentsStorage {
         attachmentNode.save();
       }
     } catch (Exception e) {
-      LOG.error("Cannot get News attachment of News " + newsNode, e);
+      LOG.error("Cannot share News attachment of News " + newsNode, e);
     }
   }
 

--- a/services/src/main/java/org/exoplatform/news/storage/jcr/JcrNewsAttachmentsStorage.java
+++ b/services/src/main/java/org/exoplatform/news/storage/jcr/JcrNewsAttachmentsStorage.java
@@ -324,17 +324,17 @@ public class JcrNewsAttachmentsStorage implements NewsAttachmentsStorage {
   }
 
   @Override
-  public void makeAttachmentsShareable(Node newsNode, Space space) throws Exception {
-    for (Node attachmentNode : getAttachmentsNodesOfNews(newsNode)) {
-      try {
+  public void makeAttachmentsShareable(Node newsNode, Space space) {
+    try {
+      for (Node attachmentNode : getAttachmentsNodesOfNews(newsNode)) {
         if (attachmentNode.canAddMixin("exo:privilegeable")) {
           attachmentNode.addMixin("exo:privilegeable");
         }
         ((ExtendedNode) attachmentNode).setPermission(space.getGroupId(), new String[] { PermissionType.READ });
         attachmentNode.save();
-      } catch (Exception e) {
-        LOG.error("Cannot make News attachment " + attachmentNode.getUUID() + " of News " + newsNode.getUUID() + " public", e);
       }
+    } catch (Exception e) {
+      LOG.error("Cannot get News attachment of News " + newsNode, e);
     }
   }
 

--- a/services/src/main/java/org/exoplatform/news/storage/jcr/JcrNewsAttachmentsStorage.java
+++ b/services/src/main/java/org/exoplatform/news/storage/jcr/JcrNewsAttachmentsStorage.java
@@ -323,6 +323,21 @@ public class JcrNewsAttachmentsStorage implements NewsAttachmentsStorage {
     }
   }
 
+  @Override
+  public void makeAttachmentsShareable(Node newsNode, Space space) throws Exception {
+    for (Node attachmentNode : getAttachmentsNodesOfNews(newsNode)) {
+      try {
+        if (attachmentNode.canAddMixin("exo:privilegeable")) {
+          attachmentNode.addMixin("exo:privilegeable");
+        }
+        ((ExtendedNode) attachmentNode).setPermission(space.getGroupId(), new String[] { PermissionType.READ });
+        attachmentNode.save();
+      } catch (Exception e) {
+        LOG.error("Cannot make News attachment " + attachmentNode.getUUID() + " of News " + newsNode.getUUID() + " public", e);
+      }
+    }
+  }
+
   protected NewsAttachment convertNodeToNewsAttachment(Node attachmentNode) throws Exception {
     String mimetype = "";
     int attachmentSize = 0;

--- a/services/src/main/java/org/exoplatform/news/storage/jcr/JcrNewsStorage.java
+++ b/services/src/main/java/org/exoplatform/news/storage/jcr/JcrNewsStorage.java
@@ -1222,7 +1222,7 @@ public class JcrNewsStorage implements NewsStorage {
         try {
           newsAttachmentsService.makeAttachmentsShareable(newsNode, space);
         } catch (Exception e) {
-          LOG.error("Error when making attachments public");
+          LOG.error("Error when making attachments shareable in" + space.getId());
         }
       }
       newsNode.setPermission("*:" + space.getGroupId(), SHARE_NEWS_PERMISSIONS);

--- a/services/src/main/java/org/exoplatform/news/storage/jcr/JcrNewsStorage.java
+++ b/services/src/main/java/org/exoplatform/news/storage/jcr/JcrNewsStorage.java
@@ -1219,7 +1219,7 @@ public class JcrNewsStorage implements NewsStorage {
         newsNode.addMixin("exo:privilegeable");
       }
       if (newsNode.hasProperty("exo:attachmentsIds")) {
-        newsAttachmentsService.makeAttachmentsShareable(newsNode, space);
+        newsAttachmentsService.shareAttachments(newsNode, space);
       }
       newsNode.setPermission("*:" + space.getGroupId(), SHARE_NEWS_PERMISSIONS);
       newsNode.save();
@@ -1237,7 +1237,7 @@ public class JcrNewsStorage implements NewsStorage {
       throw new IllegalStateException("Error while sharing news with id " + newsId + " to space " + space.getId() + " by user"
           + userIdentity.getId(), e);
     } catch (Exception e) {
-      LOG.error("Error when making attachments shareable in" + space.getId());
+      LOG.error("Error when sharing news with id " + newsId + " attachments in " + space.getId());
     }
   }
   

--- a/services/src/main/java/org/exoplatform/news/storage/jcr/JcrNewsStorage.java
+++ b/services/src/main/java/org/exoplatform/news/storage/jcr/JcrNewsStorage.java
@@ -1219,11 +1219,7 @@ public class JcrNewsStorage implements NewsStorage {
         newsNode.addMixin("exo:privilegeable");
       }
       if (newsNode.hasProperty("exo:attachmentsIds")) {
-        try {
-          newsAttachmentsService.makeAttachmentsShareable(newsNode, space);
-        } catch (Exception e) {
-          LOG.error("Error when making attachments shareable in" + space.getId());
-        }
+        newsAttachmentsService.makeAttachmentsShareable(newsNode, space);
       }
       newsNode.setPermission("*:" + space.getGroupId(), SHARE_NEWS_PERMISSIONS);
       newsNode.save();
@@ -1232,8 +1228,7 @@ public class JcrNewsStorage implements NewsStorage {
           String activities = newsNode.getProperty("exo:activities").getString();
           activities = activities.concat(";").concat(space.getId()).concat(":").concat(sharedActivityId);
           newsNode.setProperty("exo:activities", activities);
-        } 
-        else {
+        } else {
           newsNode.setProperty("exo:activities", sharedActivityId);
         }
         newsNode.save();
@@ -1241,6 +1236,8 @@ public class JcrNewsStorage implements NewsStorage {
     } catch (RepositoryException e) {
       throw new IllegalStateException("Error while sharing news with id " + newsId + " to space " + space.getId() + " by user"
           + userIdentity.getId(), e);
+    } catch (Exception e) {
+      LOG.error("Error when making attachments shareable in" + space.getId());
     }
   }
   

--- a/services/src/main/java/org/exoplatform/news/storage/jcr/JcrNewsStorage.java
+++ b/services/src/main/java/org/exoplatform/news/storage/jcr/JcrNewsStorage.java
@@ -1218,6 +1218,13 @@ public class JcrNewsStorage implements NewsStorage {
       if (newsNode.canAddMixin("exo:privilegeable")) {
         newsNode.addMixin("exo:privilegeable");
       }
+      if (newsNode.hasProperty("exo:attachmentsIds")) {
+        try {
+          newsAttachmentsService.makeAttachmentsShareable(newsNode, space);
+        } catch (Exception e) {
+          LOG.error("Error when making attachments public");
+        }
+      }
       newsNode.setPermission("*:" + space.getGroupId(), SHARE_NEWS_PERMISSIONS);
       newsNode.save();
       if (sharedActivityId != null) {


### PR DESCRIPTION
Prior to this change, when a news is shared in a space, a member of the shared in space can't preview to the shared news attachments since they are not shared like the news itself. After this change, we have shared the news attachments too to the shared in space members in order to allow them preview these attachments.