### PR TITLE
Task-52167: Fix cancel scheduling and drafts issues

### DIFF
--- a/services/src/main/java/org/exoplatform/news/storage/jcr/JcrNewsStorage.java
+++ b/services/src/main/java/org/exoplatform/news/storage/jcr/JcrNewsStorage.java
@@ -1119,6 +1119,10 @@ public class JcrNewsStorage implements NewsStorage {
         unScheduledNewsNode.save();
         publicationService.changeState(unScheduledNewsNode, PublicationDefaultStates.DRAFT, new HashMap<>());
       }
+      if (unScheduledNewsNode.hasProperty(AuthoringPublicationConstant.START_TIME_PROPERTY)) {
+        unScheduledNewsNode.getProperty(AuthoringPublicationConstant.START_TIME_PROPERTY).remove();
+        unScheduledNewsNode.save();
+      }
       draftNews = getNewsById(news.getId(), false);
       draftNews.setSchedulePostDate(null);
     } finally {

--- a/webapp/src/main/webapp/news/components/NewsAppItem.vue
+++ b/webapp/src/main/webapp/news/components/NewsAppItem.vue
@@ -61,8 +61,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
             </a>
           </span>
         </div>
-        <div class="newsDate">
-          <i class="uiIconClock"></i>
+        <div v-if="!draftNews" class="newsDate">
+          <i v-if="displayClock" class="uiIconClock"></i>
           <span v-if="news && news.schedulePostDate">
             <date-format
               :value="news.schedulePostDate"
@@ -140,6 +140,12 @@ export default {
     confirmDeleteNewsDialogTitle() {
       return this.isDraftsFilter ? this.$t('news.title.confirmDeleteDraftNews') : this.$t('news.title.confirmDeleteNews');
     },
+    displayClock() {
+      return this.news && (this.news.schedulePostDate || this.news.updatedDate);
+    },
+    draftNews() {
+      return this.news && this.news.draft;
+    }
   },
   methods: {
     editLink(news) {


### PR DESCRIPTION
Prior to this change, we have:
- The clock icon is displayed for a draft news from the news app 
- When we unschedule news, the scheduled date still exist and we can't reschedule the same news with the same scheduled date. 

After this change, the schedule problem is fixed by removing the property of schedule date when news is un scheduled and the clock icon displayed for a draft news from the news app is removed