### PR TITLE
Task-52417: Fix share news attachments

### DIFF
--- a/services/src/main/java/org/exoplatform/news/storage/jcr/JcrNewsAttachmentsStorage.java
+++ b/services/src/main/java/org/exoplatform/news/storage/jcr/JcrNewsAttachmentsStorage.java
@@ -330,7 +330,7 @@ public class JcrNewsAttachmentsStorage implements NewsAttachmentsStorage {
         if (attachmentNode.canAddMixin("exo:privilegeable")) {
           attachmentNode.addMixin("exo:privilegeable");
         }
-        ((ExtendedNode) attachmentNode).setPermission(space.getGroupId(), new String[] { PermissionType.READ });
+        ((ExtendedNode) attachmentNode).setPermission("*:" + space.getGroupId(), new String[] { PermissionType.READ });
         attachmentNode.save();
       }
     } catch (Exception e) {


### PR DESCRIPTION
Prior to this change, the shared in space permission on shared article attachment is not well set which make the attachment not shared. With this PR we fix the shared in space permission.