### PR TITLE
MAINT-52325: Fix incorrect number of views issue on news articles

### DIFF
--- a/services/src/main/java/org/exoplatform/news/storage/jcr/JcrNewsStorage.java
+++ b/services/src/main/java/org/exoplatform/news/storage/jcr/JcrNewsStorage.java
@@ -1017,7 +1017,6 @@ public class JcrNewsStorage implements NewsStorage {
     if (!newsNode.hasProperty("exo:viewers")) {
       newsNode.setProperty("exo:viewers", "");
     }
-
     String newsViewers = newsNode.getProperty("exo:viewers").getString();
     if (newsViewers.isEmpty()) {
       newsViewers = newsViewers.concat(userId);
@@ -1026,8 +1025,14 @@ public class JcrNewsStorage implements NewsStorage {
       newsViewers = newsViewers.concat(",").concat(userId);
     }
     newsNode.setProperty("exo:viewers", newsViewers);
-    Long newsViewsCount = news.getViewsCount() == null ? (long) 1 : news.getViewsCount() + 1;
-    newsNode.setProperty("exo:viewsCount", newsViewsCount);
+
+    if (!newsNode.hasProperty("exo:viewsCount")) {
+      newsNode.setProperty("exo:viewsCount", 0L);
+    } else {
+      Long newsViewsCount = newsNode.getProperty("exo:viewsCount").getValue().getLong() + 1;
+      newsNode.setProperty("exo:viewsCount", newsViewsCount);
+    }
+
     newsNode.save();
   }
   


### PR DESCRIPTION
**ISSUE**: When an article creator is about editing his article and another user visits the article to read it, the publication state of the article in turned into draft, In this case the receiver gets the live revision version which has the wrong number of `viewsCount` and not the same as the original node, the `markAsRead` function at its beginning get the news node by its uuid and it's the original node has correct `viewsCount` and correct `viewers` properties but it uses this node to update the viewers property which is the correct but it doesn't use it to update viewsCount, instead it uses the news model filled from the  `liveRevision` node passed as argument to update the `viewsCount` which overrides the the viewsCount by a wrong number and kills the possibility to correct this in the next visit for the same user by adding its user name in the list of `viewers`
**FIX**: This fix will use the updated original node to update the `viewsCount` as the way used in updating viewers