### PR TITLE
MAINT-51975: Broadcast viewArticle event to analytics listener for already added viewers to allow count multiple views by user

### DIFF
--- a/services/src/main/java/org/exoplatform/news/service/impl/NewsServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/service/impl/NewsServiceImpl.java
@@ -352,8 +352,10 @@ public class NewsServiceImpl implements NewsService {
    */
   @Override
   public void markAsRead(News news, String userId) throws Exception {
-    if(!newsStorage.isCurrentUserInNewsViewers(news.getId(), userId)) {
+    if (!newsStorage.isCurrentUserInNewsViewers(news.getId(), userId)) {
       newsStorage.markAsRead(news, userId);
+      NewsUtils.broadcastEvent(NewsUtils.VIEW_NEWS, userId, news);
+    } else {
       NewsUtils.broadcastEvent(NewsUtils.VIEW_NEWS, userId, news);
     }
   }

--- a/services/src/test/java/org/exoplatform/news/service/impl/NewsServiceImplTest.java
+++ b/services/src/test/java/org/exoplatform/news/service/impl/NewsServiceImplTest.java
@@ -1,0 +1,85 @@
+package org.exoplatform.news.service.impl;
+
+import org.exoplatform.commons.search.index.IndexingService;
+import org.exoplatform.news.model.News;
+import org.exoplatform.news.search.NewsESSearchConnector;
+import org.exoplatform.news.service.NewsService;
+import org.exoplatform.news.service.NewsTargetingService;
+import org.exoplatform.news.storage.NewsStorage;
+import org.exoplatform.news.utils.NewsUtils;
+import org.exoplatform.portal.config.UserACL;
+import org.exoplatform.social.core.manager.ActivityManager;
+import org.exoplatform.social.core.manager.IdentityManager;
+import org.exoplatform.social.core.space.spi.SpaceService;
+import org.exoplatform.upload.UploadService;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+
+import static org.mockito.Mockito.*;
+
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(NewsUtils.class)
+public class NewsServiceImplTest {
+
+    @Mock
+    private NewsStorage newsStorage;
+
+    @Mock
+    private SpaceService spaceService;
+
+    @Mock
+    private ActivityManager activityManager;
+
+    @Mock
+    private IdentityManager identityManager;
+
+    @Mock
+    private NewsESSearchConnector newsESSearchConnector;
+
+    @Mock
+    private IndexingService indexingService;
+
+    @Mock
+    private UserACL userACL;
+
+    @Mock
+    private NewsTargetingService newsTargetingService;
+
+    @Mock
+    private UploadService uploadService;
+
+    private NewsService newsService;
+
+    @Before
+    public void setUp() {
+        this.newsService = new NewsServiceImpl(spaceService, activityManager, identityManager, uploadService,
+                newsESSearchConnector,indexingService, newsStorage, userACL, newsTargetingService);
+    }
+
+    @Test
+    public void markAsRead() throws Exception {
+        News news = new News();
+        news.setId("1");
+        news.setViewsCount((long) 2);
+
+        PowerMockito.mockStatic(NewsUtils.class);
+        when(newsStorage.isCurrentUserInNewsViewers(anyString(), anyString())).thenReturn(true, false);
+        doNothing().when(newsStorage).markAsRead(any(), anyString());
+        newsService.markAsRead(news, "user");
+        PowerMockito.verifyStatic(NewsUtils.class, atLeastOnce());
+        NewsUtils.broadcastEvent(anyString(), any(), any());
+        verify(newsStorage, times(0)).markAsRead(news, "user");
+        newsService.markAsRead(news, "user");
+        PowerMockito.verifyStatic(NewsUtils.class, atLeastOnce());
+        NewsUtils.broadcastEvent(anyString(), any(), any());
+        verify(newsStorage, times(1)).markAsRead(news, "user");
+
+    }
+}


### PR DESCRIPTION
…
**ISSUE**: When a user reads an article the event `viewArticle` is dispatched only when the user is never read the article, which doesn't allow to get the multiple views for a given user on an article in the analytics app
**FIX**: The fix will allow broadcasting the event `viewArticle` even if the user already added to viewers list in an article to allow save the action in the analytics app