### PR TITLE
MAINT-51975: Avoid markNewsAsRead trigger when getting article info in analytics app

### DIFF
--- a/services/src/test/java/org/exoplatform/news/rest/NewsRestResourcesV1Test.java
+++ b/services/src/test/java/org/exoplatform/news/rest/NewsRestResourcesV1Test.java
@@ -1617,7 +1617,6 @@ public class NewsRestResourcesV1Test {
     lenient().when(spaceService.getSpaceById("space1")).thenReturn(space1);
     lenient().when(spaceService.isMember(any(Space.class), eq("john"))).thenReturn(true);
     lenient().when(spaceService.isSuperManager(eq("john"))).thenReturn(false);
-    lenient().doNothing().when(newsService).markAsRead(news, "john");
 
     // When
     Response response = newsRestResourcesV1.getNewsById(request, "1", null, false);
@@ -1644,8 +1643,6 @@ public class NewsRestResourcesV1Test {
     news.setViewsCount((long) 6);
 
     lenient().when(newsService.getNewsById("1", currentIdentity, false)).thenReturn(news);
-    lenient().doNothing().when(newsService).markAsRead(news, "john");
-
     // When
     Response response = newsRestResourcesV1.getNewsById(request, "2", null, false);
     ;
@@ -2489,5 +2486,26 @@ public class NewsRestResourcesV1Test {
 
   private void setCurrentUser(final String name) {
     ConversationState.setCurrent(new ConversationState(new org.exoplatform.services.security.Identity(name)));
+  }
+
+  @Test
+  public void testMarkAsRead() throws Exception {
+    NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
+            newsAttachmentsService,
+            spaceService,
+            identityManager,
+            container,
+            favoriteService);
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    lenient().when(request.getRemoteUser()).thenReturn("john");
+    Identity currentIdentity = new Identity("john");
+    ConversationState.setCurrent(new ConversationState(currentIdentity));
+    News news = new News();
+    news.setId("1");
+    when(newsService.getNewsById("1",currentIdentity, false)).thenReturn(news);
+    doNothing().when(newsService).markAsRead(news, "john");
+    Response response = newsRestResourcesV1.markNewsAsRead(request, "1");
+    verify(newsService, times(1)).markAsRead(news,"john");
+    assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
   }
 }

--- a/webapp/src/main/webapp/news-details/components/ExoNewsDetails.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsDetails.vue
@@ -39,6 +39,7 @@
   </div>
 </template>
 <script>
+
 const USER_TIMEZONE_ID = new window.Intl.DateTimeFormat().resolvedOptions().timeZone;
 export default {
   props: {
@@ -120,8 +121,14 @@ export default {
       };
       socialProfile.initUserProfilePopup('newsDetails', labels);
     });
+    this.markNewsAsRead(this.newsId);
   },
   methods: {
+    markNewsAsRead(newsId) {
+      if (newsId) {
+        this.$newsServices.markNewsAsRead(newsId);
+      }
+    },
     getSpaceById(spaceId) {
       this.$spaceService.getSpaceById(spaceId, 'identity')
         .then((space) => {

--- a/webapp/src/main/webapp/services/newsServices.js
+++ b/webapp/src/main/webapp/services/newsServices.js
@@ -39,6 +39,19 @@ export function getNewsSpaces(newsId) {
   });
 }
 
+export function markNewsAsRead(newsId){
+  return fetch(`${newsConstants.NEWS_API}/markAsRead/${newsId}`, {
+    credentials: 'include',
+    method: 'POST',
+  }).then((resp) => {
+    if (resp && resp.ok) {
+      return resp.text();
+    } else {
+      throw new Error('Error while marking news as read');
+    }
+  });
+}
+
 export function getNews(filter, spaces, searchText, offset, limit, returnSize) {
   let url = `${newsConstants.NEWS_API}?author=${newsConstants.userName}&publicationState=published&filter=${filter}`;
   if (searchText) {


### PR DESCRIPTION
…
**ISSUE**: The `markAsRead` function was placed in `getNewsByid` rest endpoint which will trigger this function when call the endpoint even from outside the news its self which is not correct
**FIX**: Create a new rest endpoint for marking news as read and call it when access the news details which seems more logic