### PR TITLE
Task-52602: Fix duplicated alert information message when sharing an article

### DIFF
--- a/webapp/src/main/webapp/components/snackbar/ExoNewsNotificationAlerts.vue
+++ b/webapp/src/main/webapp/components/snackbar/ExoNewsNotificationAlerts.vue
@@ -60,8 +60,8 @@ export default {
         });
       }
     });
-    this.$root.$on('activity-apps-shared', (activityId, spaces) => {
-      if (activityId && spaces && spaces.length > 0) {
+    this.$root.$on('activity-shared', (activityId, spaces, selectedApps) => {
+      if (selectedApps === 'newsApp' && activityId && spaces && spaces.length > 0) {
         const spacesList = spaces.map(space => space.displayName);
         const message = `${this.$t('news.share.message')} ${spacesList.join(', ')}`;
         this.$root.$emit('news-notification-alert', {

--- a/webapp/src/main/webapp/components/snackbar/ExoNewsNotificationAlerts.vue
+++ b/webapp/src/main/webapp/components/snackbar/ExoNewsNotificationAlerts.vue
@@ -60,7 +60,7 @@ export default {
         });
       }
     });
-    this.$root.$on('activity-shared', (activityId, spaces) => {
+    this.$root.$on('activity-apps-shared', (activityId, spaces) => {
       if (activityId && spaces && spaces.length > 0) {
         const spacesList = spaces.map(space => space.displayName);
         const message = `${this.$t('news.share.message')} ${spacesList.join(', ')}`;

--- a/webapp/src/main/webapp/news-details/components/ExoNewsDetailsActionMenu.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsDetailsActionMenu.vue
@@ -24,7 +24,7 @@
             {{ $t('news.details.header.menu.edit') }}
           </v-list-item-title>
         </v-list-item>
-        <v-list-item v-if="showShareButton && news.activityId" @click="$root.$emit('activity-share-drawer-open', news.activityId)">
+        <v-list-item v-if="showShareButton && news.activityId" @click="$root.$emit('activity-share-drawer-open', news.activityId, 'newsDetails')">
           <v-list-item-title>
             {{ $t('news.details.header.menu.share') }}
           </v-list-item-title>

--- a/webapp/src/main/webapp/news/components/ExoNewsDetailsActionMenuApp.vue
+++ b/webapp/src/main/webapp/news/components/ExoNewsDetailsActionMenuApp.vue
@@ -24,7 +24,7 @@
           {{ $t('news.details.header.menu.edit') }}
         </v-list-item-title>
       </v-list-item>
-      <v-list-item v-if="showShareButton && news.activityId" @click="$root.$emit('activity-share-drawer-open', news.activityId)">
+      <v-list-item v-if="showShareButton && news.activityId" @click="$root.$emit('activity-share-drawer-open', news.activityId, 'newsApp')">
         <v-list-item-title>
           {{ $t('news.details.header.menu.share') }}
         </v-list-item-title>


### PR DESCRIPTION
Prior to this change, the alert information after sharing an article from news app is displayed twice. The problem is due to the call of the share activity `ExoNewsNotificationAlerts` component from news App. After this change, we ensure to call this component only when sharing activity from news apps.