### PR TITLE
MAINT-51975: broadcast viewArticle event to analytics listener for already added viewers to allow count multiple views by user 

### DIFF
--- a/services/src/main/java/org/exoplatform/news/service/impl/NewsServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/service/impl/NewsServiceImpl.java
@@ -354,10 +354,8 @@ public class NewsServiceImpl implements NewsService {
   public void markAsRead(News news, String userId) throws Exception {
     if (!newsStorage.isCurrentUserInNewsViewers(news.getId(), userId)) {
       newsStorage.markAsRead(news, userId);
-      NewsUtils.broadcastEvent(NewsUtils.VIEW_NEWS, userId, news);
-    } else {
-      NewsUtils.broadcastEvent(NewsUtils.VIEW_NEWS, userId, news);
     }
+    NewsUtils.broadcastEvent(NewsUtils.VIEW_NEWS, userId, news);
   }
 
   /**

--- a/services/src/main/java/org/exoplatform/news/service/impl/NewsServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/service/impl/NewsServiceImpl.java
@@ -352,8 +352,10 @@ public class NewsServiceImpl implements NewsService {
    */
   @Override
   public void markAsRead(News news, String userId) throws Exception {
-    if(!newsStorage.isCurrentUserInNewsViewers(news.getId(), userId)) {
+    if (!newsStorage.isCurrentUserInNewsViewers(news.getId(), userId)) {
       newsStorage.markAsRead(news, userId);
+      NewsUtils.broadcastEvent(NewsUtils.VIEW_NEWS, userId, news);
+    } else {
       NewsUtils.broadcastEvent(NewsUtils.VIEW_NEWS, userId, news);
     }
   }

--- a/services/src/test/java/org/exoplatform/news/rest/NewsRestResourcesV1Test.java
+++ b/services/src/test/java/org/exoplatform/news/rest/NewsRestResourcesV1Test.java
@@ -1617,7 +1617,6 @@ public class NewsRestResourcesV1Test {
     lenient().when(spaceService.getSpaceById("space1")).thenReturn(space1);
     lenient().when(spaceService.isMember(any(Space.class), eq("john"))).thenReturn(true);
     lenient().when(spaceService.isSuperManager(eq("john"))).thenReturn(false);
-    lenient().doNothing().when(newsService).markAsRead(news, "john");
 
     // When
     Response response = newsRestResourcesV1.getNewsById(request, "1", null, false);
@@ -1644,8 +1643,6 @@ public class NewsRestResourcesV1Test {
     news.setViewsCount((long) 6);
 
     lenient().when(newsService.getNewsById("1", currentIdentity, false)).thenReturn(news);
-    lenient().doNothing().when(newsService).markAsRead(news, "john");
-
     // When
     Response response = newsRestResourcesV1.getNewsById(request, "2", null, false);
     ;
@@ -2489,5 +2486,26 @@ public class NewsRestResourcesV1Test {
 
   private void setCurrentUser(final String name) {
     ConversationState.setCurrent(new ConversationState(new org.exoplatform.services.security.Identity(name)));
+  }
+
+  @Test
+  public void testMarkAsRead() throws Exception {
+    NewsRestResourcesV1 newsRestResourcesV1 = new NewsRestResourcesV1(newsService,
+            newsAttachmentsService,
+            spaceService,
+            identityManager,
+            container,
+            favoriteService);
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    lenient().when(request.getRemoteUser()).thenReturn("john");
+    Identity currentIdentity = new Identity("john");
+    ConversationState.setCurrent(new ConversationState(currentIdentity));
+    News news = new News();
+    news.setId("1");
+    when(newsService.getNewsById("1",currentIdentity, false)).thenReturn(news);
+    doNothing().when(newsService).markAsRead(news, "john");
+    Response response = newsRestResourcesV1.markNewsAsRead(request, "1");
+    verify(newsService, times(1)).markAsRead(news,"john");
+    assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
   }
 }

--- a/services/src/test/java/org/exoplatform/news/service/impl/NewsServiceImplTest.java
+++ b/services/src/test/java/org/exoplatform/news/service/impl/NewsServiceImplTest.java
@@ -1,0 +1,85 @@
+package org.exoplatform.news.service.impl;
+
+import org.exoplatform.commons.search.index.IndexingService;
+import org.exoplatform.news.model.News;
+import org.exoplatform.news.search.NewsESSearchConnector;
+import org.exoplatform.news.service.NewsService;
+import org.exoplatform.news.service.NewsTargetingService;
+import org.exoplatform.news.storage.NewsStorage;
+import org.exoplatform.news.utils.NewsUtils;
+import org.exoplatform.portal.config.UserACL;
+import org.exoplatform.social.core.manager.ActivityManager;
+import org.exoplatform.social.core.manager.IdentityManager;
+import org.exoplatform.social.core.space.spi.SpaceService;
+import org.exoplatform.upload.UploadService;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+
+import static org.mockito.Mockito.*;
+
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(NewsUtils.class)
+public class NewsServiceImplTest {
+
+    @Mock
+    private NewsStorage newsStorage;
+
+    @Mock
+    private SpaceService spaceService;
+
+    @Mock
+    private ActivityManager activityManager;
+
+    @Mock
+    private IdentityManager identityManager;
+
+    @Mock
+    private NewsESSearchConnector newsESSearchConnector;
+
+    @Mock
+    private IndexingService indexingService;
+
+    @Mock
+    private UserACL userACL;
+
+    @Mock
+    private NewsTargetingService newsTargetingService;
+
+    @Mock
+    private UploadService uploadService;
+
+    private NewsService newsService;
+
+    @Before
+    public void setUp() {
+        this.newsService = new NewsServiceImpl(spaceService, activityManager, identityManager, uploadService,
+                newsESSearchConnector,indexingService, newsStorage, userACL, newsTargetingService);
+    }
+
+    @Test
+    public void markAsRead() throws Exception {
+        News news = new News();
+        news.setId("1");
+        news.setViewsCount((long) 2);
+
+        PowerMockito.mockStatic(NewsUtils.class);
+        when(newsStorage.isCurrentUserInNewsViewers(anyString(), anyString())).thenReturn(true, false);
+        doNothing().when(newsStorage).markAsRead(any(), anyString());
+        newsService.markAsRead(news, "user");
+        PowerMockito.verifyStatic(NewsUtils.class, atLeastOnce());
+        NewsUtils.broadcastEvent(anyString(), any(), any());
+        verify(newsStorage, times(0)).markAsRead(news, "user");
+        newsService.markAsRead(news, "user");
+        PowerMockito.verifyStatic(NewsUtils.class, atLeastOnce());
+        NewsUtils.broadcastEvent(anyString(), any(), any());
+        verify(newsStorage, times(1)).markAsRead(news, "user");
+
+    }
+}

--- a/webapp/src/main/webapp/news-details/components/ExoNewsDetails.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsDetails.vue
@@ -39,6 +39,7 @@
   </div>
 </template>
 <script>
+
 const USER_TIMEZONE_ID = new window.Intl.DateTimeFormat().resolvedOptions().timeZone;
 export default {
   props: {
@@ -120,8 +121,14 @@ export default {
       };
       socialProfile.initUserProfilePopup('newsDetails', labels);
     });
+    this.markNewsAsRead(this.newsId);
   },
   methods: {
+    markNewsAsRead(newsId) {
+      if (newsId) {
+        this.$newsServices.markNewsAsRead(newsId);
+      }
+    },
     getSpaceById(spaceId) {
       this.$spaceService.getSpaceById(spaceId, 'identity')
         .then((space) => {

--- a/webapp/src/main/webapp/services/newsServices.js
+++ b/webapp/src/main/webapp/services/newsServices.js
@@ -39,6 +39,19 @@ export function getNewsSpaces(newsId) {
   });
 }
 
+export function markNewsAsRead(newsId){
+  return fetch(`${newsConstants.NEWS_API}/markAsRead/${newsId}`, {
+    credentials: 'include',
+    method: 'POST',
+  }).then((resp) => {
+    if (resp && resp.ok) {
+      return resp.text();
+    } else {
+      throw new Error('Error while marking news as read');
+    }
+  });
+}
+
 export function getNews(filter, spaces, searchText, offset, limit, returnSize) {
   let url = `${newsConstants.NEWS_API}?author=${newsConstants.userName}&publicationState=published&filter=${filter}`;
   if (searchText) {


### PR DESCRIPTION

ISSUE: When a user reads an article the event viewArticle is dispatched only when the user is neved read the article, which doesn't allow to get the multiple views for a given user on an article in the analytics app
FIX: The fix will allow broadcasting the event viewArticle even if the user already added to viewers list in an article to allow save the action in the analytics app

MAINT-51975: Avoid markNewsAsRead trigger when getting article info in analytics app (#399)

ISSUE: The markAsRead function was placed in getNewsByid rest endpoint which will trigger this function when call the endpoint even from outside the news its self which is not correct
FIX: Create a new rest endpoint for marking news as read and call it when access the news details which seems more logic