### PR TITLE
Task-52564: Fix displaying space name, number of likes and comments on news list snapshot portlets for non space members

### DIFF
--- a/services/src/main/java/org/exoplatform/news/model/News.java
+++ b/services/src/main/java/org/exoplatform/news/model/News.java
@@ -81,6 +81,10 @@ public class News {
 
   private Long                 viewsCount;
 
+  private int                 commentsCount;
+
+  private int                 likesCount;
+
   private String               activities;
 
   private String               activityId;

--- a/services/src/main/java/org/exoplatform/news/service/impl/NewsServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/service/impl/NewsServiceImpl.java
@@ -30,6 +30,7 @@ import org.exoplatform.portal.config.UserACL;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.services.wcm.publication.PublicationDefaultStates;
+import org.exoplatform.social.common.RealtimeListAccess;
 import org.exoplatform.social.core.activity.model.ExoSocialActivity;
 import org.exoplatform.social.core.activity.model.ExoSocialActivityImpl;
 import org.exoplatform.social.core.identity.model.Identity;
@@ -218,6 +219,12 @@ public class NewsServiceImpl implements NewsService {
       news.setCanPublish(canPublishNews(currentIdentity));
       news.setCanArchive(canArchiveNews(currentIdentity, news.getAuthor()));
       news.setTargets(newsTargetingService.getTargetsByNewsId(newsId));
+      ExoSocialActivity activity = activityManager.getActivity(news.getActivityId());
+      if (activity != null) {
+        RealtimeListAccess<ExoSocialActivity> listAccess = activityManager.getCommentsWithListAccess(activity, true);
+        news.setCommentsCount(listAccess.getSize());
+        news.setLikesCount(activity.getLikeIdentityIds() == null ? 0 : activity.getLikeIdentityIds().length);
+      }
     }
     return news;
   }

--- a/webapp/src/main/webapp/news-list-view/components/views/NewsLatestViewItem.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsLatestViewItem.vue
@@ -35,18 +35,20 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         <div class="reactions">
           <v-icon class="reactionIconStyle me-1" size="12">mdi-clock</v-icon>
           <span class="postDate flex-column me-2 my-auto">{{ formatDate(item.publishDate) }}</span>
-          <v-icon class="reactionIconStyle me-1" size="12">
-            mdi-thumb-up
-          </v-icon>
-          <div class="likesCount me-2">{{ likeSize }}</div>
-          <v-icon class="reactionIconStyle commentStyle me-1" size="12">
-            mdi-comment
-          </v-icon>
-          <div class="commentsCount me-2">{{ commentsSize }}</div>
-          <v-icon class="reactionIconStyle me-1" size="12">
-            mdi-eye
-          </v-icon>
-          <div class="viewCount">{{ item.viewsCount }}</div>
+          <div class="d-flex">
+            <v-icon class="reactionIconStyle me-1" size="12">
+              mdi-thumb-up
+            </v-icon>
+            <div class="likesCount me-2">{{ item.likesCount }}</div>
+            <v-icon class="reactionIconStyle commentStyle me-1" size="12">
+              mdi-comment
+            </v-icon>
+            <div class="commentsCount me-2">{{ item.commentsCount }}</div>
+            <v-icon class="reactionIconStyle me-1" size="12">
+              mdi-eye
+            </v-icon>
+            <div class="viewCount">{{ item.viewsCount }}</div>
+          </div>
         </div>
       </div>
     </div>
@@ -62,8 +64,6 @@ export default {
     },
   },
   data: ()=> ({
-    commentsSize: 0,
-    likeSize: 0,
     fullDateFormat: {
       year: 'numeric',
       month: 'short',
@@ -72,25 +72,7 @@ export default {
       minute: '2-digit',
     },
   }),
-  created() {
-    this.retrieveComments();
-    this.retrieveLikes();
-  },
   methods: {
-    retrieveComments() {
-      this.$activityService.getActivityComments(this.item.activityId, false, 0, 0, null)
-        .then(data => {
-          this.$nextTick().then(() => {
-            this.commentsSize = data && data.size && Number(data.size) || 0;
-          });
-        });
-    },
-    retrieveLikes() {
-      return this.$activityService.getActivityById(this.item.activityId, null)
-        .then(data => {
-          this.likeSize = data && data.likesCount &&  Number(data.likesCount) || 0;
-        });
-    },
     formatDate(date) {
       return this.$dateUtil.formatDateObjectToDisplay(new Date(date.time),this.fullDateFormat, eXo.env.portal.language);
     },

--- a/webapp/src/main/webapp/news-list-view/components/views/NewsSliderView.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsSliderView.vue
@@ -53,10 +53,14 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
               <news-slider-view-item
                 :author="item.author"
                 :author-display-name="item.authorDisplayName"
-                :space-id="item.spaceId"
+                :space-display-name="item.spaceDisplayName"
+                :space-url="item.spaceUrl"
+                :space-avatar-url="item.spaceAvatarUrl"
                 :publish-date="formatDate(item.publishDate)"
                 :author-avatar-url="item.authorAvatarUrl"
                 :activity-id="item.activityId"
+                :likes-count="item.likesCount"
+                :comments-count="item.commentsCount"
                 :views-count="item.viewsCount"
                 class="d-flex flex-row newsSliderItem align-center justify-center pa-2 ms-2" />
             </div>

--- a/webapp/src/main/webapp/news-list-view/components/views/NewsSliderViewItem.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsSliderViewItem.vue
@@ -48,7 +48,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
     <div class="reactions-container d-flex ml-4">
       <div class="likes-container mb-1">
         <v-icon class="likeIconStyle" size="14">mdi-thumb-up</v-icon>
-        <span class="counterStyle ml-1">{{ likeSize }}</span>
+        <span class="counterStyle ml-1">{{ likesCount }}</span>
       </div>
       <div class="comments-container ml-2">
         <v-icon
@@ -56,7 +56,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
           size="14">
           mdi-comment
         </v-icon>
-        <span class="counterStyle ml-1">{{ commentsSize }}</span>
+        <span class="counterStyle ml-1">{{ commentsCount }}</span>
       </div>
       <div class="views-container ml-2">
         <v-icon class="views-icon" size="16">mdi-eye</v-icon>
@@ -77,7 +77,15 @@ export default {
       type: String,
       default: ''
     },
-    spaceId: {
+    spaceDisplayName: {
+      type: String,
+      default: ''
+    },
+    spaceUrl: {
+      type: String,
+      default: ''
+    },
+    spaceAvatarUrl: {
       type: String,
       default: ''
     },
@@ -97,59 +105,14 @@ export default {
       type: Number,
       default: 0
     },
+    likesCount: {
+      type: Number,
+      default: 0
+    },
+    commentsCount: {
+      type: Number,
+      default: 0
+    },
   },
-  data: () => ({
-    space: null,
-    commentsSize: 0,
-    likeSize: 0,
-  }),
-  computed: {
-    spaceUrl() {
-      if (this.space && this.space.groupId) {
-        const uri = this.space.groupId.replace(/\//g, ':');
-        return `${eXo.env.portal.context}/g/${uri}/`;
-      }
-      return '#';
-    },
-    spaceAvatarUrl() {
-      return this.space && this.space.avatarUrl;
-    },
-    spaceDisplayName() {
-      return this.space && this.space.displayName;
-    }
-  },
-  created() {
-    if (this.spaceId) {
-      this.getSpaceById(this.spaceId);
-    }
-    this.retrieveComments();
-    this.retrieveLikes();
-  },
-  methods: {
-    getSpaceById(spaceId) {
-      this.$spaceService.getSpaceById(spaceId, 'identity')
-        .then((space) => {
-          if (space && space.identity && space.identity.id) {
-            this.space = space;
-          }
-        });
-    },
-    retrieveLikes() {
-      this.loading = true;
-      this.likeSize = 5;
-      return this.$activityService.getActivityById(this.activityId, null)
-        .then(data => {
-          this.likeSize = data && data.likesCount &&  Number(data.likesCount) || 0;
-        });
-    },
-    retrieveComments() {
-      this.$activityService.getActivityComments(this.activityId, false, 0, 0, null)
-        .then(data => {
-          this.$nextTick().then(() => {
-            this.commentsSize = data && data.size && Number(data.size) || 0;
-          });
-        });
-    },
-  }
 };
 </script>


### PR DESCRIPTION
Prior to this change, the news space name, related activity number of likes and comments are not well displayed for non space members on news list snapshot portlets. After this fix, for non news space members the news space name and the related activity number of likes and comments are well displayed in snapshot slider and latest news portlets.