### PR TITLE
Task-52944: Don't display hidden news spaces name and avatar for non members

### DIFF
--- a/webapp/src/main/webapp/news-list-view/components/views/NewsLatestViewItem.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsLatestViewItem.vue
@@ -23,7 +23,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
       <img :src="item.illustrationURL !== null ? item.illustrationURL : '/news/images/news.png'" :alt="$t('news.latest.alt.articleImage')">
     </div>
     <div class="articleInfos">
-      <div class="articleSpace">
+      <div class="articleSpace" v-if="!isHiddenSpace">
         <img
           class="spaceImage"
           :src="item.spaceAvatarUrl"
@@ -78,6 +78,9 @@ export default {
     displayDate() {
       return this.item.publishDate && this.item.publishDate.time && new Date(this.item.publishDate.time);
     },
+    isHiddenSpace() {
+      return this.item && !this.item.spaceMember && this.item.hiddenSpace;
+    }
   }
 };
 </script>

--- a/webapp/src/main/webapp/news-list-view/components/views/NewsSliderView.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsSliderView.vue
@@ -62,6 +62,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                 :likes-count="item.likesCount"
                 :comments-count="item.commentsCount"
                 :views-count="item.viewsCount"
+                :hidden-space="item.hiddenSpace"
+                :space-member="item.spaceMember"
                 class="d-flex flex-row newsSliderItem align-center justify-center pa-2 ms-2" />
             </div>
           </div>

--- a/webapp/src/main/webapp/news-list-view/components/views/NewsSliderViewItem.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsSliderViewItem.vue
@@ -26,11 +26,12 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
       <span class="text-capitalize text--white my-auto ml-2">{{ authorDisplayName }}</span>
     </div>
     <v-icon
+      v-if="!isHiddenSpace"
       class="mx-1"
       small>
       mdi-chevron-right
     </v-icon>
-    <div class="newsSpaceInfos me-2 my-auto">
+    <div class="newsSpaceInfos me-2 my-auto" v-if="!isHiddenSpace">
       <v-avatar size="23" rounded>
         <v-img
           class="spaceImage"
@@ -117,6 +118,14 @@ export default {
       type: Number,
       default: 0
     },
+    spaceMember: {
+      type: Boolean,
+      default: false
+    },
+    hiddenSpace: {
+      type: Boolean,
+      default: false
+    },
   },
   data: () => ({
     dateFormat: {
@@ -129,6 +138,9 @@ export default {
     displayDate() {
       return this.publishDate && this.publishDate.time && new Date(this.publishDate.time);
     },
+    isHiddenSpace() {
+      return !this.spaceMember && this.hiddenSpace;
+    }
   }
 };
 </script>


### PR DESCRIPTION
Prior to this change, the space name and avatar are displayed on the snapshot slider and latest news portlets even when the related space is hidden and the connected user is not a member of this space. After this fix, only members of the news hidden space can see the space name and avatar on the snapshot slider and latest news.