### PR TITLE
Task-52908: Add ellipsis to latest news portlet name when it is too long

### DIFF
--- a/webapp/src/main/webapp/news-list-view/components/settings/NewsSettings.vue
+++ b/webapp/src/main/webapp/news-list-view/components/settings/NewsSettings.vue
@@ -16,7 +16,9 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 -->
 <template>
   <div class="d-flex flex-row pa-2">
-    <div class="d-flex flex-column flex-grow-1 body-1 text-uppercase text-sub-title text-truncate my-auto">{{ newsHeader }}</div>
+    <div class="d-flex latestNewsTitleContainer flex-column flex-grow-1 my-1">
+      <span class="headerLatestNews body-1 text-uppercase text-sub-title text-truncate text-center" :title="newsHeader">{{ newsHeader }}</span>
+    </div>
     <div class="d-flex flex-column me-2">
       <v-btn
         v-if="canPublishNews"

--- a/webapp/src/main/webapp/skin/less/news.less
+++ b/webapp/src/main/webapp/skin/less/news.less
@@ -87,6 +87,13 @@
     max-width: 100%;
     .list-view-card {
       height: 100%;
+      .latestNewsTitleContainer {
+        position: relative;
+        .headerLatestNews {
+          position: absolute;
+          max-width: 100%;
+        }
+      }
     }
     .news-empty-listView {
       .listViewTitle {


### PR DESCRIPTION
Prior to this change, when we add a portlet with a long name in the latest news template, it will not be well displayed. To fix the problem we ensure that the child component don't exceed the parent container.