### PR TITLE
Task-52996: Improve alert message when accessing a published article by a non member of a hidden space

### DIFF
--- a/webapp/src/main/webapp/components/snackbar/ExoNewsNotificationAlerts.vue
+++ b/webapp/src/main/webapp/components/snackbar/ExoNewsNotificationAlerts.vue
@@ -71,9 +71,14 @@ export default {
         });
       }
     });
-    this.$root.$on('restricted-space', (spaceDisplayName) => {
+    this.$root.$on('restricted-space', (spaceDisplayName, hiddenSpace) => {
       if (spaceDisplayName) {
-        const message = this.$t('news.activity.notAuthorizedUser').replace('{0}', spaceDisplayName);
+        let message = '';
+        if (hiddenSpace) {
+          message = this.$t('news.activity.notAuthorizedUserForSpaceHidden');
+        } else {
+          message = this.$t('news.activity.notAuthorizedUser').replace('{0}', spaceDisplayName);
+        }
         this.$root.$emit('news-notification-alert', {
           message,
           type: 'warning',

--- a/webapp/src/main/webapp/components/snackbar/ExoNewsNotificationAlerts.vue
+++ b/webapp/src/main/webapp/components/snackbar/ExoNewsNotificationAlerts.vue
@@ -73,12 +73,7 @@ export default {
     });
     this.$root.$on('restricted-space', (spaceDisplayName, hiddenSpace) => {
       if (spaceDisplayName) {
-        let message = '';
-        if (hiddenSpace) {
-          message = this.$t('news.activity.notAuthorizedUserForSpaceHidden');
-        } else {
-          message = this.$t('news.activity.notAuthorizedUser').replace('{0}', spaceDisplayName);
-        }
+        const message = hiddenSpace ? this.$t('news.activity.notAuthorizedUserForSpaceHidden'): this.$t('news.activity.notAuthorizedUser').replace('{0}', spaceDisplayName);
         this.$root.$emit('news-notification-alert', {
           message,
           type: 'warning',

--- a/webapp/src/main/webapp/news-details-app/components/ExoNewsDetailsApp.vue
+++ b/webapp/src/main/webapp/news-details-app/components/ExoNewsDetailsApp.vue
@@ -39,7 +39,7 @@ export default {
           this.showPublishButton = this.news.canPublish;
           this.showDeleteButton = this.news.canDelete;
           if (!this.news.spaceMember) {
-            this.$root.$emit('restricted-space', this.news.spaceDisplayName);
+            this.$root.$emit('restricted-space', this.news.spaceDisplayName, this.news.hiddenSpace);
           }
         } else {
           this.notFound = true;


### PR DESCRIPTION
Prior to this change, when a non member of a hidden space opens a published news , the name of space is displayed in the alert message. After this change, we remove the name of the hidden space from the alert message. 