### PR TITLE
MAINT-52374: Fix xss in news content details

### DIFF
--- a/services/src/main/java/org/exoplatform/news/storage/jcr/JcrNewsStorage.java
+++ b/services/src/main/java/org/exoplatform/news/storage/jcr/JcrNewsStorage.java
@@ -30,7 +30,6 @@ import javax.jcr.query.Query;
 import javax.jcr.query.QueryManager;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 
@@ -398,7 +397,6 @@ public class JcrNewsStorage implements NewsStorage {
     news.setSummary(getStringProperty(node, "exo:summary"));
     String body = getStringProperty(node, "exo:body");
     String sanitizedBody = HTMLSanitizer.sanitize(body);
-    sanitizedBody = StringEscapeUtils.unescapeHtml(sanitizedBody);
     sanitizedBody = sanitizedBody.replaceAll(HTML_AT_SYMBOL_ESCAPED_PATTERN, HTML_AT_SYMBOL_PATTERN);
     news.setBody(substituteUsernames(portalOwner, sanitizedBody));
     news.setAuthor(getStringProperty(node, "exo:author"));

--- a/webapp/src/main/webapp/news-details/components/ExoNewsDetailsBody.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsDetailsBody.vue
@@ -101,7 +101,7 @@
             id="newsBody"
             :class="[!summary ? 'fullDetailsBodyNoSummary' : '']"
             class="fullDetailsBody clearfix">
-            <span v-html="newsBody"></span>
+            <span v-sanitized-html="newsBody"></span>
           </div>
 
           <div v-show="attachments && attachments.length" class="newsAttachmentsTitle">


### PR DESCRIPTION
**ISSUE**: The news content has an xss vulnerability by using the v-html directive when displaying the news body, also the HTMLSantizer was doing its work and sanitize the body but the StringEscapeUtils.unescapeHtml was
reverting the sanitization of the svg tag which caused an xss on svg script attributes.
**FIX**: Use v-html-sanitize instead to sanitize the news body and prevent svg dangerous attributes from being executed as a script also remove the unescapeHtml on the sanitized body