### PR TITLE
Task-50876: Implement delete news target from Manage news publication targets page

### DIFF
--- a/services/src/main/java/org/exoplatform/news/rest/NewsTargetingRestResourcesV1.java
+++ b/services/src/main/java/org/exoplatform/news/rest/NewsTargetingRestResourcesV1.java
@@ -164,11 +164,11 @@ public class NewsTargetingRestResourcesV1 implements ResourceContainer, Startabl
     }
   }
 
-  @Path("{targetName}/undoDeleteNewsTarget")
+  @Path("{targetName}/undoDelete")
   @POST
   @RolesAllowed("users")
   @ApiOperation(
-          value = "Undo deleting target news if not yet effectively deleted.",
+          value = "Undo deleting news target if not yet effectively deleted.",
           httpMethod = "POST",
           response = Response.class
   )
@@ -177,7 +177,7 @@ public class NewsTargetingRestResourcesV1 implements ResourceContainer, Startabl
                   @ApiResponse(code = HTTPStatus.BAD_REQUEST, message = "Invalid query input"),
                   @ApiResponse(code = HTTPStatus.FORBIDDEN, message = "Forbidden operation"), }
   )
-  public Response undoDeleteNewsTarget(@Context HttpServletRequest request,
+  public Response undoDeleteTarget(@Context HttpServletRequest request,
                                        @ApiParam(value = "News target name identifier", required = true)
                                        @PathParam("targetName") String targetName) {
     if (StringUtils.isBlank(targetName)) {

--- a/services/src/main/java/org/exoplatform/news/rest/NewsTargetingRestResourcesV1.java
+++ b/services/src/main/java/org/exoplatform/news/rest/NewsTargetingRestResourcesV1.java
@@ -122,15 +122,15 @@ public class NewsTargetingRestResourcesV1 implements ResourceContainer, Startabl
   @Path("{targetName}")
   @Produces(MediaType.APPLICATION_JSON)
   @RolesAllowed("users")
-  @ApiOperation(value = "Delete target news", httpMethod = "DELETE", response = Response.class, notes = "This deletes the target news", consumes = "application/json")
-  @ApiResponses(value = { @ApiResponse(code = 200, message = "News target deleted"),
-          @ApiResponse(code = 400, message = "Invalid query input"),
-          @ApiResponse(code = 401, message = "User not authorized to delete the news target"),
-          @ApiResponse(code = 500, message = "Internal server error") })
-  public Response deleteTargetByName(@Context HttpServletRequest request,
+  @ApiOperation(value = "Delete news target", httpMethod = "DELETE", response = Response.class, notes = "This deletes the target news", consumes = "application/json")
+  @ApiResponses(value = { @ApiResponse(code = HTTPStatus.OK, message = "News target deleted"),
+          @ApiResponse(code = HTTPStatus.BAD_REQUEST, message = "Invalid query input"),
+          @ApiResponse(code = HTTPStatus.UNAUTHORIZED, message = "User not authorized to delete the news target"),
+          @ApiResponse(code = HTTPStatus.INTERNAL_ERROR, message = "Internal server error") })
+  public Response deleteTarget(@Context HttpServletRequest request,
                                      @ApiParam(value = "Target name", required = true)
                                      @PathParam("targetName") String targetName,
-                                     @ApiParam(value = "Time to effectively delete target news", required = false)
+                                     @ApiParam(value = "Time to effectively delete news target", required = false)
                                      @QueryParam("delay") long delay) {
     org.exoplatform.services.security.Identity currentIdentity = ConversationState.getCurrent().getIdentity();
     try {
@@ -146,8 +146,8 @@ public class NewsTargetingRestResourcesV1 implements ResourceContainer, Startabl
             try {
               newsTargetToDeleteQueue.remove(targetName);
               newsTargetingService.deleteTargetByName(targetName, currentIdentity);
-            }  catch (Exception e) {
-              LOG.warn("Error when deleting the news target with name " + targetName, e);
+            } catch (Exception e) {
+              LOG.error("Error when deleting the news target with name " + targetName, e);
             } finally {
               RequestLifeCycle.end();
             }
@@ -159,7 +159,7 @@ public class NewsTargetingRestResourcesV1 implements ResourceContainer, Startabl
       }
       return Response.ok().build();
     } catch (Exception e) {
-      LOG.warn("Error when deleting the news target");
+      LOG.error("Error when deleting the news target with name " + targetName, e);
       return Response.serverError().entity(e.getMessage()).build();
     }
   }
@@ -174,11 +174,8 @@ public class NewsTargetingRestResourcesV1 implements ResourceContainer, Startabl
   )
   @ApiResponses(
           value = {
-                  @ApiResponse(code = HTTPStatus.NO_CONTENT, message = "Request fulfilled"),
                   @ApiResponse(code = HTTPStatus.BAD_REQUEST, message = "Invalid query input"),
-                  @ApiResponse(code = HTTPStatus.FORBIDDEN, message = "Forbidden operation"),
-                  @ApiResponse(code = HTTPStatus.UNAUTHORIZED, message = "Unauthorized operation"),
-                  @ApiResponse(code = HTTPStatus.INTERNAL_ERROR, message = "Internal server error"), }
+                  @ApiResponse(code = HTTPStatus.FORBIDDEN, message = "Forbidden operation"), }
   )
   public Response undoDeleteNewsTarget(@Context HttpServletRequest request,
                                        @ApiParam(value = "News target name identifier", required = true)

--- a/services/src/main/java/org/exoplatform/news/rest/NewsTargetingRestResourcesV1.java
+++ b/services/src/main/java/org/exoplatform/news/rest/NewsTargetingRestResourcesV1.java
@@ -16,35 +16,64 @@
  */
 package org.exoplatform.news.rest;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import javax.annotation.security.RolesAllowed;
 import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
+import javax.ws.rs.*;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import io.swagger.annotations.*;
+import org.apache.commons.lang3.StringUtils;
 import org.exoplatform.common.http.HTTPStatus;
+import org.exoplatform.container.ExoContainerContext;
+import org.exoplatform.container.PortalContainer;
+import org.exoplatform.container.component.RequestLifeCycle;
 import org.exoplatform.news.service.NewsTargetingService;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.services.rest.resource.ResourceContainer;
 import org.exoplatform.services.security.ConversationState;
+import org.picocontainer.Startable;
 
 @Path("v1/news/targeting")
 @Api(tags = "v1/news/targeting", value = "v1/news/targeting")
-public class NewsTargetingRestResourcesV1 implements ResourceContainer {
+public class NewsTargetingRestResourcesV1 implements ResourceContainer, Startable {
 
-  private static final Log       LOG                             = ExoLogger.getLogger(NewsTargetingRestResourcesV1.class);
+  private static final Log         LOG                     = ExoLogger.getLogger(NewsTargetingRestResourcesV1.class);
 
-  private NewsTargetingService newsTargetingService;
+  private NewsTargetingService     newsTargetingService;
 
-  public NewsTargetingRestResourcesV1(NewsTargetingService newsTargetingService) {
+  private ScheduledExecutorService scheduledExecutor;
+
+  private PortalContainer          container;
+
+  private Map<String, String>      newsTargetToDeleteQueue = new HashMap<>();
+
+
+  public NewsTargetingRestResourcesV1(NewsTargetingService newsTargetingService, PortalContainer container) {
     this.newsTargetingService = newsTargetingService;
+    this.container = container;
+  }
+
+
+  @Override
+  public void start() {
+    scheduledExecutor = Executors.newScheduledThreadPool(1);
+  }
+
+  @Override
+  public void stop() {
+    if (scheduledExecutor != null) {
+      scheduledExecutor.shutdown();
+    }
   }
 
   @GET
@@ -86,6 +115,91 @@ public class NewsTargetingRestResourcesV1 implements ResourceContainer {
     } catch (Exception e) {
       LOG.error("Error when getting the news referenced targets", e);
       return Response.serverError().build();
+    }
+  }
+
+  @DELETE
+  @Path("{targetName}")
+  @Produces(MediaType.APPLICATION_JSON)
+  @RolesAllowed("users")
+  @ApiOperation(value = "Delete target news", httpMethod = "DELETE", response = Response.class, notes = "This deletes the target news", consumes = "application/json")
+  @ApiResponses(value = { @ApiResponse(code = 200, message = "News target deleted"),
+          @ApiResponse(code = 400, message = "Invalid query input"),
+          @ApiResponse(code = 401, message = "User not authorized to delete the news target"),
+          @ApiResponse(code = 500, message = "Internal server error") })
+  public Response deleteTargetByName(@Context HttpServletRequest request,
+                                     @ApiParam(value = "Target name", required = true)
+                                     @PathParam("targetName") String targetName,
+                                     @ApiParam(value = "Time to effectively delete target news", required = false)
+                                     @QueryParam("delay") long delay) {
+    org.exoplatform.services.security.Identity currentIdentity = ConversationState.getCurrent().getIdentity();
+    try {
+      if (StringUtils.isBlank(targetName)) {
+        return Response.status(Response.Status.BAD_REQUEST).entity("Target name ist mandatory").build();
+      }
+      if (delay > 0) {
+        newsTargetToDeleteQueue.put(targetName, currentIdentity.getUserId());
+        scheduledExecutor.schedule(() -> {
+          if (newsTargetToDeleteQueue.containsKey(targetName)) {
+            ExoContainerContext.setCurrentContainer(container);
+            RequestLifeCycle.begin(container);
+            try {
+              newsTargetToDeleteQueue.remove(targetName);
+              newsTargetingService.deleteTargetByName(targetName, currentIdentity);
+            }  catch (Exception e) {
+              LOG.warn("Error when deleting the news target with name " + targetName, e);
+            } finally {
+              RequestLifeCycle.end();
+            }
+          }
+        }, delay, TimeUnit.SECONDS);
+      } else {
+        newsTargetToDeleteQueue.remove(targetName);
+        newsTargetingService.deleteTargetByName(targetName, currentIdentity);
+      }
+      return Response.ok().build();
+    } catch (Exception e) {
+      LOG.warn("Error when deleting the news target");
+      return Response.serverError().entity(e.getMessage()).build();
+    }
+  }
+
+  @Path("{targetName}/undoDeleteNewsTarget")
+  @POST
+  @RolesAllowed("users")
+  @ApiOperation(
+          value = "Undo deleting target news if not yet effectively deleted.",
+          httpMethod = "POST",
+          response = Response.class
+  )
+  @ApiResponses(
+          value = {
+                  @ApiResponse(code = HTTPStatus.NO_CONTENT, message = "Request fulfilled"),
+                  @ApiResponse(code = HTTPStatus.BAD_REQUEST, message = "Invalid query input"),
+                  @ApiResponse(code = HTTPStatus.FORBIDDEN, message = "Forbidden operation"),
+                  @ApiResponse(code = HTTPStatus.UNAUTHORIZED, message = "Unauthorized operation"),
+                  @ApiResponse(code = HTTPStatus.INTERNAL_ERROR, message = "Internal server error"), }
+  )
+  public Response undoDeleteNewsTarget(@Context HttpServletRequest request,
+                                       @ApiParam(value = "News target name identifier", required = true)
+                                       @PathParam("targetName") String targetName) {
+    if (StringUtils.isBlank(targetName)) {
+      return Response.status(Response.Status.BAD_REQUEST).entity("Target name ist mandatory").build();
+    }
+    if (newsTargetToDeleteQueue.containsKey(targetName)) {
+      org.exoplatform.services.security.Identity currentIdentity = ConversationState.getCurrent().getIdentity();
+      String authenticatedUser = currentIdentity.getUserId();
+      String originalModifierUser = newsTargetToDeleteQueue.get(targetName);
+      if (!originalModifierUser.equals(authenticatedUser)) {
+        LOG.warn("User {} attempts to cancel deletion of a news target deleted by user {}", authenticatedUser, originalModifierUser);
+        return Response.status(Response.Status.FORBIDDEN).build();
+      }
+      newsTargetToDeleteQueue.remove(targetName);
+      return Response.noContent().build();
+    } else {
+      return Response.status(Response.Status.BAD_REQUEST)
+                     .entity("Target News with name {} was already deleted or isn't planned to be deleted" + targetName)
+                     .build();
     }
   }
 

--- a/services/src/main/java/org/exoplatform/news/rest/NewsTargetingRestResourcesV1.java
+++ b/services/src/main/java/org/exoplatform/news/rest/NewsTargetingRestResourcesV1.java
@@ -146,6 +146,8 @@ public class NewsTargetingRestResourcesV1 implements ResourceContainer, Startabl
             try {
               newsTargetToDeleteQueue.remove(targetName);
               newsTargetingService.deleteTargetByName(targetName, currentIdentity);
+            } catch (IllegalAccessException e) {
+              LOG.error("Error when deleting the news target with name " + targetName, e);
             } catch (Exception e) {
               LOG.error("Error when deleting the news target with name " + targetName, e);
             } finally {
@@ -158,6 +160,9 @@ public class NewsTargetingRestResourcesV1 implements ResourceContainer, Startabl
         newsTargetingService.deleteTargetByName(targetName, currentIdentity);
       }
       return Response.ok().build();
+    } catch (IllegalAccessException e) {
+      LOG.warn("User '{}' is not authorized to delete news target", currentIdentity.getUserId(), e);
+      return Response.status(Response.Status.UNAUTHORIZED).entity(e.getMessage()).build();
     } catch (Exception e) {
       LOG.error("Error when deleting the news target with name " + targetName, e);
       return Response.serverError().entity(e.getMessage()).build();

--- a/services/src/main/java/org/exoplatform/news/rest/NewsTargetingRestResourcesV1.java
+++ b/services/src/main/java/org/exoplatform/news/rest/NewsTargetingRestResourcesV1.java
@@ -122,7 +122,7 @@ public class NewsTargetingRestResourcesV1 implements ResourceContainer, Startabl
   @Path("{targetName}")
   @Produces(MediaType.APPLICATION_JSON)
   @RolesAllowed("users")
-  @ApiOperation(value = "Delete news target", httpMethod = "DELETE", response = Response.class, notes = "This deletes the target news", consumes = "application/json")
+  @ApiOperation(value = "Delete news target", httpMethod = "DELETE", response = Response.class, notes = "This deletes news target", consumes = "application/json")
   @ApiResponses(value = { @ApiResponse(code = HTTPStatus.OK, message = "News target deleted"),
           @ApiResponse(code = HTTPStatus.BAD_REQUEST, message = "Invalid query input"),
           @ApiResponse(code = HTTPStatus.UNAUTHORIZED, message = "User not authorized to delete the news target"),
@@ -147,7 +147,7 @@ public class NewsTargetingRestResourcesV1 implements ResourceContainer, Startabl
               newsTargetToDeleteQueue.remove(targetName);
               newsTargetingService.deleteTargetByName(targetName, currentIdentity);
             } catch (IllegalAccessException e) {
-              LOG.error("Error when deleting the news target with name " + targetName, e);
+              LOG.warn("User '{}' is not authorized to delete the news target with name " + targetName, e);
             } catch (Exception e) {
               LOG.error("Error when deleting the news target with name " + targetName, e);
             } finally {
@@ -160,9 +160,6 @@ public class NewsTargetingRestResourcesV1 implements ResourceContainer, Startabl
         newsTargetingService.deleteTargetByName(targetName, currentIdentity);
       }
       return Response.ok().build();
-    } catch (IllegalAccessException e) {
-      LOG.warn("User '{}' is not authorized to delete news target", currentIdentity.getUserId(), e);
-      return Response.status(Response.Status.UNAUTHORIZED).entity(e.getMessage()).build();
     } catch (Exception e) {
       LOG.error("Error when deleting the news target with name " + targetName, e);
       return Response.serverError().entity(e.getMessage()).build();
@@ -200,7 +197,7 @@ public class NewsTargetingRestResourcesV1 implements ResourceContainer, Startabl
       return Response.noContent().build();
     } else {
       return Response.status(Response.Status.BAD_REQUEST)
-                     .entity("Target News with name {} was already deleted or isn't planned to be deleted" + targetName)
+                     .entity("News target with name {} was already deleted or isn't planned to be deleted" + targetName)
                      .build();
     }
   }

--- a/services/src/main/java/org/exoplatform/news/service/NewsTargetingService.java
+++ b/services/src/main/java/org/exoplatform/news/service/NewsTargetingService.java
@@ -43,7 +43,7 @@ public interface NewsTargetingService {
    * @param targetName {@link News} target name to be deleted
    * @param currentIdentity {@link Identity} technical identifier
    */
-  void deleteTargetByName(String targetName, org.exoplatform.services.security.Identity currentIdentity);
+  void deleteTargetByName(String targetName, org.exoplatform.services.security.Identity currentIdentity) throws IllegalAccessException ;
 
   /**
    * Gets the {@link List} of {@link News} targets linked to a given {@link News} id

--- a/services/src/main/java/org/exoplatform/news/service/NewsTargetingService.java
+++ b/services/src/main/java/org/exoplatform/news/service/NewsTargetingService.java
@@ -70,7 +70,7 @@ public interface NewsTargetingService {
    * @param currentIdentity
    *
    * @return {@link List} of referenced targets
-   * @throws IllegalAccessException when user doesn't have access to  get referenced targets {@link News}
+   * @throws IllegalAccessException when user doesn't have access to  get referenced {@link News} targets
    */
   List<NewsTargetingEntity> getReferencedTargets(org.exoplatform.services.security.Identity currentIdentity) throws IllegalAccessException;
 
@@ -81,8 +81,8 @@ public interface NewsTargetingService {
    * @param staged {@link News} is staged news
    * @param targets {@link List} of {@link News} targets to be saved
    * @param currentUser current user attempting to save {@link News} targets
-   * @throws IllegalAccessException when user doesn't have access to save targets {@link News}
-   */
+   * @throws IllegalAccessException when user doesn't have access to save {@link News} targets of a given {@link News} id
+   */ 
   void saveNewsTarget(String newsId, boolean staged, List<String> targets, String currentUser) throws IllegalAccessException;
 
   /**
@@ -90,14 +90,14 @@ public interface NewsTargetingService {
    * 
    * @param newsId {@link News} identifier of {@link News} targets to be deleted
    * @param currentUserId
-   * @throws IllegalAccessException when user doesn't have access to delete {@link News}
+   * @throws IllegalAccessException when user doesn't have access to delete {@link News} targets of a given {@link News} id
    */
   void deleteNewsTargets(String newsId, String currentUserId) throws IllegalAccessException;
   
   /**
    * Delete the {@link List} of {@link News} targets linked to a given {@link News} id
    * 
-   * @param newsId {@link News} identifier of {@link News} targets to be deleted
+   * @param newsId {@link News} identifier of {@link News} to delete targets
    */
   void deleteNewsTargets(String newsId);
 

--- a/services/src/main/java/org/exoplatform/news/service/NewsTargetingService.java
+++ b/services/src/main/java/org/exoplatform/news/service/NewsTargetingService.java
@@ -22,6 +22,7 @@ import org.exoplatform.news.model.News;
 import org.exoplatform.news.rest.NewsTargetingEntity;
 import org.exoplatform.social.metadata.model.MetadataItem;
 import org.exoplatform.social.metadata.model.MetadataType;
+import org.exoplatform.social.core.identity.model.Identity;
 
 
 public interface NewsTargetingService {
@@ -40,8 +41,9 @@ public interface NewsTargetingService {
    * Delete the {@link News} target by a given {@link News} target name
    * 
    * @param targetName {@link News} target name to be deleted
+   * @param currentIdentity {@link Identity} technical identifier
    */
-  void deleteTargetByName(String targetName);
+  void deleteTargetByName(String targetName, org.exoplatform.services.security.Identity currentIdentity);
 
   /**
    * Gets the {@link List} of {@link News} targets linked to a given {@link News} id

--- a/services/src/main/java/org/exoplatform/news/service/impl/NewsTargetingServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/service/impl/NewsTargetingServiceImpl.java
@@ -66,7 +66,7 @@ public class NewsTargetingServiceImpl implements NewsTargetingService {
   }
   
   @Override
-  public void deleteTargetByName(String targetName, org.exoplatform.services.security.Identity  currentIdentity) {
+  public void deleteTargetByName(String targetName, org.exoplatform.services.security.Identity  currentIdentity) throws IllegalAccessException {
     if (currentIdentity != null && !NewsUtils.canPublishNews(currentIdentity)) {
       throw new IllegalArgumentException("User " + currentIdentity.getUserId() + " not authorized to publish news");
     }

--- a/services/src/main/java/org/exoplatform/news/service/impl/NewsTargetingServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/service/impl/NewsTargetingServiceImpl.java
@@ -67,7 +67,7 @@ public class NewsTargetingServiceImpl implements NewsTargetingService {
   
   @Override
   public void deleteTargetByName(String targetName, org.exoplatform.services.security.Identity  currentIdentity) throws IllegalAccessException {
-    if (currentIdentity != null && !NewsUtils.canPublishNews(currentIdentity)) {
+    if (currentIdentity != null && !NewsUtils.canDeleteTargetNews(currentIdentity)) {
       throw new IllegalArgumentException("User " + currentIdentity.getUserId()
           + " not authorized to delete news target with name " + targetName);
     }

--- a/services/src/main/java/org/exoplatform/news/service/impl/NewsTargetingServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/service/impl/NewsTargetingServiceImpl.java
@@ -42,13 +42,13 @@ import org.exoplatform.social.metadata.model.MetadataKey;
  */
 public class NewsTargetingServiceImpl implements NewsTargetingService {
 
-  private static final Log    LOG        = ExoLogger.getLogger(NewsTargetingServiceImpl.class);
+  private static final Log    LOG                             = ExoLogger.getLogger(NewsTargetingServiceImpl.class);
 
-  public static final long    LIMIT      = 100;
+  public static final long    LIMIT                           = 100;
 
-  private static final String LABEL      = "label";
+  private static final String LABEL                           = "label";
 
-  private static final String REFERENCED = "referenced";
+  private static final String REFERENCED                      = "referenced";
 
   private MetadataService     metadataService;
 
@@ -67,7 +67,7 @@ public class NewsTargetingServiceImpl implements NewsTargetingService {
   
   @Override
   public void deleteTargetByName(String targetName, org.exoplatform.services.security.Identity  currentIdentity) {
-    if (!NewsUtils.canPublishNews(currentIdentity)) {
+    if (currentIdentity != null && !NewsUtils.canPublishNews(currentIdentity)) {
       throw new IllegalArgumentException("User " + currentIdentity.getUserId() + " not authorized to publish news");
     }
     MetadataKey targetMetadataKey = new MetadataKey(METADATA_TYPE.getName(), targetName, 0);

--- a/services/src/main/java/org/exoplatform/news/service/impl/NewsTargetingServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/service/impl/NewsTargetingServiceImpl.java
@@ -42,17 +42,17 @@ import org.exoplatform.social.metadata.model.MetadataKey;
  */
 public class NewsTargetingServiceImpl implements NewsTargetingService {
 
-  private static final Log LOG                             = ExoLogger.getLogger(NewsTargetingServiceImpl.class);
+  private static final Log    LOG        = ExoLogger.getLogger(NewsTargetingServiceImpl.class);
 
-  public static final long        LIMIT           =  100;
+  public static final long    LIMIT      = 100;
 
-  private static final String        LABEL           =  "label";
+  private static final String LABEL      = "label";
 
-  private static final String        REFERENCED           =  "referenced";
+  private static final String REFERENCED = "referenced";
 
-  private MetadataService        metadataService;
-  
-  private IdentityManager identityManager;
+  private MetadataService     metadataService;
+
+  private IdentityManager     identityManager;
 
   public NewsTargetingServiceImpl(MetadataService metadataService, IdentityManager identityManager){
     this.metadataService = metadataService;
@@ -66,7 +66,10 @@ public class NewsTargetingServiceImpl implements NewsTargetingService {
   }
   
   @Override
-  public void deleteTargetByName(String targetName) {
+  public void deleteTargetByName(String targetName, org.exoplatform.services.security.Identity  currentIdentity) {
+    if (!NewsUtils.canPublishNews(currentIdentity)) {
+      throw new IllegalArgumentException("User " + currentIdentity.getUserId() + " not authorized to publish news");
+    }
     MetadataKey targetMetadataKey = new MetadataKey(METADATA_TYPE.getName(), targetName, 0);
     Metadata targetMetadata = metadataService.getMetadataByKey(targetMetadataKey);
     metadataService.deleteMetadataById(targetMetadata.getId());

--- a/services/src/main/java/org/exoplatform/news/service/impl/NewsTargetingServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/service/impl/NewsTargetingServiceImpl.java
@@ -68,7 +68,8 @@ public class NewsTargetingServiceImpl implements NewsTargetingService {
   @Override
   public void deleteTargetByName(String targetName, org.exoplatform.services.security.Identity  currentIdentity) throws IllegalAccessException {
     if (currentIdentity != null && !NewsUtils.canPublishNews(currentIdentity)) {
-      throw new IllegalArgumentException("User " + currentIdentity.getUserId() + " not authorized to publish news");
+      throw new IllegalArgumentException("User " + currentIdentity.getUserId()
+          + " not authorized to delete news target with name " + targetName);
     }
     MetadataKey targetMetadataKey = new MetadataKey(METADATA_TYPE.getName(), targetName, 0);
     Metadata targetMetadata = metadataService.getMetadataByKey(targetMetadataKey);

--- a/services/src/main/java/org/exoplatform/news/utils/NewsUtils.java
+++ b/services/src/main/java/org/exoplatform/news/utils/NewsUtils.java
@@ -25,31 +25,33 @@ import org.exoplatform.social.core.space.spi.SpaceService;
 
 public class NewsUtils {
 
-  private static final Log   LOG                       = ExoLogger.getLogger(NewsUtils.class);
+  private static final Log    LOG                             = ExoLogger.getLogger(NewsUtils.class);
 
-  public static final String POST_NEWS                 = "exo.news.postArticle";
+  public static final String  POST_NEWS                       = "exo.news.postArticle";
 
-  public static final String POST_NEWS_ARTICLE         = "exo.news.gamification.postArticle";
+  public static final String  POST_NEWS_ARTICLE               = "exo.news.gamification.postArticle";
 
-  public static final String PUBLISH_NEWS              = "exo.news.gamification.PublishArticle";
+  public static final String  PUBLISH_NEWS                    = "exo.news.gamification.PublishArticle";
 
-  public static final String VIEW_NEWS                 = "exo.news.viewArticle";
+  public static final String  VIEW_NEWS                       = "exo.news.viewArticle";
 
-  public static final String SHARE_NEWS                = "exo.news.shareArticle";
+  public static final String  SHARE_NEWS                      = "exo.news.shareArticle";
 
-  public static final String COMMENT_NEWS              = "exo.news.commentArticle";
+  public static final String  COMMENT_NEWS                    = "exo.news.commentArticle";
 
-  public static final String LIKE_NEWS                 = "exo.news.likeArticle";
+  public static final String  LIKE_NEWS                       = "exo.news.likeArticle";
 
-  public static final String DELETE_NEWS               = "exo.news.deleteArticle";
+  public static final String  DELETE_NEWS                     = "exo.news.deleteArticle";
 
-  public static final String UPDATE_NEWS               = "exo.news.updateArticle";
+  public static final String  UPDATE_NEWS                     = "exo.news.updateArticle";
 
-  public static final String NEWS_METADATA_OBJECT_TYPE = "news";
+  public static final String  NEWS_METADATA_OBJECT_TYPE       = "news";
 
-  private static final String   PUBLISHER_MEMBERSHIP_NAME       = "publisher";
+  private static final String PUBLISHER_MEMBERSHIP_NAME       = "publisher";
 
-  private static final String   PLATFORM_WEB_CONTRIBUTORS_GROUP = "/platform/web-contributors";
+  private static final String MANAGER_MEMBERSHIP_NAME         = "manager";
+
+  private static final String PLATFORM_WEB_CONTRIBUTORS_GROUP = "/platform/web-contributors";
 
   public static void broadcastEvent(String eventName, Object source, Object data) {
     try {
@@ -116,6 +118,10 @@ public class NewsUtils {
 
   public static boolean canPublishNews(org.exoplatform.services.security.Identity currentIdentity) {
     return currentIdentity != null && currentIdentity.isMemberOf(PLATFORM_WEB_CONTRIBUTORS_GROUP, PUBLISHER_MEMBERSHIP_NAME);
+  }
+
+  public static boolean canDeleteTargetNews(org.exoplatform.services.security.Identity currentIdentity) {
+    return currentIdentity != null && currentIdentity.isMemberOf(PLATFORM_WEB_CONTRIBUTORS_GROUP, MANAGER_MEMBERSHIP_NAME);
   }
 
   public static org.exoplatform.services.security.Identity getUserIdentity(String username) {

--- a/services/src/main/resources/locale/portlet/news/News_en.properties
+++ b/services/src/main/resources/locale/portlet/news/News_en.properties
@@ -204,3 +204,5 @@ newsTargets.settings.loadingResults=Searching results
 newsTargets.settings.noResultsFound=No results
 news.newsTarget.deleteSuccess=Target deleted
 news.newsTarget.deleteCanceled=Target deletion canceled
+news.newsTarget.message.confirmDeleteNews=Would you like to delete this news target?
+news.newsTarget.title.confirmDeleteNews=Delete news target?

--- a/services/src/main/resources/locale/portlet/news/News_en.properties
+++ b/services/src/main/resources/locale/portlet/news/News_en.properties
@@ -202,3 +202,5 @@ newsTargets.settings.noTargets=No targets
 newsTargets.settings.itemsPerPage=Items per page
 newsTargets.settings.loadingResults=Searching results
 newsTargets.settings.noResultsFound=No results
+news.newsTarget.deleteSuccess=Target deleted
+news.newsTarget.deleteCanceled=Target deletion canceled

--- a/services/src/test/java/org/exoplatform/news/NewsTargetingImplTest.java
+++ b/services/src/test/java/org/exoplatform/news/NewsTargetingImplTest.java
@@ -280,7 +280,7 @@ public class NewsTargetingImplTest {
     when(ExoContainerContext.getService(IdentityRegistry.class)).thenReturn(identityRegistry);
     org.exoplatform.services.security.Identity identity = mock(org.exoplatform.services.security.Identity.class);
     when(identityRegistry.getIdentity(username)).thenReturn(identity);
-    when(identity.isMemberOf("/platform/web-contributors", "publisher")).thenReturn(true);
+    when(identity.isMemberOf("/platform/web-contributors", "manager")).thenReturn(true);
 
     List<Metadata> newsTargets = new LinkedList<>();
     Metadata sliderNews = new Metadata();

--- a/services/src/test/java/org/exoplatform/news/NewsTargetingImplTest.java
+++ b/services/src/test/java/org/exoplatform/news/NewsTargetingImplTest.java
@@ -39,10 +39,10 @@ import static org.mockito.Mockito.*;
 public class NewsTargetingImplTest {
 
   @Mock
-  MetadataService metadataService;
-  
+  MetadataService  metadataService;
+
   @Mock
-  IdentityManager identityManager;
+  IdentityManager  identityManager;
 
   @Mock
   IdentityRegistry identityRegistry;

--- a/services/src/test/java/org/exoplatform/news/NewsTargetingImplTest.java
+++ b/services/src/test/java/org/exoplatform/news/NewsTargetingImplTest.java
@@ -39,10 +39,10 @@ import static org.mockito.Mockito.*;
 public class NewsTargetingImplTest {
 
   @Mock
-  MetadataService  metadataService;
-
+  MetadataService metadataService;
+  
   @Mock
-  IdentityManager  identityManager;
+  IdentityManager identityManager;
 
   @Mock
   IdentityRegistry identityRegistry;

--- a/services/src/test/java/org/exoplatform/news/NewsTargetingImplTest.java
+++ b/services/src/test/java/org/exoplatform/news/NewsTargetingImplTest.java
@@ -267,7 +267,7 @@ public class NewsTargetingImplTest {
 
   @Test
   @PrepareForTest({ ExoContainerContext.class })
-  public void testDeleteTargetByName() {
+  public void testDeleteTargetByName() throws IllegalAccessException {
     // Given
     NewsTargetingServiceImpl newsTargetingService = new NewsTargetingServiceImpl(metadataService, identityManager);
     String username = "user";

--- a/services/src/test/java/org/exoplatform/news/rest/NewsTargetingRestResourcesV1Test.java
+++ b/services/src/test/java/org/exoplatform/news/rest/NewsTargetingRestResourcesV1Test.java
@@ -1,5 +1,6 @@
 package org.exoplatform.news.rest;
 
+import org.exoplatform.container.PortalContainer;
 import org.exoplatform.news.service.NewsTargetingService;
 import org.exoplatform.services.rest.impl.RuntimeDelegateImpl;
 import org.junit.Before;
@@ -22,6 +23,9 @@ public class NewsTargetingRestResourcesV1Test {
   @Mock
   NewsTargetingService newsTargetingService;
 
+  @Mock
+  PortalContainer container;
+
   @Before
   public void setup() {
     RuntimeDelegate.setInstance(new RuntimeDelegateImpl());
@@ -30,7 +34,7 @@ public class NewsTargetingRestResourcesV1Test {
   @Test
   public void shouldReturnOkWhenGetTargets() {
     // Given
-    NewsTargetingRestResourcesV1 newsTargetingRestResourcesV1 = new NewsTargetingRestResourcesV1(newsTargetingService);
+    NewsTargetingRestResourcesV1 newsTargetingRestResourcesV1 = new NewsTargetingRestResourcesV1(newsTargetingService, container);
     HttpServletRequest request = mock(HttpServletRequest.class);
     lenient().when(request.getRemoteUser()).thenReturn("john");
 
@@ -44,7 +48,7 @@ public class NewsTargetingRestResourcesV1Test {
   @Test
   public void shouldReturnOkWhenGetReferencedTargets() {
     // Given
-    NewsTargetingRestResourcesV1 newsTargetingRestResourcesV1 = new NewsTargetingRestResourcesV1(newsTargetingService);
+    NewsTargetingRestResourcesV1 newsTargetingRestResourcesV1 = new NewsTargetingRestResourcesV1(newsTargetingService, container);
     HttpServletRequest request = mock(HttpServletRequest.class);
     lenient().when(request.getRemoteUser()).thenReturn("john");
 

--- a/services/src/test/java/org/exoplatform/news/rest/NewsTargetingRestResourcesV1Test.java
+++ b/services/src/test/java/org/exoplatform/news/rest/NewsTargetingRestResourcesV1Test.java
@@ -83,7 +83,7 @@ public class NewsTargetingRestResourcesV1Test {
     lenient().when(newsTargetingService.getTargets()).thenReturn(targets);
 
     // When
-    Response response = newsTargetingRestResourcesV1.deleteTargetByName(request, targets.get(0).getName(), 0);
+    Response response = newsTargetingRestResourcesV1.deleteTarget(request, targets.get(0).getName(), 0);
 
     // Then
     assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());

--- a/services/src/test/java/org/exoplatform/news/rest/NewsTargetingRestResourcesV1Test.java
+++ b/services/src/test/java/org/exoplatform/news/rest/NewsTargetingRestResourcesV1Test.java
@@ -1,8 +1,11 @@
 package org.exoplatform.news.rest;
 
 import org.exoplatform.container.PortalContainer;
+import org.exoplatform.news.model.NewsTargetObject;
 import org.exoplatform.news.service.NewsTargetingService;
 import org.exoplatform.services.rest.impl.RuntimeDelegateImpl;
+import org.exoplatform.services.security.ConversationState;
+import org.exoplatform.services.security.Identity;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -13,7 +16,11 @@ import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.RuntimeDelegate;
 
+import java.util.LinkedList;
+import java.util.List;
+
 import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 
@@ -54,6 +61,29 @@ public class NewsTargetingRestResourcesV1Test {
 
     // When
     Response response = newsTargetingRestResourcesV1.getReferencedTargets(request);
+
+    // Then
+    assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+  }
+
+  @Test
+  public void shouldReturnOkWhenDeleteNewsTarget() {
+    // Given
+    NewsTargetingRestResourcesV1 newsTargetingRestResourcesV1 = new NewsTargetingRestResourcesV1(newsTargetingService, container);
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    lenient().when(request.getRemoteUser()).thenReturn("john");
+    Identity currentIdentity = new Identity("john");
+    ConversationState.setCurrent(new ConversationState(currentIdentity));
+
+    List<NewsTargetingEntity> targets = new LinkedList<>();
+    NewsTargetingEntity newsTargetingEntity = new NewsTargetingEntity();
+    newsTargetingEntity.setName("test1");
+    newsTargetingEntity.setLabel("test1");
+    targets.add(newsTargetingEntity);
+    lenient().when(newsTargetingService.getTargets()).thenReturn(targets);
+
+    // When
+    Response response = newsTargetingRestResourcesV1.deleteTargetByName(request, targets.get(0).getName(), 0);
 
     // Then
     assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());

--- a/webapp/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/webapp/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -234,6 +234,9 @@
       <depends>
         <module>commonVueComponents</module>
       </depends>
+      <depends>
+        <module>newsSnackbarComponent</module>
+      </depends>
     </module>
   </portlet>
 

--- a/webapp/src/main/webapp/components/snackbar/ExoNewsNotificationAlerts.vue
+++ b/webapp/src/main/webapp/components/snackbar/ExoNewsNotificationAlerts.vue
@@ -80,6 +80,18 @@ export default {
         });
       }
     });
+    this.$root.$on('confirm-newsTarget-deletion', (targetName) => {
+      if (targetName) {
+        const clickMessage = this.$t('news.details.undoDelete');
+        const message = this.$t('news.newsTarget.deleteSuccess');
+        this.$root.$emit('news-notification-alert', {
+          message,
+          type: 'success',
+          click: () => this.undoDeleteNewsTarget(targetName),
+          clickMessage,
+        });
+      }
+    });
   },
   methods: {
     addAlert(alert) {
@@ -100,6 +112,16 @@ export default {
           this.deleteAlert(alert);
           this.addAlert({
             message: isDraftsFilter ? this.$t('news.details.deleteDraftCanceled') : this.$t('news.details.deleteCanceled'),
+            type: 'success',
+          });
+        });
+    },
+    undoDeleteNewsTarget(targetName) {
+      return this.$newsTargetingService.undoDeleteNewsTarget(targetName)
+        .then(() => {
+          this.deleteAlert(alert);
+          this.addAlert({
+            message: this.$t('news.newsTarget.deleteCanceled'),
             type: 'success',
           });
         });

--- a/webapp/src/main/webapp/components/snackbar/ExoNewsNotificationAlerts.vue
+++ b/webapp/src/main/webapp/components/snackbar/ExoNewsNotificationAlerts.vue
@@ -117,7 +117,7 @@ export default {
         });
     },
     undoDeleteNewsTarget(targetName) {
-      return this.$newsTargetingService.undoDeleteNewsTarget(targetName)
+      return this.$newsTargetingService.undoDeleteTarget(targetName)
         .then(() => {
           this.deleteAlert(alert);
           this.addAlert({

--- a/webapp/src/main/webapp/news-publish-targets-management/components/NewsPublishTargetsManagement.vue
+++ b/webapp/src/main/webapp/news-publish-targets-management/components/NewsPublishTargetsManagement.vue
@@ -75,7 +75,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                       dark
                       color="primary"
                       size="16"
-                      @click="deleteNewsTarget(props.item.name)">
+                      @click="deleteConfirmDialog(props.item.name)">
                       fas fa-trash
                     </v-icon>
                   </v-btn>
@@ -85,6 +85,13 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
           </template>
         </v-data-table>
       </div>
+      <exo-confirm-dialog
+        ref="deleteConfirmDialog"
+        :message="$t('news.newsTarget.message.confirmDeleteNews')"
+        :title="$t('news.newsTarget.title.confirmDeleteNews')"
+        :ok-label="$t('news.button.ok')"
+        :cancel-label="$t('news.button.cancel')"
+        @ok="deleteNewsTarget(selectedTarget)" />
       <exo-news-notification-alerts />
     </v-main>
   </v-app>
@@ -97,6 +104,7 @@ export default {
     itemsPerPage: 10,
     initialized: false,
     loading: true,
+    selectedTarget: '',
   }),
   computed: {
     hideFooter() {
@@ -149,6 +157,10 @@ export default {
           this.init();
         }
       }, redirectionTime);
+    },
+    deleteConfirmDialog(target) {
+      this.selectedTarget = target;
+      this.$refs.deleteConfirmDialog.open();
     },
   }
 };

--- a/webapp/src/main/webapp/news-publish-targets-management/components/NewsPublishTargetsManagement.vue
+++ b/webapp/src/main/webapp/news-publish-targets-management/components/NewsPublishTargetsManagement.vue
@@ -74,7 +74,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                     <v-icon
                       dark
                       color="primary"
-                      size="16">
+                      size="16"
+                      @click="deleteNewsTarget(props.item.name)">
                       fas fa-trash
                     </v-icon>
                   </v-btn>
@@ -84,6 +85,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
           </template>
         </v-data-table>
       </div>
+      <exo-news-notification-alerts />
     </v-main>
   </v-app>
 </template>
@@ -133,6 +135,20 @@ export default {
             this.initialized = false;
           });
       }
+    },
+    deleteNewsTarget(targetName) {
+      const deleteDelay = 6;
+      const redirectionTime = 8100;
+      this.$newsTargetingService.deleteTargetByName(targetName, deleteDelay)
+        .then(() => {
+          this.$root.$emit('confirm-newsTarget-deletion', targetName);
+        });
+      setTimeout(() => {
+        const deletedNewsTarget = localStorage.getItem('deletedNewsTarget');
+        if (deletedNewsTarget != null) {
+          this.init();
+        }
+      }, redirectionTime);
     },
   }
 };

--- a/webapp/src/main/webapp/services/newsTargetingService.js
+++ b/webapp/src/main/webapp/services/newsTargetingService.js
@@ -37,3 +37,30 @@ export function getReferencedTargets() {
     }
   });
 }
+
+export function deleteTargetByName(targetName, delay) {
+  if (delay > 0) {
+    localStorage.setItem('deletedNewsTarget', targetName);
+  }
+  return fetch(`${newsConstants.NEWS_API}/targeting/${targetName}?delay=${delay || 0}`, {
+    credentials: 'include',
+    method: 'DELETE'
+  }).then((resp) => {
+    if (resp && !resp.ok) {
+      throw new Error('Error when deleting news target');
+    }
+  });
+}
+
+export function undoDeleteNewsTarget(targetName) {
+  return fetch(`${newsConstants.NEWS_API}/targeting/${targetName}/undoDeleteNewsTarget`, {
+    method: 'POST',
+    credentials: 'include',
+  }).then((resp) => {
+    if (resp && resp.ok) {
+      localStorage.removeItem('deletedNewsTarget');
+    } else {
+      throw new Error('Error when undoing deleting news target');
+    }
+  });
+}

--- a/webapp/src/main/webapp/services/newsTargetingService.js
+++ b/webapp/src/main/webapp/services/newsTargetingService.js
@@ -52,8 +52,8 @@ export function deleteTargetByName(targetName, delay) {
   });
 }
 
-export function undoDeleteNewsTarget(targetName) {
-  return fetch(`${newsConstants.NEWS_API}/targeting/${targetName}/undoDeleteNewsTarget`, {
+export function undoDeleteTarget(targetName) {
+  return fetch(`${newsConstants.NEWS_API}/targeting/${targetName}/undoDelete`, {
     method: 'POST',
     credentials: 'include',
   }).then((resp) => {


### PR DESCRIPTION
After this change, we implement delete target and undo deleting services.