### PR TITLE
MAINT-51585: Fix draft saving success indication when creating a new article before saving it and its activity creation

### DIFF
--- a/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/NewsServiceImpl.java
@@ -1189,6 +1189,9 @@ public class NewsServiceImpl implements NewsService {
   @Override
   public void updateNewsActivity(News news, boolean post) {
     ExoSocialActivity activity = activityManager.getActivity(news.getActivityId());
+    if (activity == null) {
+      return;
+    }
     if(post) {
       activity.setUpdated(System.currentTimeMillis());
     }


### PR DESCRIPTION
…
**ISSUE**: When create a new article before saving it the draft saving indication is always in progress because of an unhandled `NPE` when getting news related activity as it still not yet created before saving the news
**FIX**: Add a check on null value of activity when calling the update activity function during the update of the news