### PR TITLE
Task-49608: News not displayed on snapshot view.

### DIFF
--- a/webapp/src/main/webapp/latest-news/components/ExoLatestNews.vue
+++ b/webapp/src/main/webapp/latest-news/components/ExoLatestNews.vue
@@ -1,6 +1,5 @@
 <template>
   <v-app
-    id="latestNewsDetails"
     class="VuetifyApp"
     flat>
     <v-container pa-0>
@@ -202,7 +201,7 @@ export default {
     }
   },
   mounted() {
-    this.$nextTick().then(() => this.$root.$emit('application-loaded'));
+    this.$root.$emit('application-loaded');
   },
   methods: {
     openNews(url){

--- a/webapp/src/main/webapp/latest-news/main.js
+++ b/webapp/src/main/webapp/latest-news/main.js
@@ -23,12 +23,9 @@ export function initLatestNews(params) {
   const lang = typeof eXo !== 'undefined' ? eXo.env.portal.language : 'en';
   // should expose the locale resources as REST API
   const url = `${newsConstants.PORTAL}/${newsConstants.PORTAL_REST}/i18n/bundle/locale.portlet.news.News-${lang}.json`;
-  exoi18n.loadLanguageAsync(lang, url).then(i18n => {
-    const appElement = document.createElement('div');
-    appElement.id = appId;
-
-    // init Vue app when locale resources are ready
-    latestNewsDetails = new Vue({
+  exoi18n.loadLanguageAsync(lang, url).then(i18n => {  
+  // init Vue app when locale resources are ready
+    latestNewsDetails = Vue.createApp({
       data: function() {
         return {
           newsInfo: params.newsInfo,
@@ -41,7 +38,7 @@ export function initLatestNews(params) {
       template: `<exo-news-latest id="${appId}" v-cacheable :news-info="newsInfo" :header="header" :see-all="seeAllLabel" :url="url"  :is-show-header="isShowHeader"></exo-news-latest>`,
       i18n,
       vuetify,
-    }).$mount(appElement);
+    }, `#${appId}`, 'news');
   });
 }
 


### PR DESCRIPTION
 Task-49608: News not displayed on snapshot view.

Problem: Before this fix, when refreshing snapshot page sometimes we get an empty latest news widget. So the problem was the same id occurred in many DOM elements and that is why many problems founded when browser, try to interpret the DOM element so sometimes has unexpected behavior.
Fix: remove the redundant id which also exists in the component Exo-latest-News and change the instantiation method of the app view by replacing new view with the createapp method of views 3 infact it is more perfermant also I mounted this application directly by the id without need to create a new div element.