### PR TITLE
Task-53138 : Fix scheduled articles problems

### DIFF
--- a/webapp/src/main/webapp/news-details-app/components/ExoNewsDetailsApp.vue
+++ b/webapp/src/main/webapp/news-details-app/components/ExoNewsDetailsApp.vue
@@ -16,6 +16,7 @@
 </template>
 
 <script>
+const UNAUTHORIZED_CODE = 401;
 export default {
   props: {
     newsId: {
@@ -33,7 +34,7 @@ export default {
   created() {
     this.$newsServices.getNewsById(this.newsId, false)
       .then(news => {
-        if (news !== null) {
+        if (news !== null && news !== UNAUTHORIZED_CODE) {
           this.news = news;
           this.showEditButton = this.news.canEdit;
           this.showPublishButton = this.news.canPublish;

--- a/webapp/src/main/webapp/news-details/components/ExoNewsDetails.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsDetails.vue
@@ -26,7 +26,6 @@
       @ok="deleteNews" />
     <exo-news-details-body
       v-if="!isMobile"
-      :un-authorized-access="unAuthorizedAccess"
       :news="news" />
     <exo-news-details-body-mobile
       v-if="isMobile"
@@ -42,7 +41,6 @@
 <script>
 
 const USER_TIMEZONE_ID = new window.Intl.DateTimeFormat().resolvedOptions().timeZone;
-const UNAUTHORIZED_CODE = 401;
 export default {
   props: {
     news: {
@@ -81,7 +79,6 @@ export default {
       currentSpace: null,
       spaceId: null,
       BYTES_IN_MB: 1048576,
-      unAuthorizedAccess: false,
       dateFormat: {
         year: 'numeric',
         month: 'long',
@@ -203,19 +200,15 @@ export default {
     getNewsById(newsId) {
       this.$newsServices.getNewsById(newsId)
         .then(news => {
-          if (news === UNAUTHORIZED_CODE){
-            this.unAuthorizedAccess = true;
-          } else {
-            this.spaceId = news.spaceId;
-            this.getSpaceById(this.spaceId);
-            if (!this.news) {
-              this.news = news;
-            }
-            if (!this.news.newsId) {
-              this.news.newsId = newsId;
-            }
-            return this.$nextTick();
+          this.spaceId = news.spaceId;
+          this.getSpaceById(this.spaceId);
+          if (!this.news) {
+            this.news = news;
           }
+          if (!this.news.newsId) {
+            this.news.newsId = newsId;
+          }
+          return this.$nextTick();
         })
         .finally(() => {
           document.title = this.$t('news.window.title', {0: this.news.title});

--- a/webapp/src/main/webapp/news-details/components/ExoNewsDetails.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsDetails.vue
@@ -26,6 +26,7 @@
       @ok="deleteNews" />
     <exo-news-details-body
       v-if="!isMobile"
+      :un-authorized-access="unAuthorizedAccess"
       :news="news" />
     <exo-news-details-body-mobile
       v-if="isMobile"
@@ -41,6 +42,7 @@
 <script>
 
 const USER_TIMEZONE_ID = new window.Intl.DateTimeFormat().resolvedOptions().timeZone;
+const UNAUTHORIZED_CODE = 401;
 export default {
   props: {
     news: {
@@ -79,6 +81,7 @@ export default {
       currentSpace: null,
       spaceId: null,
       BYTES_IN_MB: 1048576,
+      unAuthorizedAccess: false,
       dateFormat: {
         year: 'numeric',
         month: 'long',
@@ -200,15 +203,19 @@ export default {
     getNewsById(newsId) {
       this.$newsServices.getNewsById(newsId)
         .then(news => {
-          this.spaceId = news.spaceId;
-          this.getSpaceById(this.spaceId);
-          if (!this.news) {
-            this.news = news;
+          if (news === UNAUTHORIZED_CODE){
+            this.unAuthorizedAccess = true;
+          } else {
+            this.spaceId = news.spaceId;
+            this.getSpaceById(this.spaceId);
+            if (!this.news) {
+              this.news = news;
+            }
+            if (!this.news.newsId) {
+              this.news.newsId = newsId;
+            }
+            return this.$nextTick();
           }
-          if (!this.news.newsId) {
-            this.news.newsId = newsId;
-          }
-          return this.$nextTick();
         })
         .finally(() => {
           document.title = this.$t('news.window.title', {0: this.news.title});

--- a/webapp/src/main/webapp/news-details/components/ExoNewsDetailsBody.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsDetailsBody.vue
@@ -81,8 +81,7 @@
                         :format="dateTimeFormat"
                         class="newsInformationValue newsUpdatedDate ml-1 me-1" />
                     </template>
-                    <div v-else-if="news && news.updatedDate" class="newsInformationValue newsUpdatedDate">{{ news.updatedDate }}</div>
-                    <div v-if="notSameUpdater">
+                    <div v-if="notSameUpdater && showUpdateInfo">
                       <span class="newsInformationLabel"> {{ $t('news.activity.by') }} </span>
                       <a :href="updaterProfileURL" class="newsInformationValue newsUpdaterName">{{ updaterFullName }}</a>
                     </div>
@@ -161,7 +160,7 @@ export default {
       return this.news && this.news.title;
     },
     showUpdateInfo() {
-      return this.news && this.news.updateDate && this.news.updateDate !== 'null' && this.news.publicationDate && this.news.publicationDate!== 'null' && this.news.updateDate.time > this.news.publicationDate.time;
+      return this.news && this.news.updateDate && this.news.updater !=='__system' && this.news.updateDate !== 'null' && this.news.publicationDate && this.news.publicationDate !== 'null' && this.news.updateDate.time > this.news.publicationDate.time;
     },
     authorFullName() {
       return this.news && (this.news.authorFullName || this.news.authorDisplayName);
@@ -179,7 +178,7 @@ export default {
       return this.news && this.targetBlank(this.news.body);
     },
     updaterFullName() {
-      return this.news && this.news.updater !=='__system' ? this.news.updaterFullName : this.news.authorFullName;
+      return this.news && this.news.updaterFullName;
     },
     updaterProfileURL() {
       return this.news && `${eXo.env.portal.context}/${eXo.env.portal.portalName}/profile/${this.news.updater}`;
@@ -212,7 +211,7 @@ export default {
       return this.news && this.news.publicationState;
     },
     notSameUpdater() {
-      return this.news && !this.news.publicationState === 'staged' && this.news.updater !=='__system' && this.news.updater !== this.news.author;
+      return this.news && this.news.updater !== this.news.author;
     },
     scheduleDate() {
       return this.news && this.news.schedulePostDate;

--- a/webapp/src/main/webapp/news-details/components/ExoNewsDetailsBody.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsDetailsBody.vue
@@ -8,6 +8,12 @@
         <h3>{{ $t('news.archive.text') }}</h3>
       </div>
     </div>
+    <div v-show="unAuthorizedAccess" class="newsComposer">
+      <div class="articleNotFound">
+        <i class="iconNotFound"></i>
+        <h3 class="restrictedAction">{{ $t('news.details.restricted') }}</h3>
+      </div>
+    </div>
     <div class="newsDetails-description">
       <div :class="[illustrationURL ? 'newsDetails-header' : '']" class="newsDetails-header">
         <div v-if="illustrationURL" class="illustration">
@@ -127,6 +133,11 @@ export default {
       required: false,
       default: null
     },
+    unAuthorizedAccess: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
   },
   data: () => ({
     dateFormat: {
@@ -201,7 +212,7 @@ export default {
       return this.news && this.news.publicationState;
     },
     notSameUpdater() {
-      return this.news && this.news.updater !=='__system' && this.news.updater !== this.news.author;
+      return this.news && !this.news.publicationState === 'staged' && this.news.updater !=='__system' && this.news.updater !== this.news.author;
     },
     scheduleDate() {
       return this.news && this.news.schedulePostDate;

--- a/webapp/src/main/webapp/news-details/components/ExoNewsDetailsBody.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsDetailsBody.vue
@@ -8,12 +8,6 @@
         <h3>{{ $t('news.archive.text') }}</h3>
       </div>
     </div>
-    <div v-show="unAuthorizedAccess" class="newsComposer">
-      <div class="articleNotFound">
-        <i class="iconNotFound"></i>
-        <h3 class="restrictedAction">{{ $t('news.details.restricted') }}</h3>
-      </div>
-    </div>
     <div class="newsDetails-description">
       <div :class="[illustrationURL ? 'newsDetails-header' : '']" class="newsDetails-header">
         <div v-if="illustrationURL" class="illustration">
@@ -131,11 +125,6 @@ export default {
       type: Object,
       required: false,
       default: null
-    },
-    unAuthorizedAccess: {
-      type: Boolean,
-      required: false,
-      default: false
     },
   },
   data: () => ({

--- a/webapp/src/main/webapp/news-details/components/ExoNewsDetailsToolBar.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsDetailsToolBar.vue
@@ -16,6 +16,7 @@
       :show-delete-button="showDeleteButton"
       :show-publish-button="showPublishButton" />
     <exo-news-favorite-action
+      v-if="publicationState !== 'staged'"
       :news="news"
       :activity-id="activityId"
       class="mt-6 pull-right" />

--- a/webapp/src/main/webapp/news-details/components/ExoNewsFavoriteAction.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsFavoriteAction.vue
@@ -46,8 +46,8 @@ export default {
       .then(fullActivity => {
         this.isFavorite = fullActivity && fullActivity.metadatas && fullActivity.metadatas.favorites && fullActivity.metadatas.favorites.length;
       });
-    this.templateParams.newsId = this.news.id;
-    this.templateParams.spaceId = this.news.spaceId;
+    this.templateParams.newsId = this.news && this.news.id;
+    this.templateParams.spaceId = this.news && this.news.spaceId;
   },
   methods: {
     removed() {


### PR DESCRIPTION
_ISSUES_ :
- After creating a scheduled article by a redactor or a manager and try to display it by another redactor or manager, the mention **By user** is displayed next to the scheduled time which is not the expected behavior.
- While opening a scheduled article, an error **Cannot read properties of null (reading 'id')** appears.
- When a user tries to display a not authorized scheduled article or an unpublished article posted in a space in which he is not a member via URL, undefined informations are displayed.
- When a scheduled article is posted, the mention updated on (+date of post ) is displayed even if the article is not updated.

_FIX_ :
- Display the mention **By user** only if a non scheduled article is updated.
- Prevent to display the `NewsActionFavorite` component in case of a scheduled article in addition and do not get the `newsId` value if the `news` object is passed as null from the parent component.
- A restriction page is displayed when the user tries to display a non unauthorized article.
- Prevent to display the updated date just after posting the scheduled article and display it only after the edit action.