### PR TITLE
Task-52284: Fix Back button on news articles to lead to last viewed page

### DIFF
--- a/webapp/src/main/webapp/news-details/components/ExoNewsDetailsToolBar.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsDetailsToolBar.vue
@@ -1,6 +1,6 @@
 <template>
   <div :class="!showEditButton && 'me-5'" class="newsDetailsTopBar">
-    <a class="backBtn" :href="backURL"><i class="uiIconBack my-4"></i></a>
+    <a v-if="lastVisitedPage" class="backBtn" @click="goBack"><i class="uiIconBack my-4"></i></a>
     <v-btn
       v-if="publicationState === 'staged'"
       class="btn newsDetailsActionMenu mt-6 mr-2 pull-right"
@@ -87,7 +87,15 @@ export default {
     },
     newsPublished() {
       return this.news && this.news.published;
+    },
+    lastVisitedPage(){
+      return history && history.length && history.length > 2;
     }
   },
+  methods: {
+    goBack() {
+      history.back();
+    },
+  }
 };
 </script>


### PR DESCRIPTION
*ISSUE* : back button on news article details always leads to the AS in case of the user is a member and if he's not, it leads him to the snapshot page from anywhere he opens the article, because of a regression occurred somehow.

*FIX* : fix the regression by re-adding the `goBack` function which redirect to the last visited page. If the user is using a new tab in case the history navigation is clear, the go back button wont be displayed.