### PR TITLE
Task-49608 News not displayed on snapshot view

### DIFF
--- a/webapp/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/webapp/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -244,6 +244,9 @@
     <depends>
       <module>vuetify</module>
     </depends>
+    <depends>
+      <module>commonVueComponents</module>
+    </depends>
   </module>
 
   <module>


### PR DESCRIPTION
Before this fix there was a js error when latestNews initialize. The error is that Vue.createApp does not exists.
This problem is due to a missing dependency on js module commonVueComponent, which add the function createApp in Vue object
This commit add the missing dependency in gatein-resources.xml