### PR TITLE
Task-53093: Add news list portlet in content application category for full data instances

### DIFF
--- a/webapp/src/main/webapp/WEB-INF/conf/news/application-registry-configuration.xml
+++ b/webapp/src/main/webapp/WEB-INF/conf/news/application-registry-configuration.xml
@@ -16,13 +16,13 @@
   <external-component-plugins>
     <target-component>org.exoplatform.application.registry.ApplicationRegistryService</target-component>
     <component-plugin>
-      <name>spaces.portlets.registry</name>
+      <name>news.portlets.registry</name>
       <set-method>initListener</set-method>
       <type>org.exoplatform.application.registry.ApplicationCategoriesPlugins</type>
       <description>this listener init the portlets are registered in PortletRegister</description>
       <init-params>
         <value-param>
-          <name>merge</name>
+          <name>system</name>
           <value>true</value>
         </value-param>
         <object-param>
@@ -41,7 +41,7 @@
             <field name="accessPermissions">
               <collection type="java.util.ArrayList" item-type="java.lang.String">
                 <value>
-                  <string>*:/platform/web-contributors</string>
+                  <string>*:/platform/users</string>
                 </value>
               </collection>
             </field>


### PR DESCRIPTION
Prior to this change, news list portlet is not added into content application category for full data instances and added only for empty instances. After this change, we have configured 'system' value param on ApplicationCategoriesPlugins component plugin to allow that.