### PR TITLE
Task-54069: Display all targets when publishing articles

### DIFF
--- a/webapp/src/main/webapp/components/targetSelector/ExoNewsTargetsSelector.vue
+++ b/webapp/src/main/webapp/components/targetSelector/ExoNewsTargetsSelector.vue
@@ -23,7 +23,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         id="chooseTargets"
         ref="chooseTargets"
         v-model="selectedTargets"
-        :items="referencedTargets"
+        :items="targets"
         :menu-props="{ bottom: true, offsetY: true}"
         :placeholder="$t('news.composer.stepper.chooseTarget.option')"
         item-text="label"
@@ -86,7 +86,7 @@ export default {
   },
   data: () =>({
     selectedTargets: [],
-    referencedTargets: [],
+    targets: [],
   }),
   computed: {
     disableTargetOption() {
@@ -96,7 +96,7 @@ export default {
       return this.disableTargetOption && this.publish;
     },
     selectAllTargets() {
-      return this.selectedTargets.length === this.referencedTargets.length;
+      return this.selectedTargets.length === this.targets.length;
     },
     selectSomeTarget() {
       return this.selectedTargets.length > 0 && !this.selectAllTargets;
@@ -111,7 +111,7 @@ export default {
     }
   },
   created() {
-    this.getReferencedTargets();
+    this.getAllTargets();
     $(document).click(() => {
       if (this.$refs.chooseTargets && this.$refs.chooseTargets.isMenuActive) {
         this.$refs.chooseTargets.blur();
@@ -131,8 +131,8 @@ export default {
           this.selectedTargets = [];
         } else {
           const selectedTargets = [];
-          for (const item in this.referencedTargets) {
-            selectedTargets.push(this.referencedTargets[item].name);
+          for (const item in this.targets) {
+            selectedTargets.push(this.targets[item].name);
           }
           this.selectedTargets = selectedTargets;
         }
@@ -142,12 +142,12 @@ export default {
     addTarget() {
       this.$emit('selected-targets', this.selectedTargets);
     },
-    getReferencedTargets() {
-      this.$newsTargetingService.getReferencedTargets()
-        .then(referencedTargets => {
-          this.referencedTargets = referencedTargets.map(referencedTarget => ({
-            name: referencedTarget.name,
-            label: referencedTarget.properties && referencedTarget.properties.label,
+    getAllTargets() {
+      this.$newsTargetingService.getAllTargets()
+        .then(targets => {
+          this.targets = targets.map(target => ({
+            name: target.name,
+            label: target.properties && target.properties.label,
           }));
         });
     },

--- a/webapp/src/main/webapp/components/targetSelector/ExoNewsTargetsSelector.vue
+++ b/webapp/src/main/webapp/components/targetSelector/ExoNewsTargetsSelector.vue
@@ -54,6 +54,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
           <v-chip
             v-if="index === 0"
             close
+            :title="item.tooltipInfo"
             @click:close="removeTarget(item)">
             <span>{{ item.label }}</span>
           </v-chip>
@@ -147,7 +148,8 @@ export default {
         .then(targets => {
           this.targets = targets.map(target => ({
             name: target.name,
-            label: target.properties && target.properties.label,
+            label: target.properties && target.properties.label && target.properties.label.length > 35 ? target.properties.label.substring(0, 35).concat('...'): target.properties.label,
+            tooltipInfo: target.properties && target.properties.label
           }));
         });
     },

--- a/webapp/src/main/webapp/news-list-view/components/settings/NewsSettingsDrawer.vue
+++ b/webapp/src/main/webapp/news-list-view/components/settings/NewsSettingsDrawer.vue
@@ -62,7 +62,13 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
               item-value="name"
               dense
               outlined
-              @click.stop />
+              @click.stop>
+              <template v-slot:selection="{ item, index }">
+                <span :title="item.toolTipInfo">
+                  {{ item.label }}
+                </span>
+              </template>
+            </v-select>
           </div>
           <div class="d-flex flex-row">
             <label for="viewTemplate" class="listViewLabel text-subtitle-1 mt-6">
@@ -210,7 +216,8 @@ export default {
           .then(newsTargets => {
             this.newsTargets = newsTargets.map(newsTarget => ({
               name: newsTarget.name,
-              label: newsTarget.properties && newsTarget.properties.label,
+              label: newsTarget.properties && newsTarget.properties.label && newsTarget.properties.label.length > 35 ? newsTarget.properties.label.substring(0, 35).concat('...'): newsTarget.properties.label,
+              toolTipInfo: newsTarget.properties && newsTarget.properties.label
             }));
             this.initialized = true;
           })


### PR DESCRIPTION
Before this change, target selector of publishing drawer displays only referenced targets. So the newly created targets are not selectable from the publishing drawer when they are not yet referenced by one or more news list portlets instances. After this change, and waiting the update of referenced targets when any page modification is done, we will display all targets from publishing drawer.