### PR TITLE
TASK-53560: Set USER ID as a default filter for two columns in the content analytics page.

### DIFF
--- a/webapp/src/main/webapp/WEB-INF/conf/news/portal/analytics/portal/global/pages.xml
+++ b/webapp/src/main/webapp/WEB-INF/conf/news/portal/analytics/portal/global/pages.xml
@@ -114,7 +114,8 @@
                                           "periodIndependent":false,
                                           "aggregation":{
                                              "sortDirection":"desc",
-                                             "type":"COUNT",
+                                             "field": "userId",
+                                             "type": "CARDINALITY"
                                          }
                                       },
                                       "sortable":true,
@@ -154,7 +155,8 @@
                                           "periodIndependent":true,
                                           "aggregation":{
                                               "sortDirection":"desc",
-                                              "type":"COUNT",
+                                              "field": "userId",
+                                              "type": "CARDINALITY"
                                           }
                                      },
                                       "sortable":true,


### PR DESCRIPTION
ISSUES : In analytics application, the data in the columns (Number of distinct views / period, Number of all distinct views) in the Content Analytics page are not correct.
FIX : The problem is that the default filter of columns (Number of distinct views / period, Number of all distinct views) is 'Count samples' and should be 'Count samples with distinct field' and it fixed by changing the default settings in page.xml.