### PR TITLE
Task-54302: [Accessibility-Image C1.3] Put news title as alternative text "alt" attribute value for news article illustration image of news details

### DIFF
--- a/webapp/src/main/webapp/news-details/components/ExoNewsDetailsBody.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsDetailsBody.vue
@@ -14,7 +14,7 @@
           <img
             :src="illustrationURL"
             class="newsDetailsImage illustrationPicture"
-            alt="News"
+            :alt="newsTitle"
             longdesc="#newsSummary">
         </div>
         <div class="newsDetails">


### PR DESCRIPTION

Prior to this change, in news details, alternative text "alt" attribute of news article illustration image has the generic "News" value. In order to be compliant with Accessibility image criterion C1.3, after this change, we ensure that alternative text "alt" attribute of news article illustration image has as value the news article title. 