### PR TITLE
Task-53818: Fix loading problem of news targets management page

### DIFF
--- a/webapp/src/main/webapp/news-publish-targets-management/components/NewsPublishTargetsManagement.vue
+++ b/webapp/src/main/webapp/news-publish-targets-management/components/NewsPublishTargetsManagement.vue
@@ -134,7 +134,6 @@ export default {
   methods: {
     init() {
       if (!this.initialized) {
-        this.initializing = true;
         this.loading = true;
         this.$newsTargetingService.getAllTargets()
           .then(newsTargets => {

--- a/webapp/src/main/webapp/news-publish-targets-management/components/NewsPublishTargetsManagementDrawer.vue
+++ b/webapp/src/main/webapp/news-publish-targets-management/components/NewsPublishTargetsManagementDrawer.vue
@@ -111,7 +111,7 @@ export default {
       return this.targetName && !this.targetName.trim().match(/^[\w\-\s]+$/) && this.targetName.length > 0 ? this.$t('news.list.settings.name.errorMessage') : '';
     },
     disabled() {
-      return (this.selectedTarget.targetName === this.targetName && this.selectedTarget.targetDescription === this.targetDescription) || this.checkAlphanumeric !== '' || this.targetName.length === 0 || this.sameTargetError;
+      return (this.selectedTarget.targetName === this.targetName && this.selectedTarget.targetDescription === this.targetDescription) || this.checkAlphanumeric !== '' || this.targetName.length === 0 || this.sameTargetError || this.targetDescription.length > this.targetDescriptionTextLength;
     },
     saveButtonLabel() {
       return this.saveMode === 'edit' ? 'Update' : this.$t('news.publishTargets.managementDrawer.btn.confirm');

--- a/webapp/src/main/webapp/news-publish-targets-management/main.js
+++ b/webapp/src/main/webapp/news-publish-targets-management/main.js
@@ -15,6 +15,13 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 import './initComponents.js';
+import * as newsTargetingService from '../services/newsTargetingService.js';
+
+if (!Vue.prototype.$newsTargetingService) {
+  window.Object.defineProperty(Vue.prototype, '$newsTargetingService', {
+    value: newsTargetingService,
+  });
+}
 
 // get override components if exists
 if (extensionRegistry) {


### PR DESCRIPTION
**Issue:**  When accessing to news targets management page, the page still loads without displaying news targets.
**Fix:**  We define newsTargetingService in the main.js file of news Publish Targets Management portlet to ensure being loaded when the portlet is displayed.