### PR TITLE
Task-52983 : push notifications for published articles show up empty on mobile #446

### DIFF
--- a/services/src/main/java/org/exoplatform/news/notification/provider/PushTemplateProvider.java
+++ b/services/src/main/java/org/exoplatform/news/notification/provider/PushTemplateProvider.java
@@ -10,7 +10,8 @@ import org.exoplatform.social.core.space.spi.SpaceService;
 
 @TemplateConfigs(templates = {
     @TemplateConfig(pluginId = PostNewsNotificationPlugin.ID, template = "war:/notification/templates/push/postNewsNotificationPlugin.gtmpl"),
-    @TemplateConfig(pluginId = MentionInNewsNotificationPlugin.ID, template = "war:/notification/templates/push/postNewsNotificationPlugin.gtmpl") })
+    @TemplateConfig(pluginId = MentionInNewsNotificationPlugin.ID, template = "war:/notification/templates/push/postNewsNotificationPlugin.gtmpl"),
+    @TemplateConfig(pluginId = PublishNewsNotificationPlugin.ID, template = "war:/notification/templates/push/postNewsNotificationPlugin.gtmpl")})
 public class PushTemplateProvider extends WebTemplateProvider {
   protected static Log log = ExoLogger.getLogger(PushTemplateProvider.class);
 


### PR DESCRIPTION
ISSUE: push notifications for published articles show up empty on mobile
FIX: added missing configuration for published news in the class PushTemplateProvider