### PR TITLE
Task-53281: article post push notification redirects to a wrong content #454

### DIFF
--- a/services/src/main/java/org/exoplatform/news/notification/provider/WebTemplateProvider.java
+++ b/services/src/main/java/org/exoplatform/news/notification/provider/WebTemplateProvider.java
@@ -98,6 +98,7 @@ public class WebTemplateProvider extends TemplateProvider {
       // binding the exception throws by processing template
       ctx.setException(templateContext.getException());
       MessageInfo messageInfo = new MessageInfo();
+      messageInfo.subject(activityUrl.toString());
       return messageInfo.body(body).end();
     }
 


### PR DESCRIPTION
ISSUE: the url for news push notification are beign sent empty 
FIX: added the url to the messageInfo object that's being sent to firebase message mublisher