### PR TITLE
Task-54647: Bad display for slider news

### DIFF
--- a/webapp/src/main/webapp/skin/less/news.less
+++ b/webapp/src/main/webapp/skin/less/news.less
@@ -2741,6 +2741,7 @@
   flex: 1 1 auto;
   max-width: 100%;
   height: 100%;
+  margin-bottom: 20px;
   #news-latest-view {
     overflow: hidden;
     background: #fff;


### PR DESCRIPTION
Problem: When you add the slider news on another page(not snapshot page) there’s a bad display : no padding and the height is not fixed.
Fix: I fixed the display of slider news, so I added a margin-bottom of the newsListViewApp in news skins to make a separation between the Activity and the news container