### PR TITLE
TASK-55066 : Search tags from a news doesn't work after update

### DIFF
--- a/services/src/main/java/org/exoplatform/news/service/impl/NewsServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/service/impl/NewsServiceImpl.java
@@ -598,6 +598,7 @@ public class NewsServiceImpl implements NewsService {
       if (post) {
         activity.setUpdated(System.currentTimeMillis());
       }
+      activity.setBody(news.getBody());
       activity.isHidden(news.isActivityPosted());
       activityManager.updateActivity(activity, true);
     }


### PR DESCRIPTION
force the news indexing service to perform the indexing process after updating a news . 