### PR TITLE
TASK-55137: article it has been archived should not displayed in the latest news

### DIFF
--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>news</artifactId>
     <groupId>org.exoplatform.addons.news</groupId>
-    <version>2.3.x-SNAPSHOT</version>
+    <version>2.3.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>news-packaging</artifactId>
   <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
   </parent>
   <groupId>org.exoplatform.addons.news</groupId>
   <artifactId>news</artifactId>
-  <version>2.3.x-SNAPSHOT</version>
+  <version>2.3.x-maintenance-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>eXo Add-on:: News</name>
   <description>News</description>
@@ -40,10 +40,10 @@
   </modules>
 
   <properties>
-    <org.exoplatform.social.version>6.3.x-SNAPSHOT</org.exoplatform.social.version>
-    <org.exoplatform.platform-ui.version>6.3.x-SNAPSHOT</org.exoplatform.platform-ui.version>
-    <addon.exo.ecms.version>6.3.x-SNAPSHOT</addon.exo.ecms.version>
-    <addon.exo.analytics.version>1.2.x-SNAPSHOT</addon.exo.analytics.version>
+    <org.exoplatform.social.version>6.3.x-maintenance-SNAPSHOT</org.exoplatform.social.version>
+    <org.exoplatform.platform-ui.version>6.3.x-maintenance-SNAPSHOT</org.exoplatform.platform-ui.version>
+    <addon.exo.ecms.version>6.3.x-maintenance-SNAPSHOT</addon.exo.ecms.version>
+    <addon.exo.analytics.version>1.2.x-maintenance-SNAPSHOT</addon.exo.analytics.version>
     <pitest.version>1.4.10</pitest.version>
     
     <sonar.organization>exoplatform</sonar.organization>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>news</artifactId>
     <groupId>org.exoplatform.addons.news</groupId>
-    <version>2.3.x-SNAPSHOT</version>
+    <version>2.3.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>news-services</artifactId>
   <packaging>jar</packaging>

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>news</artifactId>
     <groupId>org.exoplatform.addons.news</groupId>
-    <version>2.3.x-SNAPSHOT</version>
+    <version>2.3.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>news-webapp</artifactId>
   <packaging>war</packaging>

--- a/webapp/src/main/webapp/news-list-view/components/views/NewsLatestView.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsLatestView.vue
@@ -89,7 +89,7 @@ export default {
       if (!this.initialized) {
         this.$newsListService.getNewsList(this.newsTarget, this.offset, this.limit, true)
           .then(newsList => {
-            this.newsInfo = newsList.news;
+            this.newsInfo = newsList.news.filter(news => news.archived === false);
             if (this.newsInfo && this.newsInfo[0] && this.newsInfo[0].spaceId) {
               this.getSpaceById(this.newsInfo[0].spaceId);
             }


### PR DESCRIPTION
Prior to this change, when post an article with title and content, then publish it with choosing Snapshot latest news as target 
,click to Archive button related to this article , then go to the Snapshot page, Article is displayed . 
This is due to the fact that article displayed in the latest news section is not filtered by not archived , 
After this change, we ensure that article archived is not displayed in the latest news section of the snapshot page.