### PR TITLE
Task-55137: Do not display archived articles in the latest news

### DIFF
--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>news</artifactId>
     <groupId>org.exoplatform.addons.news</groupId>
-    <version>2.3.x-SNAPSHOT</version>
+    <version>2.3.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>news-packaging</artifactId>
   <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
   </parent>
   <groupId>org.exoplatform.addons.news</groupId>
   <artifactId>news</artifactId>
-  <version>2.3.x-SNAPSHOT</version>
+  <version>2.3.x-maintenance-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>eXo Add-on:: News</name>
   <description>News</description>
@@ -40,10 +40,10 @@
   </modules>
 
   <properties>
-    <org.exoplatform.social.version>6.3.x-SNAPSHOT</org.exoplatform.social.version>
-    <org.exoplatform.platform-ui.version>6.3.x-SNAPSHOT</org.exoplatform.platform-ui.version>
-    <addon.exo.ecms.version>6.3.x-SNAPSHOT</addon.exo.ecms.version>
-    <addon.exo.analytics.version>1.2.x-SNAPSHOT</addon.exo.analytics.version>
+    <org.exoplatform.social.version>6.3.x-maintenance-SNAPSHOT</org.exoplatform.social.version>
+    <org.exoplatform.platform-ui.version>6.3.x-maintenance-SNAPSHOT</org.exoplatform.platform-ui.version>
+    <addon.exo.ecms.version>6.3.x-maintenance-SNAPSHOT</addon.exo.ecms.version>
+    <addon.exo.analytics.version>1.2.x-maintenance-SNAPSHOT</addon.exo.analytics.version>
     <pitest.version>1.4.10</pitest.version>
     
     <sonar.organization>exoplatform</sonar.organization>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>news</artifactId>
     <groupId>org.exoplatform.addons.news</groupId>
-    <version>2.3.x-SNAPSHOT</version>
+    <version>2.3.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>news-services</artifactId>
   <packaging>jar</packaging>

--- a/services/src/main/java/org/exoplatform/news/service/NewsService.java
+++ b/services/src/main/java/org/exoplatform/news/service/NewsService.java
@@ -241,14 +241,9 @@ public interface NewsService {
   boolean canArchiveNews(org.exoplatform.services.security.Identity currentIdentity, String newsAuthor);
 
   /**
-   * Check if an object identified by its type/id for a user has favorite metadata
-   * or not
+   * isArchive a news
    *
-   * @param newsId {@link News} object that has to define: - objectType
-   *          object type, can be of any type: activity, comment, notes... -
-   *          objectId object technical unique identifier - userIdentityId
-   *          {@link Identity} technical identifier of the user
-   * @throws ObjectNotFoundException when the favorite doesn't exists
+   * @param newsId The id of the news to be archived
    */
-  boolean isArchived(long userIdentityId,String newsId )throws Exception;
+  boolean isArchived(long userIdentityId,String newsId );
 }

--- a/services/src/main/java/org/exoplatform/news/service/NewsService.java
+++ b/services/src/main/java/org/exoplatform/news/service/NewsService.java
@@ -239,4 +239,16 @@ public interface NewsService {
    * @return
    */
   boolean canArchiveNews(org.exoplatform.services.security.Identity currentIdentity, String newsAuthor);
+
+  /**
+   * Check if an object identified by its type/id for a user has favorite metadata
+   * or not
+   *
+   * @param newsId {@link News} object that has to define: - objectType
+   *          object type, can be of any type: activity, comment, notes... -
+   *          objectId object technical unique identifier - userIdentityId
+   *          {@link Identity} technical identifier of the user
+   * @throws ObjectNotFoundException when the favorite doesn't exists
+   */
+  boolean isArchived(long userIdentityId,String newsId )throws Exception;
 }

--- a/services/src/main/java/org/exoplatform/news/service/NewsTargetingService.java
+++ b/services/src/main/java/org/exoplatform/news/service/NewsTargetingService.java
@@ -63,7 +63,7 @@ public interface NewsTargetingService {
    * 
    * @return {@link List} of {@link News} target items by a target name
    */
-  List<MetadataItem> getNewsTargetItemsByTargetName(String targetName, long offset, long limit);
+  List<MetadataItem> getNewsTargetItemsByTargetName(String targetName,boolean isArchived, long offset, long limit);
 
   /**
    * Gets the {@link List} of referenced targets from {@link News} list portlets 

--- a/services/src/main/java/org/exoplatform/news/service/impl/NewsServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/service/impl/NewsServiceImpl.java
@@ -664,10 +664,9 @@ public class NewsServiceImpl implements NewsService {
     return false;
   }
 
-  private void createMetaDataArchive(String newId , long userIdentityId) throws
-                                                 ObjectAlreadyExistsException {
+  private void createMetaDataArchive(String newId , long userIdentityId) throws ObjectAlreadyExistsException {
     MetadataKey metadataKey = new MetadataKey(METADATA_TYPE.getName(),"0",0);
-    MetadataObject metadataObject = new MetadataObject("archives",newId);
+    MetadataObject metadataObject = new MetadataObject(METADATA_TYPE.getName(),newId);
 
     metadataService.createMetadataItem(metadataObject,
                                        metadataKey,
@@ -676,7 +675,7 @@ public class NewsServiceImpl implements NewsService {
 
   public void deleteMetaDataArchive(String newId ,long userIdentityId) throws ObjectNotFoundException {
     MetadataKey metadataKey = new MetadataKey(METADATA_TYPE.getName(),"0",0);
-    MetadataObject metadataObject = new MetadataObject("archives",newId);
+    MetadataObject metadataObject = new MetadataObject(METADATA_TYPE.getName(),newId);
 
     List<MetadataItem> archives = metadataService.getMetadataItemsByMetadataAndObject(metadataKey, metadataObject);
     if (CollectionUtils.isEmpty(archives)) {
@@ -687,10 +686,9 @@ public class NewsServiceImpl implements NewsService {
     }
   }
   @Override
-  public boolean isArchived(long userIdentityId,String newId) throws Exception {
-
+  public boolean isArchived(long userIdentityId,String newId){
     MetadataKey metadataKey = new MetadataKey(METADATA_TYPE.getName(), String.valueOf(userIdentityId), userIdentityId);
-    MetadataObject metadataObject = new MetadataObject("archives",newId);
+    MetadataObject metadataObject = new MetadataObject(METADATA_TYPE.getName(),newId);
     List<MetadataItem> archives = metadataService.getMetadataItemsByMetadataAndObject(metadataKey,metadataObject);
 
     return !archives.isEmpty();

--- a/services/src/main/java/org/exoplatform/news/service/impl/NewsTargetingServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/service/impl/NewsTargetingServiceImpl.java
@@ -115,7 +115,7 @@ public class NewsTargetingServiceImpl implements NewsTargetingService {
   }
 
   @Override
-  public List<MetadataItem> getNewsTargetItemsByTargetName(String targetName, long offset, long limit) {
+  public List<MetadataItem> getNewsTargetItemsByTargetName(String targetName,boolean isArchived, long offset, long limit) {
     return metadataService.getMetadataItemsByMetadataNameAndTypeAndObjectAndMetadataItemProperty(targetName, METADATA_TYPE.getName(), NewsUtils.NEWS_METADATA_OBJECT_TYPE, PublicationDefaultStates.STAGED, String.valueOf(false), offset, limit);
   }
   

--- a/services/src/test/java/org/exoplatform/news/NewsTargetingImplTest.java
+++ b/services/src/test/java/org/exoplatform/news/NewsTargetingImplTest.java
@@ -255,7 +255,7 @@ public class NewsTargetingImplTest {
     when(metadataService.getMetadataItemsByMetadataNameAndTypeAndObjectAndMetadataItemProperty("newsTargets", NewsTargetingService.METADATA_TYPE.getName(),"news", PublicationDefaultStates.STAGED, String.valueOf(false),0,10)).thenReturn(metadataItems);
 
     // When
-    List<MetadataItem> newsTargetsItems = newsTargetingService.getNewsTargetItemsByTargetName("newsTargets", 0, 10);
+    List<MetadataItem> newsTargetsItems = newsTargetingService.getNewsTargetItemsByTargetName("newsTargets",false, 0, 10);
 
     // Then
     assertNotNull(newsTargetsItems);

--- a/services/src/test/java/org/exoplatform/news/service/impl/NewsServiceImplTest.java
+++ b/services/src/test/java/org/exoplatform/news/service/impl/NewsServiceImplTest.java
@@ -11,6 +11,7 @@ import org.exoplatform.portal.config.UserACL;
 import org.exoplatform.social.core.manager.ActivityManager;
 import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.social.core.space.spi.SpaceService;
+import org.exoplatform.social.metadata.MetadataService;
 import org.exoplatform.upload.UploadService;
 import org.junit.Before;
 import org.junit.Test;
@@ -60,10 +61,12 @@ public class NewsServiceImplTest {
 
     private NewsService newsService;
 
+    private MetadataService metadataService;
+    
     @Before
     public void setUp() {
         this.newsService = new NewsServiceImpl(spaceService, activityManager, identityManager, uploadService,
-                newsESSearchConnector,indexingService, newsStorage, userACL, newsTargetingService);
+                newsESSearchConnector,indexingService, newsStorage, userACL, newsTargetingService, metadataService);
     }
 
     @Test

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>news</artifactId>
     <groupId>org.exoplatform.addons.news</groupId>
-    <version>2.3.x-SNAPSHOT</version>
+    <version>2.3.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>news-webapp</artifactId>
   <packaging>war</packaging>

--- a/webapp/src/main/webapp/WEB-INF/conf/news/metadata-plugins-configuration.xml
+++ b/webapp/src/main/webapp/WEB-INF/conf/news/metadata-plugins-configuration.xml
@@ -121,6 +121,34 @@
         </object-param>
       </init-params>
     </component-plugin>
+    <component-plugin>
+      <name>NewsArchivedMetadataPlugin</name>
+      <set-method>addMetadataTypePlugin</set-method>
+      <type>org.exoplatform.social.metadata.MetadataTypePlugin</type>
+      <init-params>
+        <value-param>
+          <name>shareable</name>
+          <description>Whether to share metadatas when an associated object has been shared to a different space or to a user</description>
+          <value>false</value>
+        </value-param>
+        <value-param>
+          <name>allowMultipleItemsPerObject</name>
+          <description>Whether to allow adding the same object to the same Metadata or not</description>
+          <value>false</value>
+        </value-param>
+        <object-param>
+          <name>metadataType</name>
+          <object type="org.exoplatform.social.metadata.model.MetadataType">
+            <field name="id">
+              <int>5</int>
+            </field>
+            <field name="name">
+              <string>archives</string>
+            </field>
+          </object>
+        </object-param>
+      </init-params>
+    </component-plugin>
   </external-component-plugins>
 
   <external-component-plugins>


### PR DESCRIPTION
Prior to this change, when post an article with title and content, then publish it with choosing Snapshot latest news as target
,click to Archive button related to this article , then go to the Snapshot page, Article is displayed .
This is due to the fact that article displayed in the latest news section is not filtered by not archived ,
After this change, we ensure that article archived is not displayed in the latest news section of the snapshot page.