### PR TITLE
Task-55722: Fix exception when liking or commenting an activity

### DIFF
--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>news</artifactId>
     <groupId>org.exoplatform.addons.news</groupId>
-    <version>2.3.x-SNAPSHOT</version>
+    <version>2.3.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>news-packaging</artifactId>
   <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
   </parent>
   <groupId>org.exoplatform.addons.news</groupId>
   <artifactId>news</artifactId>
-  <version>2.3.x-SNAPSHOT</version>
+  <version>2.3.x-maintenance-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>eXo Add-on:: News</name>
   <description>News</description>
@@ -40,10 +40,10 @@
   </modules>
 
   <properties>
-    <org.exoplatform.social.version>6.3.x-SNAPSHOT</org.exoplatform.social.version>
-    <org.exoplatform.platform-ui.version>6.3.x-SNAPSHOT</org.exoplatform.platform-ui.version>
-    <addon.exo.ecms.version>6.3.x-SNAPSHOT</addon.exo.ecms.version>
-    <addon.exo.analytics.version>1.2.x-SNAPSHOT</addon.exo.analytics.version>
+    <org.exoplatform.social.version>6.3.x-maintenance-SNAPSHOT</org.exoplatform.social.version>
+    <org.exoplatform.platform-ui.version>6.3.x-maintenance-SNAPSHOT</org.exoplatform.platform-ui.version>
+    <addon.exo.ecms.version>6.3.x-maintenance-SNAPSHOT</addon.exo.ecms.version>
+    <addon.exo.analytics.version>1.2.x-maintenance-SNAPSHOT</addon.exo.analytics.version>
     <pitest.version>1.4.10</pitest.version>
     
     <sonar.organization>exoplatform</sonar.organization>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>news</artifactId>
     <groupId>org.exoplatform.addons.news</groupId>
-    <version>2.3.x-SNAPSHOT</version>
+    <version>2.3.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>news-services</artifactId>
   <packaging>jar</packaging>

--- a/services/src/main/java/org/exoplatform/news/listener/NewsActivityListener.java
+++ b/services/src/main/java/org/exoplatform/news/listener/NewsActivityListener.java
@@ -73,7 +73,7 @@ public class NewsActivityListener extends ActivityListenerPlugin {
   public void likeActivity(ActivityLifeCycleEvent event) {
     super.likeActivity(event);
     ExoSocialActivity activity = event.getActivity();
-    if (activity != null) {
+    if (activity != null && activity.getTemplateParams() != null && activity.getTemplateParams().containsKey(NEWS_ID)) {
       org.exoplatform.services.security.Identity currentIdentity = ConversationState.getCurrent().getIdentity();
       try {
         News news = newsService.getNewsByActivityId(activity.getId(), currentIdentity);
@@ -88,7 +88,7 @@ public class NewsActivityListener extends ActivityListenerPlugin {
   public void saveComment(ActivityLifeCycleEvent event) {
     super.saveComment(event);
     ExoSocialActivity activity = event.getActivity();
-    if (activity != null) {
+    if (activity != null && activity.getTemplateParams() != null && activity.getTemplateParams().containsKey(NEWS_ID)) {
       org.exoplatform.services.security.Identity currentIdentity = ConversationState.getCurrent().getIdentity();
       try {
         News news = newsService.getNewsByActivityId(activity.getParentId(), currentIdentity);

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>news</artifactId>
     <groupId>org.exoplatform.addons.news</groupId>
-    <version>2.3.x-SNAPSHOT</version>
+    <version>2.3.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>news-webapp</artifactId>
   <packaging>war</packaging>


### PR DESCRIPTION
Prior to this change, when liking or commenting any activity, exceptions coming from NewsActivity like and comment listeners are raised. After this commit, we ensure to execute these listeners only for news activity type.