### PR TITLE
Task-55722 : Fix exception when liking or commenting an activity

### DIFF
--- a/services/src/main/java/org/exoplatform/news/listener/NewsActivityListener.java
+++ b/services/src/main/java/org/exoplatform/news/listener/NewsActivityListener.java
@@ -73,7 +73,7 @@ public class NewsActivityListener extends ActivityListenerPlugin {
   public void likeActivity(ActivityLifeCycleEvent event) {
     super.likeActivity(event);
     ExoSocialActivity activity = event.getActivity();
-    if (activity != null) {
+    if (activity != null && activity.getTemplateParams() != null && activity.getTemplateParams().containsKey(NEWS_ID)) {
       org.exoplatform.services.security.Identity currentIdentity = ConversationState.getCurrent().getIdentity();
       try {
         News news = newsService.getNewsByActivityId(activity.getId(), currentIdentity);
@@ -88,7 +88,7 @@ public class NewsActivityListener extends ActivityListenerPlugin {
   public void saveComment(ActivityLifeCycleEvent event) {
     super.saveComment(event);
     ExoSocialActivity activity = event.getActivity();
-    if (activity != null) {
+    if (activity != null && activity.getTemplateParams() != null && activity.getTemplateParams().containsKey(NEWS_ID)) {
       org.exoplatform.services.security.Identity currentIdentity = ConversationState.getCurrent().getIdentity();
       try {
         News news = newsService.getNewsByActivityId(activity.getParentId(), currentIdentity);


### PR DESCRIPTION
Prior to this change, when liking or commenting any activity, exceptions coming from NewsActivity like and comment listeners are raised. After this commit, we ensure to execute these listeners only for news activity type.