### PR TITLE
Task-55322: Confirm button is not disabled when Edit the scheduling post later when chose date and time

### DIFF
--- a/webapp/src/main/webapp/schedule-news-drawer/components/ExoScheduleNewsDrawer.vue
+++ b/webapp/src/main/webapp/schedule-news-drawer/components/ExoScheduleNewsDrawer.vue
@@ -279,7 +279,11 @@ export default {
       }
       const postDate = new Date(this.postDate);
       const scheduleDate = new Date(this.schedulePostDate);
-      this.disabled = postDate.getTime() === scheduleDate.getTime();
+      const postDateString = postDate.getFullYear().toString() + postDate.getMonth().toString()+ postDate.getDate().toString() ;
+      const scheduleDateString = scheduleDate.getFullYear().toString() + scheduleDate.getMonth().toString() + scheduleDate.getDate().toString();
+      const postTimeString = postDate.getHours().toString() + postDate.getMinutes().toString();
+      const scheduleTimeString = scheduleDate.getHours().toString() + scheduleDate.getMinutes().toString();
+      this.disabled = ((postDateString === scheduleDateString) && (postTimeString === scheduleTimeString));
       postDate.setHours(this.postDateTime.getHours());
       postDate.setMinutes(this.postDateTime.getMinutes());
       postDate.setSeconds(0);


### PR DESCRIPTION
Prior to this change, when add User as redactor to space page, user connect to PLF and go to space , click to space then write an article , add title and content then click on post , click post later and click Schedule then click on Scheduled article
This is due to the fact that button is enabled but date or time not change in Schedule article ,
After this change, we ensure that button is disabled without changes at date or time.