### PR TITLE
Task-49273: Display drawer attachment when clicking on attach ckeditr button with attached files number and files details in news details mobile view

### DIFF
--- a/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
+++ b/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
@@ -373,6 +373,14 @@ export default {
       shareButton.style.display = 'block';
     }
   },
+  created() {
+    document.addEventListener('switch-view-plugins', () => {
+      this.changeView();
+    });
+    document.addEventListener('attach-file-plugins', () => {
+      this.openApp();
+    });
+  },
   methods: {
     initCKEditor: function() {
       if (CKEDITOR.instances['newsContent'] && CKEDITOR.instances['newsContent'].destroy) {
@@ -422,6 +430,17 @@ export default {
         },
         on: {
           instanceReady: function(evt) {
+            const numerotationGroupButton = document.getElementById('cke_14');
+            const attachMediaButton = document.getElementById('cke_18');
+            const attachFileButton = document.getElementById('cke_22');
+            numerotationGroupButton.style.borderRight = 'none';
+            attachMediaButton.style.display = 'none';
+            attachFileButton.style.display = 'none';
+            const spanBadge = document.createElement('span');
+            spanBadge.setAttribute('class','badge');
+            spanBadge.setAttribute('id','badge');
+            spanBadge.innerHTML = '0';
+            attachFileButton.appendChild(spanBadge);
             self.news.body = evt.editor.getData();
             $(CKEDITOR.instances['newsContent'].document.$)
               .find('.atwho-inserted')
@@ -783,8 +802,9 @@ export default {
     openApp() {
       this.$refs.attachmentsComponent.toggleAttachmentsDrawer();
     },
-    onHideAttachmentsDrawer: function(showAttachments){
-      this.showAttachmentsDrawer = showAttachments;
+    onHideAttachmentsDrawer: function(){
+      const spanBadge = document.getElementById('badge');
+      spanBadge.innerHTML = String(this.news.attachments.length);
     },
     setUploadingCount: function(uploadingCount) {
       this.uploading = uploadingCount > 0;

--- a/webapp/src/main/webapp/news-details/components/mobile/ExoNewsDetailsBodyMobile.vue
+++ b/webapp/src/main/webapp/news-details/components/mobile/ExoNewsDetailsBodyMobile.vue
@@ -37,6 +37,18 @@
     <div class="d-flex flex-row pa-4">
       <span v-html="newsBody"></span>
     </div>
+    <div v-show="attachments && attachments.length" class="d-flex flex-row pa-4 newsAttachmentsTitle subtitle-2">
+      {{ $t('news.details.attachments.title') }} ({{ attachments ? attachments.length : 0 }})
+    </div>
+    <div v-show="attachments && attachments.length" class="newsAttachments">
+      <div
+        v-for="attachedFile in attachments"
+        :key="attachedFile.id"
+        class="newsAttachment text-truncate"
+        @click="openPreview(attachedFile)">
+        <exo-attachment-item :file="attachedFile" />
+      </div>
+    </div>
   </div>
 </template>
 
@@ -105,6 +117,9 @@ export default {
     newsAuthor() {
       return this.news && this.news.author;
     },
+    attachments() {
+      return this.news && this.news.attachments;
+    },
   },
   methods: {
     targetBlank: function (content) {
@@ -123,6 +138,23 @@ export default {
         }
       }
       return docElement.innerHTML;
+    },
+    openPreview(attachedFile) {
+      const self = this;
+      window.require(['SHARED/documentPreview'], function(documentPreview) {
+        documentPreview.init({
+          doc: {
+            id: attachedFile.id,
+            repository: 'repository',
+            workspace: 'collaboration',
+            title: attachedFile.name,
+            downloadUrl: `/portal/rest/v1/news/attachments/${attachedFile.id}/file`,
+            openUrl: `/portal/rest/v1/news/attachments/${attachedFile.id}/open`
+          },
+          showComments: false
+        });
+        self.hideDocPreviewComments();
+      });
     },
   }
 };

--- a/webapp/src/main/webapp/skin/less/news.less
+++ b/webapp/src/main/webapp/skin/less/news.less
@@ -548,6 +548,19 @@
 
 }
 .newsComposer {
+  .badge {
+    position: absolute;
+    width: 10px;
+    height: 10px;
+    margin-left: -10px;
+    margin-top: 10px;
+    padding: 1px;
+    border-radius: 50%;
+    font-size: 10px;
+    text-align: center;
+    background: @primaryColorDefault;
+    color: @baseBackgroundDefault;
+  }
   display: flex;
   position: fixed;
   width: 100%;
@@ -3874,6 +3887,40 @@ p.caption-title:after {
     }
     #newsDetails .newsDetailsActionMenu {
       margin: 0;
+    }
+  }
+  .newsComposer #newsForm .newsFormInput {
+    margin: 0;
+    .formInputGroup {
+      input[type="text"] {
+        text-align: left;
+      }
+      textarea#newsSummary {
+        text-align: left;
+      }
+    }
+  }
+  .newsContent {
+    .newsAttachments {
+      width: 80%;
+      display: flex;
+      flex-flow: row wrap;
+      margin: 0 auto;
+      padding-bottom: 20px;
+    }
+    .newsAttachment {
+      width: 30vw;
+      padding: 10px;
+      margin: 0px;
+      border: 1px transparent solid;
+      border-radius: 10px;
+      cursor: pointer;
+    }
+    .newsAttachmentsTitle {
+      margin: 0 auto;
+      color: @headingColor;
+      text-align: left ~'; /** orientation=lt */ ';
+      text-align: right ~'; /** orientation=rt */ ';
     }
   }
 }


### PR DESCRIPTION
Prior to this change, we use attach button in the bottom of ckeditor. With this enhancement, we add an attach button to ckeditor toolbar which will open attachment drawer, the number of attached files will be shown in the bottom of the attach button and the attached files details will be displayed.
