### PR TITLE
Task-56259: Fix news slider template height

### DIFF
--- a/webapp/src/main/webapp/news-list-view/components/views/NewsSliderView.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsSliderView.vue
@@ -20,6 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
       cycle
       show-arrows-on-hover
       interval="10000"
+      height="220"
       hide-delimiter-background
       class="sliderNewsItems fill-height">
       <v-carousel-item


### PR DESCRIPTION
Prior to this change, when a news list portlet is added outside slider container of snapshot page and configured with news slider template, the height is set to the default implicit value 500px which is not the adequate one. After this fix, the height is set explicitly to 220px.