### PR TITLE
Task-56069: Fix drawers display issues after opening and closing a portlet settings drawer (#499)

### DIFF
--- a/webapp/src/main/webapp/WEB-INF/jsp/newsListView.jsp
+++ b/webapp/src/main/webapp/WEB-INF/jsp/newsListView.jsp
@@ -61,9 +61,9 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
     if (conversationState != null) {
       currentIdentity = ConversationState.getCurrent().getIdentity();
     }
-    if (!NewsUtils.canPublishNews(currentIdentity)) {
-      saveSettingsURL = null;
-    }
+
+    boolean canPublishNews = NewsUtils.canPublishNews(currentIdentity);
+    saveSettingsURL = canPublishNews ? saveSettingsURL : null;
   %>
   <div class="news-list-view-app" id="<%= appId %>">
     <script type="text/javascript">
@@ -84,6 +84,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         showArticleReactions: <%= showArticleReactions == null ? null : "'" + showArticleReactions + "'" %>,
         showArticleDate: <%= showArticleDate == null ? null : "'" + showArticleDate + "'" %>,
         seeAllUrl: <%= seeAllUrl == null ? null : "'" + seeAllUrl + "'" %>,
+        canPublishNews: <%= canPublishNews %>,
       }));
     </script>
   </div>

--- a/webapp/src/main/webapp/news-list-view/components/NewsListView.vue
+++ b/webapp/src/main/webapp/news-list-view/components/NewsListView.vue
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
   <v-app class="news-list-view-app position-relative">
     <v-card flat class="list-view-card rounded-0">
       <v-card-text class="pa-0">
-        <news-settings v-if="viewTemplate && (viewTemplate !== 'NewsSlider' && viewTemplate !== 'NewsAlert')" />
+        <news-settings v-if="displayHeader" />
         <extension-registry-component
           v-if="selectedViewExtension"
           element-class="news-list-view"
@@ -26,6 +26,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
           :params="viewComponentParams" />
       </v-card-text>
     </v-card>
+    <news-settings-drawer v-if="$root.canPublishNews" />
   </v-app>
 </template>
 
@@ -99,6 +100,9 @@ export default {
     offset: 0,
   }),
   computed: {
+    displayHeader() {
+      return this.viewTemplate && (this.viewTemplate !== 'NewsSlider' && this.viewTemplate !== 'NewsAlert');
+    },
     selectedViewExtension() {
       if (this.viewTemplate) {
         if (this.viewTemplate === 'NewsSlider' && this.newsList.length === 0) {

--- a/webapp/src/main/webapp/news-list-view/components/settings/NewsSettings.vue
+++ b/webapp/src/main/webapp/news-list-view/components/settings/NewsSettings.vue
@@ -24,7 +24,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
     </div>
     <div class="d-flex flex-column me-2">
       <v-btn
-        v-if="canPublishNews"
+          v-if="$root.canPublishNews"
         icon
         @click="openDrawer">
         <v-icon>mdi-cog</v-icon>
@@ -39,7 +39,6 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         {{ $t('news.published.seeAll') }}
       </v-btn>
     </div>
-    <news-settings-drawer ref="settingsDrawer" />
   </div>
 </template>
 <script>
@@ -49,7 +48,6 @@ export default {
     seeAllUrl: 'news?filter=pinned',
     showHeader: false,
     showSeeAll: false,
-    canPublishNews: false,
   }),
   created() {
     this.$root.$on('saved-news-settings', (newsTarget, selectedOptions) => {
@@ -62,13 +60,10 @@ export default {
     this.seeAllUrl = this.$root.seeAllUrl;
     this.showSeeAll = this.$root.showSeeAll;
     this.showHeader = this.$root.showHeader;
-    this.$newsServices.canPublishNews().then(canPublishNews => {
-      this.canPublishNews = canPublishNews;
-    });
   },
   methods: {
     openDrawer() {
-      this.$refs.settingsDrawer.open();
+      this.$root.$emit('news-settings-drawer-open');
     },
     seeAllNews() {
       window.location.href = `${eXo.env.portal.context}/${eXo.env.portal.portalName}${this.seeAllUrl}`;

--- a/webapp/src/main/webapp/news-list-view/components/settings/NewsSettingsDrawer.vue
+++ b/webapp/src/main/webapp/news-list-view/components/settings/NewsSettingsDrawer.vue
@@ -245,22 +245,15 @@ export default {
   created() {
     this.disabled = true;
     this.init();
+    this.$root.$on('news-settings-drawer-open', () => this.open());
   },
   methods: {
     open() {
       this.reset();
-      const overlayElement = document.getElementById('drawers-overlay');
-      if (overlayElement) {
-        overlayElement.style.display = 'block';
-      }
       this.$refs.newsSettingsDrawer.open();
     },
     close() {
       this.$refs.newsSettingsDrawer.close();
-      const overlayElement = document.getElementById('drawers-overlay');
-      if (overlayElement) {
-        overlayElement.style.display = 'none';
-      }
       window.setTimeout(() => this.showAdvancedSettings = false, 200);
     },
     reset() {

--- a/webapp/src/main/webapp/news-list-view/components/views/NewsAlertView.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsAlertView.vue
@@ -64,13 +64,12 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         <v-icon>chevron_right</v-icon>
       </v-btn>
       <v-btn
-        v-if="canPublishNews"
-        @click="openDrawer"
-        icon>
+        v-if="$root.canPublishNews"
+        icon
+        @click="openDrawer">
         <v-icon>mdi-cog</v-icon>
       </v-btn>
     </div>
-    <news-settings-drawer ref="settingsDrawer" />
   </div>
 </template>
 
@@ -85,7 +84,6 @@ export default {
   },
   data () {
     return {
-      canPublishNews: false,
       slider: 0,
       news: [],
       initialized: false,
@@ -120,13 +118,10 @@ export default {
     this.reset();
     this.$root.$on('saved-news-settings', this.refreshNewsViews);
     this.getNewsList();
-    this.$newsServices.canPublishNews().then(canPublishNews => {
-      this.canPublishNews = canPublishNews;
-    });
   },
   methods: {
     openDrawer() {
-      this.$refs.settingsDrawer.open();
+      this.$root.$emit('news-settings-drawer-open');
     },
     getNewsList() {
       if (!this.initialized) {

--- a/webapp/src/main/webapp/news-list-view/components/views/NewsEmptySliderView.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsEmptySliderView.vue
@@ -17,7 +17,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 <template>
   <div class="noNewsSlideContent">
     <v-btn
-      v-if="canPublishNews"
+      v-if="$root.canPublishNews"
       icon
       @click="openDrawer"
       class="mt-2 me-4 float-right">
@@ -29,22 +29,13 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
     <div class="NewsSliderText">
       <div class="noNewsMsg">{{ $t('news.slider.yourArticleTitleGoesHere') }}</div>
     </div>
-    <news-settings-drawer ref="settingsDrawer" />
   </div>
 </template>
 <script>
 export default {
-  data: () => ({
-    canPublishNews: false,
-  }),
-  created() {
-    this.$newsServices.canPublishNews().then(canPublishNews => {
-      this.canPublishNews = canPublishNews;
-    });
-  },
   methods: {
     openDrawer() {
-      this.$refs.settingsDrawer.open();
+      this.$root.$emit('news-settings-drawer-open');
     },
   }
 };

--- a/webapp/src/main/webapp/news-list-view/components/views/NewsEmptyTemplate.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsEmptyTemplate.vue
@@ -21,7 +21,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         <v-spacer />
         <div class="d-flex flex-row newsSettingButton justify-end">
           <v-btn
-            v-if="canPublishNews"
+            v-if="$root.canPublishNews"
             icon
             @click="openDrawer">
             <v-icon>mdi-cog</v-icon>
@@ -36,24 +36,15 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
           </span>
         </div>
       </v-flex>
-      <news-settings-drawer ref="settingsDrawer" />
     </v-main>
   </v-app>
 </template>
 
 <script>
 export default {
-  data: () => ({
-    canPublishNews: false,
-  }),
-  created() {
-    this.$newsServices.canPublishNews().then(canPublishNews => {
-      this.canPublishNews = canPublishNews;
-    });
-  },
   methods: {
     openDrawer() {
-      this.$refs.settingsDrawer.open();
+      this.$root.$emit('news-settings-drawer-open');
     },
   }
 };

--- a/webapp/src/main/webapp/news-list-view/components/views/NewsSliderView.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsSliderView.vue
@@ -37,7 +37,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
           <div class="flex flex-column carouselNewsInfo">
             <div class="flex flex-row" :class="!canPublishNews ? 'mt-9' : ''">
               <v-btn
-                v-if="canPublishNews"
+                v-if="$root.canPublishNews"
                 icon
                 @click="openDrawer"
                 class="float-right settingNewsButton">
@@ -75,7 +75,6 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         </v-container>
       </v-carousel-item>
     </v-carousel>
-    <news-settings-drawer ref="settingsDrawer" />
   </div>
 </template>
 <script>
@@ -91,7 +90,6 @@ export default {
     return {
       news: [],
       initialized: false,
-      canPublishNews: false,
       limit: 4,
       offset: 0,
       fullDateFormat: {
@@ -118,17 +116,10 @@ export default {
     this.reset();
     this.$root.$on('saved-news-settings', this.refreshNewsViews);
     this.getNewsList();
-    this.$newsServices.canPublishNews().then(canPublishNews => {
-      this.canPublishNews = canPublishNews;
-    });
   },
   methods: {
     openDrawer() {
-      const overlayElement = document.getElementById('drawers-overlay');
-      if (overlayElement) {
-        overlayElement.style.display = 'block';
-      }
-      this.$refs.settingsDrawer.open();
+      this.$root.$emit('news-settings-drawer-open');
     },
     getNewsList() {
       if (!this.initialized) {

--- a/webapp/src/main/webapp/news-list-view/main.js
+++ b/webapp/src/main/webapp/news-list-view/main.js
@@ -73,6 +73,7 @@ export function init(params) {
   const showArticleReactions = params.showArticleReactions === '' ? true : params.showArticleReactions === 'true';
   const showArticleDate  = params.showArticleDate === '' ? true : params.showArticleDate === 'true';
   const seeAllUrl = params.seeAllUrl;
+  const canPublishNews = params.canPublishNews;
 
   exoi18n.loadLanguageAsync(lang, url).then(i18n => {
     // init Vue app when locale resources are ready
@@ -93,6 +94,7 @@ export function init(params) {
         showArticleReactions,
         showArticleDate,
         seeAllUrl,
+        canPublishNews
       },
       template: `<news-list-view
                   id="${appId}"


### PR DESCRIPTION
Prior to this fix, when user try to open any drawer after closing the portlet settings drawer. The dark mask on the screen is lost and it is no longer possible to close the drawer by click outside.

After this fix, we will be able to open and close all the drawers without any dark mask issue.