### PR TITLE
Task-56520: Display the author name in published article detail of a hidden space

### DIFF
--- a/webapp/src/main/webapp/news-details/components/ExoNewsDetailsBody.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsDetailsBody.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div v-if="news">
     <div v-if="archivedNews && !news.canArchive">
       <div class="userNotAuthorized">
         <div class="notAuthorizedIconDiv">


### PR DESCRIPTION
Prior this fix, the author name of a published article in a hidden space cannot be displayed for a non-member. After this fix, a non-member of a hidden space can see the published article's author name.