### PR TITLE
Task-55137: Archived articles should not be displayed in news list portlets

### DIFF
--- a/services/src/main/java/org/exoplatform/news/rest/NewsRestResourcesV1.java
+++ b/services/src/main/java/org/exoplatform/news/rest/NewsRestResourcesV1.java
@@ -793,9 +793,9 @@ public class NewsRestResourcesV1 implements ResourceContainer, Startable {
         }
         news.setArchived(updatedNews.isArchived());
         if (news.isArchived()) {
-          newsService.archiveNews(id);
+          newsService.archiveNews(id, currentIdentity.getUserId());
         } else {
-          newsService.unarchiveNews(id);
+          newsService.unarchiveNews(id, currentIdentity.getUserId());
         }
       }
 

--- a/services/src/main/java/org/exoplatform/news/service/NewsService.java
+++ b/services/src/main/java/org/exoplatform/news/service/NewsService.java
@@ -220,17 +220,19 @@ public interface NewsService {
    * Archive a news
    *
    * @param newsId The id of the news to be archived
+   * @param currentUserName {@link Identity} of user archiving the news
    * @throws Exception when error
    */
-  void archiveNews(String newsId) throws Exception;
+  void archiveNews(String newsId, String currentUserName) throws Exception;
   
   /**
    * Unarchive a news
    *
    * @param newsId The id of the news to be unarchived
+   * @param currentUserName {@link Identity} of user unarchiving the news
    * @throws Exception when error
    */
-  void unarchiveNews(String newsId) throws Exception;
+  void unarchiveNews(String newsId, String currentUserName) throws Exception;
   
   /**
    * 

--- a/services/src/main/java/org/exoplatform/news/service/NewsTargetingService.java
+++ b/services/src/main/java/org/exoplatform/news/service/NewsTargetingService.java
@@ -17,6 +17,7 @@
 package org.exoplatform.news.service;
 
 import java.util.List;
+import java.util.Map;
 
 import org.exoplatform.news.model.News;
 import org.exoplatform.news.rest.NewsTargetingEntity;
@@ -79,12 +80,12 @@ public interface NewsTargetingService {
    * Save a {@link List} of {@link News} targets of a given {@link News} id by the current user
    *
    * @param newsId {@link News} identifier of {@link News} targets to be saved 
-   * @param staged {@link News} is staged news
+   * @param displayed {@link News} is news displayed in news list portlet
    * @param targets {@link List} of {@link News} targets to be saved
    * @param currentUser current user attempting to save {@link News} targets
    * @throws IllegalAccessException when user doesn't have access to save {@link News} targets of a given {@link News} id
    */ 
-  void saveNewsTarget(String newsId, boolean staged, List<String> targets, String currentUser) throws IllegalAccessException;
+  void saveNewsTarget(String newsId, boolean displayed, List<String> targets, String currentUser) throws IllegalAccessException;
 
   /**
    * Delete the {@link List} of {@link News} targets linked to a given {@link News} id

--- a/services/src/main/java/org/exoplatform/news/utils/NewsUtils.java
+++ b/services/src/main/java/org/exoplatform/news/utils/NewsUtils.java
@@ -47,6 +47,8 @@ public class NewsUtils {
 
   public static final String  NEWS_METADATA_OBJECT_TYPE       = "news";
 
+  public static final String  DISPLAYED_STATUS                = "displayed";
+
   private static final String PUBLISHER_MEMBERSHIP_NAME       = "publisher";
 
   private static final String MANAGER_MEMBERSHIP_NAME         = "manager";

--- a/services/src/test/java/org/exoplatform/news/NewsTargetingImplTest.java
+++ b/services/src/test/java/org/exoplatform/news/NewsTargetingImplTest.java
@@ -220,10 +220,10 @@ public class NewsTargetingImplTest {
     memberships.add(membershipEntry);
     identity.setMemberships(memberships);
     Map<String, String> properties = new LinkedHashMap<>();
-    properties.put(PublicationDefaultStates.STAGED, String.valueOf(false));
+    properties.put("displayed", String.valueOf(true));
 
     // When
-    newsTargetingService.saveNewsTarget(news.getId(), false, news.getTargets(), "root");
+    newsTargetingService.saveNewsTarget(news.getId(), true, news.getTargets(), "root");
 
     // Then
     verify(identityManager, times(1)).getOrCreateIdentity(OrganizationIdentityProvider.NAME, "root");
@@ -252,7 +252,13 @@ public class NewsTargetingImplTest {
     metadataItem.setMetadata(sliderNews);
     List<MetadataItem> metadataItems = new LinkedList<>();
     metadataItems.add(metadataItem);
-    when(metadataService.getMetadataItemsByMetadataNameAndTypeAndObjectAndMetadataItemProperty("newsTargets", NewsTargetingService.METADATA_TYPE.getName(),"news", PublicationDefaultStates.STAGED, String.valueOf(false),0,10)).thenReturn(metadataItems);
+    when(metadataService.getMetadataItemsByMetadataNameAndTypeAndObjectAndMetadataItemProperty("newsTargets",
+                                                                                               NewsTargetingService.METADATA_TYPE.getName(),
+                                                                                               "news",
+                                                                                               "displayed",
+                                                                                               String.valueOf(true),
+                                                                                               0,
+                                                                                               10)).thenReturn(metadataItems);
 
     // When
     List<MetadataItem> newsTargetsItems = newsTargetingService.getNewsTargetItemsByTargetName("newsTargets", 0, 10);

--- a/services/src/test/java/org/exoplatform/news/rest/NewsRestResourcesV1Test.java
+++ b/services/src/test/java/org/exoplatform/news/rest/NewsRestResourcesV1Test.java
@@ -555,7 +555,7 @@ public class NewsRestResourcesV1Test {
     Response response = newsRestResourcesV1.patchNews(request, "id123", updatedNews);
 
     // Then
-    verify(newsService, times(1)).archiveNews("id123");
+    verify(newsService, times(1)).archiveNews("id123", "john");
     verify(newsService, times(0)).updateNews(oldnews, request.getRemoteUser(), null, oldnews.isPublished());
     assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
   }
@@ -604,7 +604,7 @@ public class NewsRestResourcesV1Test {
     Response response = newsRestResourcesV1.patchNews(request, "id123", updatedNews);
 
     // Then
-    verify(newsService, times(1)).unarchiveNews("id123");
+    verify(newsService, times(1)).unarchiveNews("id123", "john");
     verify(newsService, times(0)).updateNews(oldnews, request.getRemoteUser(), null, oldnews.isPublished());
     assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
   }
@@ -652,7 +652,7 @@ public class NewsRestResourcesV1Test {
     Response response = newsRestResourcesV1.patchNews(request, "id123", updatedNews);
 
     // Then
-    verify(newsService, times(0)).archiveNews("id123");
+    verify(newsService, times(0)).archiveNews("id123", "john");
     verify(newsService, times(0)).updateNews(oldnews, request.getRemoteUser(), null, oldnews.isPublished());
     assertEquals(Response.Status.UNAUTHORIZED.getStatusCode(), response.getStatus());
   }


### PR DESCRIPTION
Prior to this change, when post an article with title and content, then publish it with choosing any target,click to Archive button related to this article , then go to the dedicated target, Article is displayed .
To solve this problem, we add a new metadata items property "archived" linked to metadataItem for the archived article witch have a targets.