### PR TITLE
Task-56777: Fix articles display regressions

### DIFF
--- a/webapp/src/main/webapp/news-list-view/components/NewsListView.vue
+++ b/webapp/src/main/webapp/news-list-view/components/NewsListView.vue
@@ -175,7 +175,7 @@ export default {
       this.loading = true;
       return this.$newsListService.getNewsList(this.newsTarget, this.offset, this.limit, true)
         .then(newsList => {
-          this.newsList = newsList.news || [];
+          this.newsList = newsList.news.filter(news => news !== null) || [];
           this.hasMore = this.newsList.length > this.limit;
         })
         .finally(() => this.loading = false);

--- a/webapp/src/main/webapp/news-list-view/components/views/NewsAlertView.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsAlertView.vue
@@ -127,7 +127,7 @@ export default {
       if (!this.initialized) {
         this.$newsListService.getNewsList(this.newsTarget, this.offset, this.limit, true)
           .then(newsList => {
-            this.news = newsList.news;
+            this.news = newsList.news.filter(news => news !== null);
             this.initialized = true;
           })
           .finally(() => this.initialized = false);

--- a/webapp/src/main/webapp/news-list-view/components/views/NewsCardsView.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsCardsView.vue
@@ -65,7 +65,7 @@ export default {
       if (!this.initialized) {
         this.$newsListService.getNewsList(this.newsTarget, this.offset, this.limit, true)
           .then(newsList => {
-            this.news = newsList.news;
+            this.news = newsList.news.filter(news => news !== null);
             this.initialized = true;
           })
           .finally(() => this.initialized = false);

--- a/webapp/src/main/webapp/news-list-view/components/views/NewsLatestView.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsLatestView.vue
@@ -89,7 +89,7 @@ export default {
       if (!this.initialized) {
         this.$newsListService.getNewsList(this.newsTarget, this.offset, this.limit, true)
           .then(newsList => {
-            this.newsInfo = newsList.news;
+            this.newsInfo = newsList.news.filter(news => news !== null);
             if (this.newsInfo && this.newsInfo[0] && this.newsInfo[0].spaceId) {
               this.getSpaceById(this.newsInfo[0].spaceId);
             }

--- a/webapp/src/main/webapp/news-list-view/components/views/NewsListTemplateView.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsListTemplateView.vue
@@ -71,7 +71,7 @@ export default {
       if (!this.initialized) {
         this.$newsListService.getNewsList(this.newsTarget, this.offset, this.limit, true)
           .then(newsList => {
-            this.newsInfo = newsList.news;
+            this.newsInfo = newsList.news.filter(news => news !== null);
             this.initialized = true;
           })
           .finally(() => this.initialized = false);

--- a/webapp/src/main/webapp/news-list-view/components/views/NewsMosaicView.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsMosaicView.vue
@@ -96,7 +96,7 @@ export default {
       if (!this.initialized) {
         this.$newsListService.getNewsList(this.newsTarget, this.offset, this.limit, true)
           .then(newsList => {
-            this.news = newsList.news;
+            this.news = newsList.news.filter(news => news !== null);
             this.initialized = true;
           })
           .finally(() => this.initialized = false);

--- a/webapp/src/main/webapp/news-list-view/components/views/NewsSliderView.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsSliderView.vue
@@ -125,7 +125,7 @@ export default {
       if (!this.initialized) {
         this.$newsListService.getNewsList(this.newsTarget, this.offset, this.limit, true)
           .then(newsList => {
-            this.news = newsList.news;
+            this.news = newsList.news.filter(news => news !== null);
             this.initialized = true;
           })
           .finally(() => this.initialized = false);

--- a/webapp/src/main/webapp/news-list-view/components/views/NewsStoriesView.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsStoriesView.vue
@@ -92,7 +92,7 @@ export default {
       if (!this.initialized) {
         this.$newsListService.getNewsList(this.newsTarget, this.offset, this.limit, true)
           .then(newsList => {
-            this.news = newsList.news;
+            this.news = newsList.news.filter(news => news !== null);
             this.initialized = true;
           })
           .finally(() => this.initialized = false);


### PR DESCRIPTION
Prior to this change, there is no check of news objects nullability before displaying it in news list portlets. After this fix, we added nullability checks to avoid displaying null articles. 