### PR TITLE
Task-56740: Fix display of title and summary in news list portlet with List View Template

### DIFF
--- a/webapp/src/main/webapp/news-list-view/components/settings/NewsSettings.vue
+++ b/webapp/src/main/webapp/news-list-view/components/settings/NewsSettings.vue
@@ -24,7 +24,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
     </div>
     <div class="d-flex flex-column me-2">
       <v-btn
-          v-if="$root.canPublishNews"
+        v-if="$root.canPublishNews"
         icon
         @click="openDrawer">
         <v-icon>mdi-cog</v-icon>

--- a/webapp/src/main/webapp/news-list-view/components/views/NewsCardsViewItem.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsCardsViewItem.vue
@@ -37,7 +37,10 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
           v-if="!isHiddenSpace && showArticleSpace"
           :href="item.spaceUrl">
           <div class="article-space">
-            <img class="space-icon" :src="item.spaceAvatarUrl" alt="Space icon">
+            <img
+              class="space-icon"
+              :src="item.spaceAvatarUrl"
+              alt="Space icon">
             <div class="space-name">{{ item.spaceDisplayName }}</div>
           </div>
         </a>

--- a/webapp/src/main/webapp/news-list-view/components/views/NewsListTemplateViewItem.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsListTemplateViewItem.vue
@@ -24,7 +24,17 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
     </div>
     <div class="article-item-content">
       <span v-if="showArticleTitle" class="article-title">{{ item.title }}</span>
-      <span v-if="showArticleAuthor" class="article-preTitle">{{ item.authorDisplayName }}</span>
+      <span v-if="showArticleSummary" class="article-title">{{ item.summary }}</span>
+      <div class="d-flex">
+        <span v-if="showArticleAuthor" class="article-preTitle">{{ item.authorDisplayName }}</span>
+        <v-icon
+          v-if="showArticleSpace && showArticleAuthor"
+          class="mx-1"
+          small>
+          mdi-chevron-right
+        </v-icon>
+        <span v-if="showArticleSpace" class="article-preTitle">{{ item.spaceDisplayName }}</span>
+      </div>
       <div class="article-postTitle">
         <span class="article-date me-2">
           <div v-if="showArticleDate" class="flex-column">
@@ -84,6 +94,12 @@ export default {
     },
     showArticleDate() {
       return this.selectedOption?.showArticleDate;
+    },
+    showArticleTitle() {
+      return this.selectedOption?.showArticleTitle;
+    },
+    showArticleSummary() {
+      return this.selectedOption?.showArticleSummary;
     },
     showArticleReactions() {
       return this.selectedOption?.showArticleReactions;

--- a/webapp/src/main/webapp/skin/less/news.less
+++ b/webapp/src/main/webapp/skin/less/news.less
@@ -4556,7 +4556,6 @@ input.ignore-vuetify-classes.datePickerText.flex-grow-0 {
   }
   .article-preTitle {
     display: block;
-    width: 100%;
     font-size: 12px;
     line-height: 12px;
     overflow: hidden;
@@ -4568,13 +4567,12 @@ input.ignore-vuetify-classes.datePickerText.flex-grow-0 {
     width: 100%;
     font-size: 14px;
     color:  @textColorDefault;
-    margin-bottom: 2px;
     transition: 0.3s;
     line-height: 20px;
     overflow: hidden;
     display: -webkit-box;
     -webkit-box-orient: vertical;
-    -webkit-line-clamp: 2;
+    -webkit-line-clamp: 1;
   }
   .article-postTitle {
     display: flex;


### PR DESCRIPTION
Prior to these changes, we cannot display title and summary of articles displayed in news list portlet with List View Template. After this commit, we will be able articles title and summary are displayed correctly.