### PR TITLE
Task-56942: Accents are not supported on news targets name

### DIFF
--- a/webapp/src/main/webapp/news-publish-targets-management/components/NewsPublishTargetsManagementDrawer.vue
+++ b/webapp/src/main/webapp/news-publish-targets-management/components/NewsPublishTargetsManagementDrawer.vue
@@ -108,7 +108,7 @@ export default {
   }),
   computed: {
     checkAlphanumeric() {
-      return this.targetName && !this.targetName.trim().match(/^[\w\-\s]+$/) && this.targetName.length > 0 ? this.$t('news.list.settings.name.errorMessage') : '';
+      return this.targetName && !this.targetName.trim().match(/^[a-zA-Z\u00C0-\u00FF ]*$/) && this.targetName.length > 0 ? this.$t('news.list.settings.name.errorMessage') : '';
     },
     disabled() {
       return (this.selectedTarget.targetName === this.targetName && this.selectedTarget.targetDescription === this.targetDescription) || this.checkAlphanumeric !== '' || this.targetName.length === 0 || this.sameTargetError || this.targetDescription.length > this.targetDescriptionTextLength;


### PR DESCRIPTION
Prior to this change, we can't add a news targets with a name that contain accented character.
Fix: Update Reg expression using the unicode values for accented characters.