### PR TITLE
Task-56827: Add text truncate in mobile  when space name is too long

### DIFF
--- a/webapp/src/main/webapp/skin/less/news.less
+++ b/webapp/src/main/webapp/skin/less/news.less
@@ -3515,6 +3515,7 @@
                 margin-left: 5px ~'; /** orientation=lt */ ';
                 margin-right: 5px ~'; /** orientation=rt */ ';
                 align-items: center;
+                max-width: 50px;
 
                 a {
                   margin-left: 5px ~'; /** orientation=lt */ ';


### PR DESCRIPTION
Prior to this change, When the space name is too long, the date is hidden.
Fix: Add max-width to truncate the space name when it is too long
