### PR TITLE
Task 56744: Search by favorites and news (article bookmarked/unbookmarked from the activity ) (#509)

### DIFF
--- a/services/src/main/java/org/exoplatform/news/listener/NewsMetadataListener.java
+++ b/services/src/main/java/org/exoplatform/news/listener/NewsMetadataListener.java
@@ -48,7 +48,7 @@ public class NewsMetadataListener extends Listener<Long, MetadataItem> {
 
   private static final String   METADATA_TAG = "tags";
 
-  private static final String   METADATA_FAVORITE = "favorite";
+  private static final String   METADATA_FAVORITE = "favorites";
 
 
   public NewsMetadataListener(IndexingService indexingService,


### PR DESCRIPTION
Problem: news still displays in search by using favorite filtering after unbookmarking.
Fix: the process of deleting activity was completed but not the case for activity details (news) because there is a wrong comparison which stopped the deleting of activity details. that's why the details stay saved and then displayed in search and also in recent favorites.