### PR TITLE
Task-57041: Adjust news list display in small containers and mobile

### DIFF
--- a/webapp/src/main/webapp/skin/less/news.less
+++ b/webapp/src/main/webapp/skin/less/news.less
@@ -4506,8 +4506,9 @@ input.ignore-vuetify-classes.datePickerText.flex-grow-0 {
   background: white;
   padding: 15px;
   .article-list-container {
-    display: grid;
+    display: flex;
     grid-gap: 15px;
+    flex-wrap: wrap;
   }
   .article {
     position: relative;


### PR DESCRIPTION
Prior to this fix, when putting the news list template in a small container or using mobile device, the display is wrong: only images are shown and listed in a row.
After this fix, the news list template will be well displayed vertically, using flex wrap, in case of a small container or a mobile device.