### PR TITLE
TASK-56521 Avoid duplicating Note Favorite & Tag Metadatas with Activity

### DIFF
--- a/services/src/main/java/org/exoplatform/news/activity/processor/ActivityNewsProcessor.java
+++ b/services/src/main/java/org/exoplatform/news/activity/processor/ActivityNewsProcessor.java
@@ -5,21 +5,26 @@ import java.util.HashMap;
 import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.news.model.News;
 import org.exoplatform.news.service.NewsService;
+import org.exoplatform.news.utils.NewsUtils;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
-import org.exoplatform.services.security.ConversationState;
+import org.exoplatform.social.common.RealtimeListAccess;
 import org.exoplatform.social.core.BaseActivityProcessorPlugin;
 import org.exoplatform.social.core.activity.model.ExoSocialActivity;
+import org.exoplatform.social.core.manager.ActivityManager;
 
 public class ActivityNewsProcessor extends BaseActivityProcessorPlugin {
 
-  private NewsService      newsService;
-
   private static final Log LOG = ExoLogger.getLogger(ActivityNewsProcessor.class);
 
-  public ActivityNewsProcessor(NewsService newsService, InitParams initParams) {
+  private NewsService      newsService;
+
+  private ActivityManager  activityManager;
+
+  public ActivityNewsProcessor(ActivityManager activityManager, NewsService newsService, InitParams initParams) {
     super(initParams);
     this.newsService = newsService;
+    this.activityManager = activityManager;
   }
 
   @Override
@@ -32,12 +37,17 @@ public class ActivityNewsProcessor extends BaseActivityProcessorPlugin {
     }
     News news = (News) activity.getLinkedProcessedEntities().get("news");
     if (news == null) {
-      org.exoplatform.services.security.Identity currentIdentity = ConversationState.getCurrent().getIdentity();
       try {
-        news = newsService.getNewsById(activity.getTemplateParams().get("newsId"), currentIdentity, false);
-      } catch (IllegalAccessException e) {
-        LOG.warn("User {} attempt to access unauthorized news with id {}",
-                 currentIdentity.getUserId(),
+        news = newsService.getNewsById(activity.getTemplateParams().get("newsId"), false);
+
+        RealtimeListAccess<ExoSocialActivity> listAccess = activityManager.getCommentsWithListAccess(activity, true);
+        news.setCommentsCount(listAccess.getSize());
+        news.setLikesCount(activity.getLikeIdentityIds() == null ? 0 : activity.getLikeIdentityIds().length);
+
+        activity.setMetadataObjectId(news.getId());
+        activity.setMetadataObjectType(NewsUtils.NEWS_METADATA_OBJECT_TYPE);
+      } catch (Exception e) {
+        LOG.warn("Error retrieving news with id {}",
                  activity.getTemplateParams().get("newsId"),
                  e);
       }

--- a/services/src/main/java/org/exoplatform/news/listener/AttachedActivityCacheUpdater.java
+++ b/services/src/main/java/org/exoplatform/news/listener/AttachedActivityCacheUpdater.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2003-2022 eXo Platform SAS.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see<http://www.gnu.org/licenses/>.
+ */
+package org.exoplatform.news.listener;
+
+import org.apache.commons.lang.StringUtils;
+import org.exoplatform.news.model.News;
+import org.exoplatform.services.listener.Event;
+import org.exoplatform.services.listener.Listener;
+import org.exoplatform.social.core.activity.model.ExoSocialActivity;
+import org.exoplatform.social.core.storage.api.ActivityStorage;
+import org.exoplatform.social.core.storage.cache.CachedActivityStorage;
+
+/**
+ * A listener to clear cached news inside
+ * {@link ExoSocialActivity#getLinkedProcessedEntities()} after any modification
+ * made on {@link News}
+ */
+public class AttachedActivityCacheUpdater extends Listener<String, News> {
+
+  private CachedActivityStorage cachedActivityStorage;
+
+  public AttachedActivityCacheUpdater(ActivityStorage activityStorage) {
+    if (activityStorage instanceof CachedActivityStorage) {
+      this.cachedActivityStorage = (CachedActivityStorage) activityStorage;
+    }
+  }
+
+  @Override
+  public void onEvent(Event<String, News> event) throws Exception {
+    if (cachedActivityStorage != null && event.getData() != null && StringUtils.isNotBlank(event.getData().getActivityId())) {
+      cachedActivityStorage.clearActivityCached(event.getData().getActivityId());
+    }
+  }
+
+}

--- a/services/src/main/java/org/exoplatform/news/listener/MetadataItemModified.java
+++ b/services/src/main/java/org/exoplatform/news/listener/MetadataItemModified.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2003-2022 eXo Platform SAS.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see<http://www.gnu.org/licenses/>.
+ */
+package org.exoplatform.news.listener;
+
+import org.apache.commons.lang3.StringUtils;
+import org.exoplatform.commons.search.index.IndexingService;
+import org.exoplatform.news.model.News;
+import org.exoplatform.news.search.NewsIndexingServiceConnector;
+import org.exoplatform.news.service.NewsService;
+import org.exoplatform.news.utils.NewsUtils;
+import org.exoplatform.services.listener.Event;
+import org.exoplatform.services.listener.Listener;
+import org.exoplatform.social.core.storage.api.ActivityStorage;
+import org.exoplatform.social.core.storage.cache.CachedActivityStorage;
+import org.exoplatform.social.metadata.model.MetadataItem;
+
+public class MetadataItemModified extends Listener<Long, MetadataItem> {
+
+  private IndexingService       indexingService;
+
+  private NewsService           newsService;
+
+  private CachedActivityStorage cachedActivityStorage;
+
+  public MetadataItemModified(NewsService newsService, IndexingService indexingService, ActivityStorage activityStorage) {
+    this.newsService = newsService;
+    this.indexingService = indexingService;
+    if (activityStorage instanceof CachedActivityStorage) {
+      this.cachedActivityStorage = (CachedActivityStorage) activityStorage;
+    }
+  }
+
+  @Override
+  public void onEvent(Event<Long, MetadataItem> event) throws Exception {
+    MetadataItem metadataItem = event.getData();
+    String objectType = metadataItem.getObjectType();
+    String objectId = metadataItem.getObjectId();
+    if (isNewsEvent(objectType)) {
+      // Ensure to re-execute all ActivityProcessors to compute & cache
+      // metadatas of the activity again
+      News news = newsService.getNewsById(objectId, false);
+      if (news != null) {
+        if (StringUtils.isNotBlank(news.getActivityId())) {
+          clearCache(news.getActivityId());
+        }
+        reindexNews(objectId);
+      }
+    }
+  }
+
+  protected boolean isNewsEvent(String objectType) {
+    return StringUtils.equals(objectType, NewsUtils.NEWS_METADATA_OBJECT_TYPE);
+  }
+
+  private void clearCache(String activityId) {
+    if (cachedActivityStorage != null) {
+      cachedActivityStorage.clearActivityCached(activityId);
+    }
+  }
+
+  private void reindexNews(String newsId) {
+    indexingService.reindex(NewsIndexingServiceConnector.TYPE, newsId);
+  }
+
+}

--- a/services/src/main/java/org/exoplatform/news/listener/NewsActivityListener.java
+++ b/services/src/main/java/org/exoplatform/news/listener/NewsActivityListener.java
@@ -71,7 +71,6 @@ public class NewsActivityListener extends ActivityListenerPlugin {
 
   @Override
   public void likeActivity(ActivityLifeCycleEvent event) {
-    super.likeActivity(event);
     ExoSocialActivity activity = event.getActivity();
     if (activity != null && activity.getTemplateParams() != null && activity.getTemplateParams().containsKey(NEWS_ID)) {
       org.exoplatform.services.security.Identity currentIdentity = ConversationState.getCurrent().getIdentity();
@@ -86,7 +85,6 @@ public class NewsActivityListener extends ActivityListenerPlugin {
 
   @Override
   public void saveComment(ActivityLifeCycleEvent event) {
-    super.saveComment(event);
     ExoSocialActivity activity = event.getActivity();
     if (activity != null && activity.getTemplateParams() != null && activity.getTemplateParams().containsKey(NEWS_ID)) {
       org.exoplatform.services.security.Identity currentIdentity = ConversationState.getCurrent().getIdentity();

--- a/services/src/main/java/org/exoplatform/news/listener/NewsMetadataListener.java
+++ b/services/src/main/java/org/exoplatform/news/listener/NewsMetadataListener.java
@@ -1,139 +1,85 @@
+/*
+ * Copyright (C) 2003-2022 eXo Platform SAS.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see<http://www.gnu.org/licenses/>.
+ */
 package org.exoplatform.news.listener;
 
-import org.apache.commons.collections.MapUtils;
+import java.util.Set;
+
 import org.apache.commons.lang3.StringUtils;
 import org.exoplatform.commons.search.index.IndexingService;
 import org.exoplatform.news.model.News;
 import org.exoplatform.news.search.NewsIndexingServiceConnector;
-import org.exoplatform.news.service.NewsService;
 import org.exoplatform.news.utils.NewsUtils;
 import org.exoplatform.services.listener.Event;
 import org.exoplatform.services.listener.Listener;
-import org.exoplatform.services.security.ConversationState;
-import org.exoplatform.services.security.Identity;
-import org.exoplatform.social.core.activity.model.ExoSocialActivity;
-import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;
-import org.exoplatform.social.core.manager.ActivityManager;
 import org.exoplatform.social.core.manager.IdentityManager;
-import org.exoplatform.social.core.processor.MetadataActivityProcessor;
-import org.exoplatform.social.metadata.favorite.FavoriteService;
-import org.exoplatform.social.metadata.favorite.model.Favorite;
-import org.exoplatform.social.metadata.model.MetadataItem;
+import org.exoplatform.social.core.space.model.Space;
+import org.exoplatform.social.core.space.spi.SpaceService;
 import org.exoplatform.social.metadata.tag.TagService;
 import org.exoplatform.social.metadata.tag.model.TagName;
 import org.exoplatform.social.metadata.tag.model.TagObject;
 
-import java.util.Set;
-
-public class NewsMetadataListener extends Listener<Long, MetadataItem> {
-
-  public static final String NEWS_METADATA_OBJECT_TYPE = "news";
+public class NewsMetadataListener extends Listener<String, News> {
 
   private final IndexingService indexingService;
 
-  private final NewsService     newsService;
-
-  private final FavoriteService favoriteService;
-
   private final IdentityManager identityManager;
 
-  private final ActivityManager activityManager;
+  private final SpaceService    spaceService;
 
-  private TagService tagService;
-
-
-  private static final String   METADATA_CREATED = "social.metadataItem.created";
-
-  private static final String   METADATA_DELETED = "social.metadataItem.deleted";
-
-  private static final String   METADATA_TAG = "tags";
-
-  private static final String   METADATA_FAVORITE = "favorites";
-
+  private TagService            tagService;
 
   public NewsMetadataListener(IndexingService indexingService,
-                              NewsService newsService,
-                              FavoriteService favoriteService,
+                              SpaceService spaceService,
                               IdentityManager identityManager,
-                              ActivityManager activityManager,
                               TagService tagService) {
     this.indexingService = indexingService;
-    this.newsService = newsService;
-    this.favoriteService = favoriteService;
     this.identityManager = identityManager;
-    this.activityManager = activityManager;
+    this.spaceService = spaceService;
     this.tagService = tagService;
   }
 
   @Override
-  public void onEvent(Event<Long, MetadataItem> event) throws Exception {
-    ConversationState conversationstate = ConversationState.getCurrent();
-    Identity currentIdentity = conversationstate == null
-        || conversationstate.getIdentity() == null ? null : conversationstate.getIdentity();
-    MetadataItem metadataItem = event.getData();
-    String objectType = event.getData().getObjectType();
-    String objectId = metadataItem.getObjectId();
-    if (StringUtils.equals(objectType, NewsUtils.NEWS_METADATA_OBJECT_TYPE)) {
-      indexingService.reindex(NewsIndexingServiceConnector.TYPE, objectId);
-    } else if (StringUtils.equals(objectType, MetadataActivityProcessor.ACTIVITY_METADATA_OBJECT_TYPE)) {
-      ExoSocialActivity activity = activityManager.getActivity(objectId);
-      if (activity.getType().equals(NewsUtils.NEWS_METADATA_OBJECT_TYPE) && currentIdentity != null) {
-        News news = newsService.getNewsByActivityId(objectId, currentIdentity);
-        org.exoplatform.social.core.identity.model.Identity userIdentity =
-                                                                         identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME,
-                                                                                                             currentIdentity.getUserId());
-        Favorite favorite = new Favorite(NewsUtils.NEWS_METADATA_OBJECT_TYPE,
-                                         news.getId(),
-                                         "",
-                                         Long.parseLong(userIdentity.getId()));
-        if (event.getEventName().equals(METADATA_CREATED)) {
-          if (!metadataItem.getObjectType().equals(NEWS_METADATA_OBJECT_TYPE) && metadataItem.getMetadataTypeName().equals(METADATA_TAG)) {
-            updateActivityTags(activity, news);
-          }
-          else {
-            favoriteService.createFavorite(favorite);
-          }
-        } else if (event.getEventName().equals(METADATA_DELETED) && metadataItem.getMetadataTypeName().equals(METADATA_FAVORITE)) {
-          favoriteService.deleteFavorite(favorite);
-        }
-        indexingService.reindex(NewsIndexingServiceConnector.TYPE, news.getId());
-      }
-    }
-  }
-  private void updateActivityTags(ExoSocialActivity activity, News news) {
-    String objectType = NEWS_METADATA_OBJECT_TYPE;
+  public void onEvent(Event<String, News> event) throws Exception {
+    News news = event.getData();
+    String username = event.getSource();
 
-    long creatorId = getPosterId(activity);
+    saveTags(news, username);
 
-    org.exoplatform.social.core.identity.model.Identity audienceIdentity = activityManager.getActivityStreamOwnerIdentity(activity.getId());
-    long audienceId = Long.parseLong(audienceIdentity.getId());
-    String content = getActivityBody(activity);
-
-    Set<TagName> tagNames = tagService.detectTagNames(content);
-    tagService.saveTags(new TagObject(objectType,
-                    news.getId(),
-                    activity.getParentId()),
-            tagNames,
-            audienceId,
-            creatorId);
-  }
-  private long getPosterId(ExoSocialActivity activity) {
-    String userId = activity.getUserId();
-    if (StringUtils.isBlank(userId)) {
-      userId = activity.getPosterId();
-    }
-    return StringUtils.isBlank(userId) ? 0 : Long.parseLong(userId);
+    indexingService.reindex(NewsIndexingServiceConnector.TYPE, news.getId());
   }
 
-  private String getActivityBody(ExoSocialActivity activity) {
-    String body = MapUtils.getString(activity.getTemplateParams(), "comment");
-    if (StringUtils.isNotBlank(body)) {
-      return body;
-    } else if (StringUtils.isNotBlank(activity.getTitle())) {
-      return activity.getTitle();
-    } else {
-      return activity.getBody();
-    }
+  private void saveTags(News news, String username) {
+    long creatorId = getPosterId(username);
+    long audienceId = getStreamOwnerId(news.getSpaceId(), username);
+
+    Set<TagName> tagNames = tagService.detectTagNames(news.getBody());
+    tagService.saveTags(new TagObject(NewsUtils.NEWS_METADATA_OBJECT_TYPE,
+                                      news.getId(),
+                                      null),
+                        tagNames,
+                        audienceId,
+                        creatorId);
+  }
+
+  private long getStreamOwnerId(String spaceId, String username) {
+    Space space = spaceService.getSpaceById(spaceId);
+    return space == null ? getPosterId(username)
+                         : Long.parseLong(identityManager.getOrCreateSpaceIdentity(space.getPrettyName()).getId());
+  }
+
+  private long getPosterId(String username) {
+    return StringUtils.isBlank(username) ? 0 : Long.parseLong(identityManager.getOrCreateUserIdentity(username).getId());
   }
 
 }

--- a/services/src/main/java/org/exoplatform/news/search/NewsIndexingServiceConnector.java
+++ b/services/src/main/java/org/exoplatform/news/search/NewsIndexingServiceConnector.java
@@ -16,11 +16,13 @@
  */
 package org.exoplatform.news.search;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang.StringUtils;
-
 import org.exoplatform.commons.search.domain.Document;
 import org.exoplatform.commons.search.index.impl.ElasticIndexingServiceConnector;
 import org.exoplatform.commons.utils.CommonsUtils;
@@ -39,7 +41,6 @@ import org.exoplatform.social.core.identity.model.Identity;
 import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;
 import org.exoplatform.social.core.manager.ActivityManager;
 import org.exoplatform.social.core.manager.IdentityManager;
-import org.exoplatform.social.core.processor.MetadataActivityProcessor;
 import org.exoplatform.social.core.search.DocumentWithMetadata;
 import org.exoplatform.social.metadata.MetadataService;
 import org.exoplatform.social.metadata.model.MetadataItem;

--- a/services/src/main/java/org/exoplatform/news/utils/NewsUtils.java
+++ b/services/src/main/java/org/exoplatform/news/utils/NewsUtils.java
@@ -37,6 +37,10 @@ public class NewsUtils {
 
   public static final String  SHARE_NEWS                      = "exo.news.shareArticle";
 
+  public static final String  ARCHIVE_NEWS                    = "exo.news.archiveArticle";
+
+  public static final String  UNARCHIVE_NEWS                  = "exo.news.unarchiveArticle";
+
   public static final String  COMMENT_NEWS                    = "exo.news.commentArticle";
 
   public static final String  LIKE_NEWS                       = "exo.news.likeArticle";
@@ -44,6 +48,10 @@ public class NewsUtils {
   public static final String  DELETE_NEWS                     = "exo.news.deleteArticle";
 
   public static final String  UPDATE_NEWS                     = "exo.news.updateArticle";
+
+  public static final String  SCHEDULE_NEWS                   = "exo.news.scheduleArticle";
+
+  public static final String  UNSCHEDULE_NEWS                 = "exo.news.unscheduleArticle";
 
   public static final String  NEWS_METADATA_OBJECT_TYPE       = "news";
 

--- a/services/src/test/java/org/exoplatform/news/listener/MetadataItemModifiedTest.java
+++ b/services/src/test/java/org/exoplatform/news/listener/MetadataItemModifiedTest.java
@@ -1,0 +1,96 @@
+package org.exoplatform.news.listener;
+
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import org.exoplatform.commons.search.index.IndexingService;
+import org.exoplatform.news.model.News;
+import org.exoplatform.news.search.NewsIndexingServiceConnector;
+import org.exoplatform.news.service.NewsService;
+import org.exoplatform.news.utils.NewsUtils;
+import org.exoplatform.services.listener.Event;
+import org.exoplatform.social.core.storage.cache.CachedActivityStorage;
+import org.exoplatform.social.metadata.model.MetadataItem;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+@SuppressWarnings("unchecked")
+public class MetadataItemModifiedTest {
+
+  @Mock
+  private IndexingService       indexingService;
+
+  @Mock
+  private NewsService           newsService;
+
+  @Mock
+  private CachedActivityStorage activityStorage;
+
+  @Test
+  public void testNoInteractionWhenMetadataNotForNews() throws Exception {
+    MetadataItemModified metadataItemModified = new MetadataItemModified(newsService, indexingService, activityStorage);
+    MetadataItem metadataItem = mock(MetadataItem.class);
+    Event<Long, MetadataItem> event = mock(Event.class);
+    when(event.getData()).thenReturn(metadataItem);
+    when(event.getData().getObjectType()).thenReturn("activity");
+    when(metadataItem.getObjectId()).thenReturn("1");
+
+    metadataItemModified.onEvent(event);
+
+    verifyNoInteractions(newsService);
+  }
+
+  @Test
+  public void testReindexNewsWhenNewsSetAsFavorite() throws Exception {
+    MetadataItemModified metadataItemModified = new MetadataItemModified(newsService, indexingService, activityStorage);
+    String newsId = "100";
+
+    MetadataItem metadataItem = mock(MetadataItem.class);
+    when(metadataItem.getObjectType()).thenReturn(NewsUtils.NEWS_METADATA_OBJECT_TYPE);
+    when(metadataItem.getObjectId()).thenReturn(newsId);
+
+    Event<Long, MetadataItem> event = mock(Event.class);
+    when(event.getData()).thenReturn(metadataItem);
+
+    News news = new News();
+    news.setId(newsId);
+    when(newsService.getNewsById(eq(newsId), anyBoolean())).thenReturn(news);
+
+    metadataItemModified.onEvent(event);
+    verify(newsService, times(1)).getNewsById(newsId, false);
+    verify(indexingService, times(1)).reindex(NewsIndexingServiceConnector.TYPE, newsId);
+  }
+
+  @Test
+  public void testCleanNewsActivityCacheWhenMarkAsFavorite() throws Exception {
+    MetadataItemModified metadataItemModified = new MetadataItemModified(newsService, indexingService, activityStorage);
+    String newsId = "200";
+
+    MetadataItem metadataItem = mock(MetadataItem.class);
+    when(metadataItem.getObjectType()).thenReturn(NewsUtils.NEWS_METADATA_OBJECT_TYPE);
+    when(metadataItem.getObjectId()).thenReturn(newsId);
+
+    Event<Long, MetadataItem> event = mock(Event.class);
+    when(event.getData()).thenReturn(metadataItem);
+
+    String activityId = "activityId";
+    News news = new News();
+    news.setId(newsId);
+    news.setActivityId(activityId);
+    when(newsService.getNewsById(eq(newsId), anyBoolean())).thenReturn(news);
+
+    metadataItemModified.onEvent(event);
+    verify(newsService, times(1)).getNewsById(newsId, false);
+    verify(indexingService, times(1)).reindex(NewsIndexingServiceConnector.TYPE, newsId);
+    verify(activityStorage, times(1)).clearActivityCached(activityId);
+  }
+
+}

--- a/services/src/test/java/org/exoplatform/news/listener/NewsActivityListenerTest.java
+++ b/services/src/test/java/org/exoplatform/news/listener/NewsActivityListenerTest.java
@@ -11,11 +11,6 @@ import static org.mockito.Mockito.when;
 
 import java.util.Map;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
-
 import org.exoplatform.news.model.News;
 import org.exoplatform.news.service.NewsService;
 import org.exoplatform.services.security.ConversationState;
@@ -27,6 +22,10 @@ import org.exoplatform.social.core.manager.ActivityManager;
 import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceService;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 @SuppressWarnings("unchecked")
@@ -43,7 +42,7 @@ public class NewsActivityListenerTest {
 
   @Mock
   private NewsService     newsService;
-  
+
   @Test
   public void testNotShareWhenActivityNotFound() {
     NewsActivityListener newsActivityListener = new NewsActivityListener(activityManager,
@@ -169,7 +168,10 @@ public class NewsActivityListenerTest {
     newsActivityListener.shareActivity(event);
 
     verify(newsService, times(1)).getNewsById(newsId, currentIdentity, false);
-    verify(newsService, never()).shareNews(nullable(News.class), nullable(Space.class), nullable(Identity.class), nullable(String.class));
+    verify(newsService, never()).shareNews(nullable(News.class),
+                                           nullable(Space.class),
+                                           nullable(Identity.class),
+                                           nullable(String.class));
   }
 
   @Test
@@ -204,13 +206,13 @@ public class NewsActivityListenerTest {
 
     String newsId = "newsId";
     when(sharedTemplateParams.get("newsId")).thenReturn(newsId);
-    
+
     org.exoplatform.services.security.Identity currentIdentity = new org.exoplatform.services.security.Identity("john");
     ConversationState.setCurrent(new ConversationState(currentIdentity));
-    
+
     News news = new News();
     when(newsService.getNewsById(newsId, currentIdentity, false)).thenReturn(news);
-    
+
     newsActivityListener.shareActivity(event);
 
     verify(newsService, times(1)).getNewsById(newsId, currentIdentity, false);

--- a/services/src/test/java/org/exoplatform/news/listener/NewsMetadataListenerTest.java
+++ b/services/src/test/java/org/exoplatform/news/listener/NewsMetadataListenerTest.java
@@ -1,148 +1,97 @@
 package org.exoplatform.news.listener;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.HashSet;
+
 import org.exoplatform.commons.search.index.IndexingService;
 import org.exoplatform.news.model.News;
 import org.exoplatform.news.search.NewsIndexingServiceConnector;
-import org.exoplatform.news.service.NewsService;
 import org.exoplatform.news.utils.NewsUtils;
 import org.exoplatform.services.listener.Event;
-import org.exoplatform.services.security.ConversationState;
-import org.exoplatform.services.security.Identity;
-import org.exoplatform.services.security.MembershipEntry;
-import org.exoplatform.social.core.activity.model.ExoSocialActivity;
-import org.exoplatform.social.core.activity.model.ExoSocialActivityImpl;
-import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;
-import org.exoplatform.social.core.manager.ActivityManager;
+import org.exoplatform.social.core.identity.model.Identity;
 import org.exoplatform.social.core.manager.IdentityManager;
-import org.exoplatform.social.metadata.favorite.FavoriteService;
-import org.exoplatform.social.metadata.model.MetadataItem;
+import org.exoplatform.social.core.space.model.Space;
+import org.exoplatform.social.core.space.spi.SpaceService;
 import org.exoplatform.social.metadata.tag.TagService;
+import org.exoplatform.social.metadata.tag.model.TagName;
+import org.exoplatform.social.metadata.tag.model.TagObject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import java.util.Collections;
-
-import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 @SuppressWarnings("unchecked")
 public class NewsMetadataListenerTest {
 
-  private static final String METADATA_TYPE_NAME = "testMetadataListener";
+  private static final String USERNAME = "testuser";
 
   @Mock
   private IndexingService     indexingService;
 
   @Mock
-  private NewsService         newsService;
-
-  @Mock
-  private FavoriteService     favoriteService;
+  private SpaceService        spaceService;
 
   @Mock
   private IdentityManager     identityManager;
 
   @Mock
-  private ActivityManager     activityManager;
-
-  @Mock
   private TagService          tagService;
 
   @Test
-  public void testReindexNewsWhenNewsSetAsFavorite() throws Exception {
-    NewsMetadataListener newsActivityListener = new NewsMetadataListener(indexingService,
-                                                                         newsService,
-                                                                         favoriteService,
+  public void testCreateNewsTagsWhenNewsSaved() throws Exception {
+    NewsMetadataListener newsMetadataListener = new NewsMetadataListener(indexingService,
+                                                                         spaceService,
                                                                          identityManager,
-                                                                         activityManager,
                                                                          tagService);
-    setCurrentUser("john");
-    MetadataItem metadataItem = mock(MetadataItem.class);
-    Event<Long, MetadataItem> event = mock(Event.class);
-    lenient().when(event.getData()).thenReturn(metadataItem);
-    lenient().when(event.getData().getObjectType()).thenReturn("news");
-    lenient().when(metadataItem.getObjectId()).thenReturn("1");
+    String newsId = "newsId";
+    String spaceId = "spaceId";
+    String content = "Test #tag1 Test #tag2.";
 
-    newsActivityListener.onEvent(event);
+    News news = mock(News.class);
+    when(news.getId()).thenReturn(newsId);
+    when(news.getSpaceId()).thenReturn(spaceId);
+    when(news.getBody()).thenReturn(content);
 
-    verifyNoInteractions(newsService);
-  }
+    Event<String, News> event = mock(Event.class);
+    when(event.getData()).thenReturn(news);
+    when(event.getSource()).thenReturn(USERNAME);
 
-  @Test
-  public void testReindexActivityWhenNewsSetAsFavorite() throws Exception {
-    NewsMetadataListener newsActivityListener = new NewsMetadataListener(indexingService,
-                                                                         newsService,
-                                                                         favoriteService,
-                                                                         identityManager,
-                                                                         activityManager,
-                                                                         tagService);
-    Identity johnIdentity = new Identity("1", Collections.singletonList(new MembershipEntry("john")));
-    ConversationState.setCurrent(new ConversationState(johnIdentity));
-    MetadataItem metadataItem = mock(MetadataItem.class);
-    Event<Long, MetadataItem> event = mock(Event.class);
-    lenient().when(event.getData()).thenReturn(metadataItem);
-    lenient().when(event.getData().getObjectType()).thenReturn("activity");
-    lenient().when(event.getEventName()).thenReturn("social.metadataItem.created");
-    lenient().when(metadataItem.getMetadataTypeName()).thenReturn("favorites");
-    lenient().when(metadataItem.getObjectId()).thenReturn("1");
-    News news = new News();
-    news.setId("1234");
-    ExoSocialActivity activity = new ExoSocialActivityImpl();
-    activity.setType(NewsUtils.NEWS_METADATA_OBJECT_TYPE);
-    lenient().when(newsService.getNewsByActivityId("1", johnIdentity)).thenReturn(news);
-    org.exoplatform.social.core.identity.model.Identity userIdentity =
-                                                                     new org.exoplatform.social.core.identity.model.Identity(OrganizationIdentityProvider.NAME,
-                                                                                                                             "john");
-    userIdentity.setId("1");
-    lenient().when(identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "1")).thenReturn(userIdentity);
-    lenient().when(activityManager.getActivity("1")).thenReturn(activity);
-    lenient().when(activityManager.getActivityStreamOwnerIdentity(activity.getId())).thenReturn(userIdentity);
+    HashSet<TagName> contentTags = new HashSet<>(Arrays.asList(new TagName("tag1"), new TagName("tag2")));
 
-    newsActivityListener.onEvent(event);
-    verify(newsService, times(1)).getNewsByActivityId("1", johnIdentity);
-    verify(favoriteService, times(1)).createFavorite(any());
-    verify(indexingService, times(1)).reindex(NewsIndexingServiceConnector.TYPE, news.getId());
-  }
+    String spacePrettyName = "spacePrettyName";
 
-  @Test
-  public void testDropindexActivityWhenRemoveNewsFromFavorite() throws Exception {
-    NewsMetadataListener newsActivityListener = new NewsMetadataListener(indexingService,
-            newsService,
-            favoriteService,
-            identityManager,
-            activityManager,
-            tagService);
-    Identity johnIdentity = new Identity("1", Collections.singletonList(new MembershipEntry("john")));
-    ConversationState.setCurrent(new ConversationState(johnIdentity));
-    MetadataItem metadataItem = mock(MetadataItem.class);
-    Event<Long, MetadataItem> event = mock(Event.class);
-    lenient().when(event.getData()).thenReturn(metadataItem);
-    lenient().when(event.getData().getObjectType()).thenReturn("activity");
-    lenient().when(event.getEventName()).thenReturn("social.metadataItem.deleted");
-    lenient().when(metadataItem.getMetadataTypeName()).thenReturn("favorites");
-    lenient().when(metadataItem.getObjectId()).thenReturn("1");
-    News news = new News();
-    news.setId("1234");
-    ExoSocialActivity activity = new ExoSocialActivityImpl();
-    activity.setType(NewsUtils.NEWS_METADATA_OBJECT_TYPE);
-    lenient().when(newsService.getNewsByActivityId("1", johnIdentity)).thenReturn(news);
-    org.exoplatform.social.core.identity.model.Identity userIdentity =
-            new org.exoplatform.social.core.identity.model.Identity(OrganizationIdentityProvider.NAME,
-                    "john");
-    userIdentity.setId("1");
-    lenient().when(identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "1")).thenReturn(userIdentity);
-    lenient().when(activityManager.getActivity("1")).thenReturn(activity);
-    lenient().when(activityManager.getActivityStreamOwnerIdentity(activity.getId())).thenReturn(userIdentity);
+    Space space = mock(Space.class);
+    when(space.getPrettyName()).thenReturn(spacePrettyName);
+    when(spaceService.getSpaceById(spaceId)).thenReturn(space);
 
-    newsActivityListener.onEvent(event);
-    verify(newsService, times(1)).getNewsByActivityId("1", johnIdentity);
-    verify(favoriteService, times(1)).deleteFavorite(any());
-    verify(indexingService, times(1)).reindex(NewsIndexingServiceConnector.TYPE, news.getId());
-  }
+    String spaceIdentityId = "200";
+    Identity spaceIdentity = mock(Identity.class);
+    when(spaceIdentity.getId()).thenReturn(spaceIdentityId);
 
-  private void setCurrentUser(final String name) {
-    ConversationState.setCurrent(new ConversationState(new org.exoplatform.services.security.Identity(name)));
+    when(identityManager.getOrCreateSpaceIdentity(spacePrettyName)).thenReturn(spaceIdentity);
+
+    String userIdentityId = "300";
+    Identity userIdentity = mock(Identity.class);
+    when(userIdentity.getId()).thenReturn(userIdentityId);
+    when(identityManager.getOrCreateUserIdentity(USERNAME)).thenReturn(userIdentity);
+
+    when(tagService.detectTagNames(content)).thenReturn(contentTags);
+
+    newsMetadataListener.onEvent(event);
+
+    verify(indexingService, times(1)).reindex(NewsIndexingServiceConnector.TYPE, newsId);
+    verify(tagService, times(1)).saveTags(new TagObject(NewsUtils.NEWS_METADATA_OBJECT_TYPE,
+                                                        news.getId(),
+                                                        null),
+                                          contentTags,
+                                          Long.parseLong(spaceIdentityId),
+                                          Long.parseLong(userIdentityId));
   }
 
 }

--- a/webapp/src/main/webapp/WEB-INF/conf/news/activity-listener-configuration.xml
+++ b/webapp/src/main/webapp/WEB-INF/conf/news/activity-listener-configuration.xml
@@ -79,4 +79,43 @@
       <type>org.exoplatform.news.listener.AnalyticsNewsListener</type>
     </component-plugin>
   </external-component-plugins>
+
+  <external-component-plugins>
+    <target-component>org.exoplatform.services.listener.ListenerService</target-component>
+    <component-plugin>
+      <name>exo.news.postArticle</name>
+      <set-method>addListener</set-method>
+      <type>org.exoplatform.news.listener.AttachedActivityCacheUpdater</type>
+    </component-plugin>
+    <component-plugin>
+      <name>exo.news.updateArticle</name>
+      <set-method>addListener</set-method>
+      <type>org.exoplatform.news.listener.AttachedActivityCacheUpdater</type>
+    </component-plugin>
+    <component-plugin>
+      <name>exo.news.shareArticle</name>
+      <set-method>addListener</set-method>
+      <type>org.exoplatform.news.listener.AttachedActivityCacheUpdater</type>
+    </component-plugin>
+    <component-plugin>
+      <name>exo.news.archiveArticle</name>
+      <set-method>addListener</set-method>
+      <type>org.exoplatform.news.listener.AttachedActivityCacheUpdater</type>
+    </component-plugin>
+    <component-plugin>
+      <name>exo.news.unarchiveArticle</name>
+      <set-method>addListener</set-method>
+      <type>org.exoplatform.news.listener.AttachedActivityCacheUpdater</type>
+    </component-plugin>
+    <component-plugin>
+      <name>exo.news.scheduleArticle</name>
+      <set-method>addListener</set-method>
+      <type>org.exoplatform.news.listener.AttachedActivityCacheUpdater</type>
+    </component-plugin>
+    <component-plugin>
+      <name>exo.news.unscheduleArticle</name>
+      <set-method>addListener</set-method>
+      <type>org.exoplatform.news.listener.AttachedActivityCacheUpdater</type>
+    </component-plugin>
+  </external-component-plugins>
 </configuration>

--- a/webapp/src/main/webapp/WEB-INF/conf/news/metadata-plugins-configuration.xml
+++ b/webapp/src/main/webapp/WEB-INF/conf/news/metadata-plugins-configuration.xml
@@ -126,19 +126,34 @@
   <external-component-plugins>
     <target-component>org.exoplatform.services.listener.ListenerService</target-component>
     <component-plugin>
-      <name>social.metadataItem.created</name>
+      <name>exo.news.postArticle</name>
+      <set-method>addListener</set-method>
+      <type>org.exoplatform.news.listener.NewsMetadataListener</type>
+    </component-plugin>
+    <component-plugin>
+      <name>exo.news.updateArticle</name>
+      <set-method>addListener</set-method>
+      <type>org.exoplatform.news.listener.NewsMetadataListener</type>
+    </component-plugin>
+    <component-plugin>
+      <name>exo.news.shareArticle</name>
       <set-method>addListener</set-method>
       <type>org.exoplatform.news.listener.NewsMetadataListener</type>
     </component-plugin>
     <component-plugin>
       <name>social.metadataItem.deleted</name>
       <set-method>addListener</set-method>
-      <type>org.exoplatform.news.listener.NewsMetadataListener</type>
+      <type>org.exoplatform.news.listener.MetadataItemModified</type>
     </component-plugin>
     <component-plugin>
       <name>social.metadataItem.updated</name>
       <set-method>addListener</set-method>
-      <type>org.exoplatform.news.listener.NewsMetadataListener</type>
+      <type>org.exoplatform.news.listener.MetadataItemModified</type>
+    </component-plugin>
+    <component-plugin>
+      <name>social.metadataItem.created</name>
+      <set-method>addListener</set-method>
+      <type>org.exoplatform.news.listener.MetadataItemModified</type>
     </component-plugin>
   </external-component-plugins>
 </configuration>

--- a/webapp/src/main/webapp/news-details/components/ExoNewsFavoriteAction.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsFavoriteAction.vue
@@ -1,12 +1,12 @@
 <template>
   <favorite-button
-    :id="activityId"
+    :id="newsId"
     :favorite="isFavorite"
     :absolute="absolute"
     :top="top"
     :right="right"
     :template-params="templateParams"
-    type="activity"
+    type="news"
     type-label="News"
     @removed="removed"
     @remove-error="removeError"
@@ -42,6 +42,11 @@ export default {
     isFavorite: false,
     templateParams: {},
   }),
+  computed: {
+    newsId() {
+      return this.news?.id;
+    },
+  },
   created() {
     this.$activityService.getActivityById(this.activityId)
       .then(fullActivity => {
@@ -53,24 +58,14 @@ export default {
   methods: {
     removed() {
       this.displayAlert(this.$t('Favorite.tooltip.SuccessfullyDeletedFavorite', {0: this.$t('news.label')}));
-      this.$favoriteService.removeFavorite('news', this.news.id)
-        .then(() => {
-          this.isFavorite = false;
-          this.$emit('removed');
-        })
-        .catch(() => this.$emit('remove-error'));
+      this.$emit('removed');
     },
     removeError() {
       this.displayAlert(this.$t('Favorite.tooltip.ErrorDeletingFavorite', {0: this.$t('news.label')}), 'error');
     },
     added() {
       this.displayAlert(this.$t('Favorite.tooltip.SuccessfullyAddedAsFavorite', {0: this.$t('news.label')}));
-      this.$favoriteService.addFavorite('news', this.news.id)
-        .then(() => {
-          this.isFavorite = true;
-          this.$emit('added');
-        })
-        .catch(() => this.$emit('add-error'));
+      this.$emit('added');
     },
     addError() {
       this.displayAlert(this.$t('Favorite.tooltip.ErrorAddingAsFavorite', {0: this.$t('news.label')}), 'error');

--- a/webapp/webpack.dev.js
+++ b/webapp/webpack.dev.js
@@ -15,7 +15,7 @@ let config = merge(webpackCommonConfig, {
   output: {
     path: path.resolve(`${exoServerPath}/webapps/${app}/`)
   },
-  devtool: 'inline-source-map'
+  devtool: 'eval-source-map'
 });
 
 module.exports = config;


### PR DESCRIPTION
Prior to this change, when adding a news as favorite from Activity stream, a Favorite Metadata is associated to Activity and to the News at the same time (Same for tags). This fix will ensure to associate the favorite Metadata to the News content only. In fact, an improvement for Activity Metadata Management has been added (https://github.com/Meeds-io/social/pull/1460) that allows to add a specific target Object Type+Id when displaying activity in Stream. Thus, the Favorite button will manage the favorites of News Content Object identified by its real id.