### PR TITLE
TASK-56600 Improve Tags Search by making it case insensitive for News

### DIFF
--- a/services/src/main/resources/news-search-query.json
+++ b/services/src/main/resources/news-search-query.json
@@ -5,13 +5,14 @@
     "bool": {
       @term_query@
       "filter": [
-        @metadatas_query@
+        @favorite_query@
         {
           "terms": {
             "permissions": [@permissions@]
           }
         }
       ]
+      @tags_query@
     }
   },
   "highlight" : {


### PR DESCRIPTION
Prior to this change, the Tags Search and listing are case sensitive. This change will list the Tags in Search UI in case insensitive (group same spelled tags) and will make a search on selected tag name in case insensitive way.