### PR TITLE
TASK-57050: Fix no notification is sent to the mentioned user when the mention is done from the edition form

### DIFF
--- a/services/src/main/java/org/exoplatform/news/model/News.java
+++ b/services/src/main/java/org/exoplatform/news/model/News.java
@@ -20,7 +20,11 @@ public class News {
 
   private String               summary;
 
+  /* sanitizedBody with usernames */
   private String               body;
+
+  /* originalBody with user mentions */
+  private String               originalBody;
 
   private String               author;
 

--- a/services/src/main/java/org/exoplatform/news/service/impl/NewsServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/service/impl/NewsServiceImpl.java
@@ -151,7 +151,8 @@ public class NewsServiceImpl implements NewsService {
     if (!canEditNews(news, updater)) {  
       throw new IllegalArgumentException("User " + updater + " is not authorized to update news");
     }
-    Set<String> previousMentions = NewsUtils.processMentions(news.getBody());
+    News originalNews = newsStorage.getNewsById(news.getId(), false);
+    Set<String> previousMentions = NewsUtils.processMentions(originalNews.getOriginalBody());
     if (publish != news.isPublished() && news.isCanPublish()) {
       news.setPublished(publish);
       if (news.isPublished()) {

--- a/services/src/main/java/org/exoplatform/news/storage/jcr/JcrNewsStorage.java
+++ b/services/src/main/java/org/exoplatform/news/storage/jcr/JcrNewsStorage.java
@@ -398,6 +398,7 @@ public class JcrNewsStorage implements NewsStorage {
     String sanitizedBody = HTMLSanitizer.sanitize(body);
     sanitizedBody = sanitizedBody.replaceAll(HTML_AT_SYMBOL_ESCAPED_PATTERN, HTML_AT_SYMBOL_PATTERN);
     news.setBody(substituteUsernames(portalOwner, sanitizedBody));
+    news.setOriginalBody(sanitizedBody);
     news.setAuthor(getStringProperty(node, "exo:author"));
     news.setCreationDate(getDateProperty(node, "exo:dateCreated"));
     news.setPublicationDate(getPublicationDate(node));


### PR DESCRIPTION
ISSUES : when update an article and mention a user, no notification is sent to the mentioned user.
FIX : the problem is that in the case of update and when we mention user the mentioned user was removed from the body of the news before sending it in the notification, so we can't get  mentionedIds from the contentBody. it fixed by sending the BodyContent news with the mentioned users.