### PR TITLE
TASK-56875: Fix external user does not receive published news notification

### DIFF
--- a/services/src/main/java/org/exoplatform/news/notification/plugin/PostNewsNotificationPlugin.java
+++ b/services/src/main/java/org/exoplatform/news/notification/plugin/PostNewsNotificationPlugin.java
@@ -46,14 +46,8 @@ public class PostNewsNotificationPlugin extends BaseNotificationPlugin {
 
   public static final ArgumentLiteral<String> CURRENT_USER     = new ArgumentLiteral<>(String.class, "CURRENT_USER");
 
-  private SpaceService                        spaceService;
-
-  private UserHandler                         userhandler;
-
-  public PostNewsNotificationPlugin(InitParams initParams, SpaceService spaceService, OrganizationService organizationService) {
+  public PostNewsNotificationPlugin(InitParams initParams) {
     super(initParams);
-    this.spaceService = spaceService;
-    this.userhandler = organizationService.getUserHandler();
   }
 
   @Override
@@ -93,7 +87,7 @@ public class PostNewsNotificationPlugin extends BaseNotificationPlugin {
 
     List<String> receivers = new ArrayList<String>();
     try {
-      receivers = getReceivers(contentSpaceId, currentUserName);
+      receivers = NotificationUtils.getReceivers(contentSpaceId, currentUserName);
     } catch (Exception e) {
       LOG.error("An error occured when trying to have the list of receivers " + e.getMessage(), e);
     }
@@ -112,18 +106,5 @@ public class PostNewsNotificationPlugin extends BaseNotificationPlugin {
                            .key(getKey())
                            .end();
 
-  }
-
-  private List<String> getReceivers(String contentSpaceId,
-                                    String currentUserName) throws Exception {
-    Space space = spaceService.getSpaceById(contentSpaceId);
-    ListAccess<User> members = userhandler.findUsersByGroupId(space.getGroupId());
-    User[] userArray = members.load(0, members.getSize());
-    List<String> receiverUsers = Arrays.stream(userArray)
-            .filter(u -> !u.getUserName().equals(currentUserName))
-            .distinct()
-            .map(User::getUserName)
-            .collect(Collectors.toList());
-    return receiverUsers;
   }
 }

--- a/services/src/main/java/org/exoplatform/news/notification/plugin/PublishNewsNotificationPlugin.java
+++ b/services/src/main/java/org/exoplatform/news/notification/plugin/PublishNewsNotificationPlugin.java
@@ -9,6 +9,10 @@ import org.exoplatform.news.notification.utils.NotificationUtils;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 
+import java.util.ArrayList;
+import java.util.List;
+
+
 public class PublishNewsNotificationPlugin extends BaseNotificationPlugin {
 
   private static final Log   LOG = ExoLogger.getLogger(PublishNewsNotificationPlugin.class);
@@ -53,10 +57,17 @@ public class PublishNewsNotificationPlugin extends BaseNotificationPlugin {
     String authorAvatarUrl = ctx.value(PostNewsNotificationPlugin.AUTHOR_AVATAR_URL);
     String activityLink = ctx.value(PostNewsNotificationPlugin.ACTIVITY_LINK);
     String newsId = ctx.value(PostNewsNotificationPlugin.NEWS_ID);
+    String contentSpaceId = ctx.value(PostNewsNotificationPlugin.CONTENT_SPACE_ID);
+    List<String> receivers = new ArrayList<>();
+    try {
+      receivers = NotificationUtils.getReceivers(contentSpaceId, currentUserName);
+    } catch (Exception e) {
+      LOG.error("An error occured when trying to have the list of receivers " + e.getMessage(), e);
+    }
 
     return NotificationInfo.instance()
                            .setFrom(currentUserName)
-                           .setSendAllInternals(true)
+                           .to(receivers)
                            .exclude(currentUserName)
                            .with(NotificationConstants.CONTENT_TITLE, contentTitle)
                            .with(NotificationConstants.CONTENT_AUTHOR, contentAuthor)

--- a/services/src/main/java/org/exoplatform/news/notification/utils/NotificationUtils.java
+++ b/services/src/main/java/org/exoplatform/news/notification/utils/NotificationUtils.java
@@ -5,20 +5,37 @@ import javax.jcr.Node;
 import javax.jcr.Session;
 
 import org.exoplatform.commons.utils.CommonsUtils;
+import org.exoplatform.commons.utils.ListAccess;
 import org.exoplatform.commons.utils.PropertyManager;
 import org.exoplatform.container.PortalContainer;
 import org.exoplatform.news.model.News;
-import org.exoplatform.services.jcr.RepositoryService;
-import org.exoplatform.services.jcr.ext.app.SessionProviderService;
-import org.exoplatform.services.jcr.ext.common.SessionProvider;
 import org.exoplatform.services.organization.OrganizationService;
 import org.exoplatform.services.organization.User;
 import org.exoplatform.services.organization.UserHandler;
 import org.exoplatform.social.core.service.LinkProvider;
 import org.exoplatform.social.core.space.model.Space;
+import org.exoplatform.social.core.space.spi.SpaceService;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class NotificationUtils {
 
+  public static List<String> getReceivers(String contentSpaceId,
+                                    String currentUserName) throws Exception {
+    OrganizationService organizationService = CommonsUtils.getService(OrganizationService.class);
+    SpaceService spaceService = CommonsUtils.getService(SpaceService.class);
+    UserHandler userHandler = organizationService.getUserHandler();
+    Space space = spaceService.getSpaceById(contentSpaceId);
+    ListAccess<User> members =  userHandler.findUsersByGroupId(space.getGroupId());
+    User[] userArray = members.load(0, members.getSize());
+    return Arrays.stream(userArray)
+            .filter(u -> !u.getUserName().equals(currentUserName))
+            .distinct()
+            .map(User::getUserName)
+            .collect(Collectors.toList());
+  }
   public static String getUserFullName(String userName) throws Exception {
     OrganizationService organizationService = CommonsUtils.getService(OrganizationService.class);
     UserHandler userHandler = organizationService.getUserHandler();


### PR DESCRIPTION
ISSUES : When we post and publish news, the external user does not receive published news notification .
FIX : The problem that the notification of the published news are sent to the internal users, so it fixed by getting the receivers that are the members of the space (internals and externals).