### PR TITLE
Task-57193 : News activity update mail notifications should be sent only for non draft status

### DIFF
--- a/services/src/main/java/org/exoplatform/news/service/impl/NewsServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/service/impl/NewsServiceImpl.java
@@ -188,7 +188,7 @@ public class NewsServiceImpl implements NewsService {
       }
       indexingService.reindex(NewsIndexingServiceConnector.TYPE, String.valueOf(news.getId()));
     }
-    if (post != null) {
+    if (post != null && !PublicationDefaultStates.DRAFT.equals(news.getPublicationState())) {
       updateNewsActivity(news, post);
     }
     NewsUtils.broadcastEvent(NewsUtils.UPDATE_NEWS, updater, news);


### PR DESCRIPTION
ISSUE : When a user creates an article in a space and another user likes or comments it. If the creator edits the article, the liker or commenter receives many mail notifications.
FIX : The news activity update should be done only when the article hasn't draft status.