### PR TITLE
Task-56827: Add text truncate in mobile when space name is too long

### DIFF
--- a/webapp/src/main/webapp/news/components/NewsAppItem.vue
+++ b/webapp/src/main/webapp/news/components/NewsAppItem.vue
@@ -52,13 +52,14 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
           <exo-user-avatar
             :profile-id="newsAuthor"
             :size="25"
-            class="align-center my-auto text-truncate flex-grow-0 flex"
+            class="align-center width-full my-auto text-truncate flex-grow-0 flex"
             small-font-size
             popover />
           <i v-if="!news.hiddenSpace" class="uiIconArrowNext pt-1"></i>
           <exo-space-avatar
             v-if="!news.hiddenSpace"
             :space-id="spaceId"
+            class="width-full text-truncate"
             :size="25"
             extra-class="ps-1"
             small-font-size

--- a/webapp/src/main/webapp/skin/less/news.less
+++ b/webapp/src/main/webapp/skin/less/news.less
@@ -3515,7 +3515,6 @@
                 margin-left: 5px ~'; /** orientation=lt */ ';
                 margin-right: 5px ~'; /** orientation=rt */ ';
                 align-items: center;
-                max-width: 60px;
 
                 a {
                   margin-left: 5px ~'; /** orientation=lt */ ';

--- a/webapp/src/main/webapp/skin/less/news.less
+++ b/webapp/src/main/webapp/skin/less/news.less
@@ -3515,7 +3515,7 @@
                 margin-left: 5px ~'; /** orientation=lt */ ';
                 margin-right: 5px ~'; /** orientation=rt */ ';
                 align-items: center;
-                max-width: 50px;
+                max-width: 60px;
 
                 a {
                   margin-left: 5px ~'; /** orientation=lt */ ';


### PR DESCRIPTION

Prior to this change, When the space name is too long, the first letter should be displayed.
Fix: Add max-width to the space name