### PR TITLE
Task-57270: Accented characters are not allowed in the "Add a target" drawer and the News list settings drawer (#548)

### DIFF
--- a/webapp/src/main/webapp/news-list-view/components/settings/NewsSettingsDrawer.vue
+++ b/webapp/src/main/webapp/news-list-view/components/settings/NewsSettingsDrawer.vue
@@ -201,7 +201,7 @@ export default {
       return this.viewTemplates.filter(e=> !e.name.includes('EmptyTemplate'));
     },
     checkAlphanumeric() {
-      return this.newsHeader && !this.newsHeader.trim().match(/^[\w\-\s]+$/) && this.newsHeader.length > 0 ? this.$t('news.list.settings.name.errorMessage') : '';
+      return this.newsHeader && !this.newsHeader.trim().match(/^[a-zA-Z\u00C0-\u00FF ]*$/) && this.newsHeader.length > 0 ? this.$t('news.list.settings.name.errorMessage') : '';
     },
     disabled() {
       return this.checkAlphanumeric !== '' || (this.newsHeader && this.newsHeader.length === 0) || (this.showSeeAll && this.seeAllUrl && this.seeAllUrl.length === 0);


### PR DESCRIPTION

Problem: we can't add an accented character in the header field which  in News settings drawer.
Fix: Update Reg expression using the unicode values for accented characters.