### PR TITLE
Task-56676: A space member should be allowed to Bookmark a news

### DIFF
--- a/webapp/src/main/webapp/news-details/components/ExoNewsDetailsToolBar.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsDetailsToolBar.vue
@@ -93,7 +93,7 @@ export default {
       return history && history.length && history.length > 2;
     },
     displayFavoriteButton() {
-      return this.showEditButton && this.publicationState !== 'staged';
+      return this.publicationState !== 'staged';
     }
   },
   methods: {


### PR DESCRIPTION
Problem: Favorite icon is not displayed at the right side on the news details for member in space X.
Fix: the display of Favorite icon will be made independently from edit permission for current user.