### PR TITLE
Task-51771: fix problem when pressing enter in input title that redirect to loading page.

### DIFF
--- a/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
+++ b/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
@@ -205,7 +205,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         <div id="newsTop"></div>
       </div>
 
-      <form id="newsForm" class="newsForm">
+      <form id="newsForm" class="newsForm" onsubmit="event.preventDefault(); return false;">
         <div class="newsFormInput">
           <div id="newsFormAttachment" class="newsFormAttachment">
             <div class="control-group attachments">


### PR DESCRIPTION
ISSUE: When the user opens the composer space and click on write an article an type a text in the "Title" field then press "enter", he's redirected to another page .
FIX:Add prevent default behavior for the article form 