### PR TITLE
TASK-57548: Adjust alignment of news list template

### DIFF
--- a/webapp/src/main/webapp/news-list-view/components/views/NewsListTemplateView.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsListTemplateView.vue
@@ -16,18 +16,20 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 -->
 <template>
   <div id="article-list-view">
-    <div class="article-list-container">
-      <div
+    <v-row>
+      <v-col
         v-for="(item, index) of newsInfo"
-        :key="item"
-        class="article"
-        :id="`article-item-${index}`">
-        <news-list-template-view-item
-          :item="item"
-          :selected-option="selectedOption"
-          :key="index" />
-      </div>  
-    </div>
+        :key="item">
+        <div
+          class="article"
+          :id="`article-item-${index}`">
+          <news-list-template-view-item
+            :item="item"
+            :selected-option="selectedOption"
+            :key="index" />
+        </div>
+      </v-col>
+    </v-row>
   </div>
 </template>
 

--- a/webapp/src/main/webapp/skin/less/news.less
+++ b/webapp/src/main/webapp/skin/less/news.less
@@ -4504,15 +4504,11 @@ input.ignore-vuetify-classes.datePickerText.flex-grow-0 {
   overflow: hidden;
   background: white;
   padding: 15px;
-  .article-list-container {
-    display: flex;
-    grid-gap: 15px;
-    flex-wrap: wrap;
-  }
   .article {
     position: relative;
     height: 70px;
     overflow: hidden;
+    max-width: 270px;
     &:hover {
       img {
         transform: scale(1.08);
@@ -4639,32 +4635,9 @@ input.ignore-vuetify-classes.datePickerText.flex-grow-0 {
     }
   } 
 }
-@media (min-width: 620px) {
-  #article-list-view {
-    .article-list-container {
-      grid-template-columns: 1fr 1fr;
-    }
-  } 
-}
-@media (min-width: 1000px) {
-  #article-list-view {
-    .article-list-container {
-      grid-template-columns: 1fr 1fr 1fr;
-    }
-  }
-}
-@media (min-width: 1760px) {
-  #article-list-view {
-    .article-list-container {
-      grid-template-columns: 1fr 1fr 1fr 1fr;
-    }
-  }
-}
-@media (min-width: 2140px) {
-  #article-list-view {
-    .article-list-container {
-      grid-template-columns: 1fr 1fr 1fr 1fr 1fr;
-    }
+@media (max-width: 488px) {
+  .article {
+    max-width: 100% !important;
   }
 }
 


### PR DESCRIPTION
Prior to this fix, the news list template is badly displayed. After publishing some articles whose titles and summaries have different lengths, no alignment is applied on it.

After this fix, we will be able to display these articles correctly using the `Vuetify Grid System`.