### PR TITLE
Task-56988: Photo disappears when it is moved or resized in editor

### DIFF
--- a/services/src/main/java/org/exoplatform/news/storage/jcr/JcrNewsStorage.java
+++ b/services/src/main/java/org/exoplatform/news/storage/jcr/JcrNewsStorage.java
@@ -66,7 +66,6 @@ import org.exoplatform.services.wcm.extensions.publication.lifecycle.impl.Lifecy
 import org.exoplatform.services.wcm.publication.PublicationDefaultStates;
 import org.exoplatform.services.wcm.publication.WCMPublicationService;
 import org.exoplatform.services.wcm.publication.lifecycle.stageversion.StageAndVersionPublicationConstant;
-import org.exoplatform.social.common.service.HTMLUploadImageProcessor;
 import org.exoplatform.social.core.identity.model.Identity;
 import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;
 import org.exoplatform.social.core.manager.ActivityManager;
@@ -118,9 +117,7 @@ public class JcrNewsStorage implements NewsStorage {
   private DataDistributionType     dataDistributionType;
   
   private IdentityManager          identityManager;
-  
-  private HTMLUploadImageProcessor imageProcessor;
-  
+
   private LinkManager              linkManager;
 
   private NewsAttachmentsStorage   newsAttachmentsService;
@@ -150,7 +147,6 @@ public class JcrNewsStorage implements NewsStorage {
                          ActivityManager activityManager,
                          SpaceService spaceService,
                          UploadService uploadService,
-                         HTMLUploadImageProcessor imageProcessor,
                          PublicationService publicationService,
                          PublicationManager publicationManager,
                          NewsAttachmentsStorage newsAttachmentsService,
@@ -161,7 +157,6 @@ public class JcrNewsStorage implements NewsStorage {
     
     this.activityManager = activityManager;
     this.dataDistributionType = dataDistributionManager.getDataDistributionType(DataDistributionMode.NONE);
-    this.imageProcessor = imageProcessor;
     this.identityManager = identityManager;
     this.linkManager = linkManager;
     this.newsAttachmentsService = newsAttachmentsService;
@@ -250,7 +245,7 @@ public class JcrNewsStorage implements NewsStorage {
     }
     publicationService.enrollNodeInLifecycle(newsDraftNode, lifecycleName);
     publicationService.changeState(newsDraftNode, PublicationDefaultStates.DRAFT, new HashMap<>());
-    newsDraftNode.setProperty("exo:body", imageProcessor.processImages(news.getBody(), newsDraftNode.getUUID(), "images"));
+    newsDraftNode.setProperty("exo:body", news.getBody());
     spaceNewsRootNode.save();
 
     if (StringUtils.isNotEmpty(news.getUploadId())) {
@@ -613,12 +608,10 @@ public class JcrNewsStorage implements NewsStorage {
 
     Node newsNode = session.getNodeByUUID(news.getId());
     if (newsNode != null) {
-      String processedBody = imageProcessor.processImages(news.getBody(), newsNode.getUUID(), "images");
       newsNode.setProperty("exo:title", news.getTitle());
       newsNode.setProperty("exo:name", news.getTitle());
       newsNode.setProperty("exo:summary", news.getSummary());
-      news.setBody(processedBody);
-      newsNode.setProperty("exo:body", processedBody);
+      newsNode.setProperty("exo:body", news.getBody());
       newsNode.setProperty("exo:dateModified", Calendar.getInstance());
       newsNode.setProperty(EXO_NEWS_LAST_MODIFIER, updater);
       // illustration

--- a/services/src/test/java/org/exoplatform/news/storage/jcr/JcrNewsStorageTest.java
+++ b/services/src/test/java/org/exoplatform/news/storage/jcr/JcrNewsStorageTest.java
@@ -3521,7 +3521,6 @@ public class JcrNewsStorageTest {
                                                   activityManager,
                                                   spaceService,
                                                   uploadService,
-                                                  imageProcessor,
                                                   publicationServiceImpl,
                                                   publicationManagerImpl,
                                                   newsAttachmentsService,

--- a/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
+++ b/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
@@ -366,6 +366,7 @@ export default {
       loading: true,
       currentSpace: {},
       spaceURL: null,
+      spaceGroupId: null,
       currentUser: eXo.env.portal.userName,
       fullDateFormat: {
         year: 'numeric',
@@ -463,10 +464,11 @@ export default {
     elementNewTop.classList.add('darkComposerEffect');
     document.body.style.overflow = 'hidden';
     autosize(document.querySelector('#newsSummary'));
-    
+
     this.$newsServices.getSpaceById(this.spaceId).then(space => {
       this.currentSpace = space;
       this.spaceURL = this.currentSpace.prettyName;
+      this.spaceGroupId = this.currentSpace.groupId;
       this.displayFormTitle();
 
       this.$newsServices.canUserCreateNews(this.currentSpace.id).then(canCreateNews => {
@@ -494,7 +496,7 @@ export default {
         this.canScheduleNews = canScheduleNews;
       });
     });
-    
+
     this.$nextTick(() => {
       const attachmentsComposer = JSON.parse(localStorage.getItem('exo-activity-composer-attachments'));
       if (attachmentsComposer) {
@@ -530,12 +532,13 @@ export default {
       CKEDITOR.plugins.addExternal('switchView','/news/js/ckeditor/plugins/switchView/','plugin.js');
       CKEDITOR.plugins.addExternal('attachFile','/news/js/ckeditor/plugins/attachment/','plugin.js');
       CKEDITOR.dtd.$removeEmpty['i'] = false;
-      let extraPlugins = 'sharedspace,simpleLink,selectImage,suggester,font,justify,widget,video,switchView,attachFile';
+      let extraPlugins = 'sharedspace,simpleLink,suggester,font,justify,widget,video,switchView,attachFile';
+      let removePlugins = 'image,confirmBeforeReload,maximize,resize,embedsemantic';
       const windowWidth = $(window).width();
       const windowHeight = $(window).height();
       if (windowWidth > windowHeight && windowWidth < this.SMARTPHONE_LANDSCAPE_WIDTH) {
         // Disable suggester on smart-phone landscape
-        extraPlugins = 'simpleLink,selectImage';
+        extraPlugins = 'simpleLink';
       }
       if (eXo.env.portal.activityTagsEnabled) {
         extraPlugins = `${extraPlugins},tagSuggester`;
@@ -552,7 +555,7 @@ export default {
           { name: 'switchView', items: ['switchView'] },
           { name: 'basicstyles', items: [ 'Bold', 'Italic', 'Underline', 'Strike', '-', 'RemoveFormat'] },
           { name: 'paragraph', items: [ 'NumberedList', 'BulletedList', '-', 'Blockquote' ] },
-          { name: 'links', items: [ 'selectImage', 'Video'] },
+          { name: 'links', items: ['Video'] },
           { name: 'attachFile', items: ['attachFile'] },
         );
       } else {
@@ -563,17 +566,31 @@ export default {
           { name: 'fontsize', items: ['FontSize'] },
           { name: 'colors', items: [ 'TextColor' ] },
           { name: 'align', items: [ 'JustifyLeft', 'JustifyCenter', 'JustifyRight', 'JustifyBlock'] },
-          { name: 'links', items: [ 'simpleLink', 'selectImage', 'Video'] },
+          { name: 'links', items: [ 'simpleLink', 'Video'] },
         );
       }
 
+      const ckEditorExtensions = extensionRegistry.loadExtensions('WYSIWYGPlugins', 'image');
+      if (ckEditorExtensions && ckEditorExtensions.length) {
+        const ckEditorExtraPlugins = ckEditorExtensions.map(ckEditorExtension => ckEditorExtension.extraPlugin).join(',');
+        const ckEditorRemovePlugins = ckEditorExtensions.map(ckEditorExtension => ckEditorExtension.removePlugin).join(',');
+        if (ckEditorExtraPlugins) {
+          extraPlugins = `${extraPlugins},${ckEditorExtraPlugins}`;
+        }
+        if (ckEditorRemovePlugins) {
+          removePlugins = `${extraPlugins},${ckEditorRemovePlugins}`;
+        }
+        ckEditorExtensions.forEach(ckEditorExtension => newsToolbar.find(toolbarItem => toolbarItem.name === 'links').items.push(ckEditorExtension.extraToolbarItem));
+      }
       $('textarea#newsContent').ckeditor({
         customConfig: '/commons-extension/ckeditorCustom/config.js',
         extraPlugins: extraPlugins,
-        removePlugins: 'image,confirmBeforeReload,maximize,resize,embedsemantic',
+        removePlugins: removePlugins,
         allowedContent: true,
         typeOfRelation: 'mention_activity_stream',
         spaceURL: self.spaceURL,
+        spaceGroupId: self.spaceGroupId,
+        imagesDownloadFolder: 'news/images',
         toolbarLocation: 'top',
         extraAllowedContent: 'img[style,class,src,referrerpolicy,alt,width,height]; span(*)[*]{*}; span[data-atwho-at-query,data-atwho-at-value,contenteditable]; a[*];i[*]',
         removeButtons: 'Subscript,Superscript,Cut,Copy,Paste,PasteText,PasteFromWord,Undo,Redo,Scayt,Unlink,Anchor,Table,HorizontalRule,SpecialChar,Maximize,Source,Strike,Outdent,Indent,BGColor,About',


### PR DESCRIPTION
The Image URLs in the editor are generated from the upload ID after uploading.
This upload ID is stored temporarily and will be deleted and the image will be stored in the document storage when saving content.
But, this download ID will be deleted also when the server is stopped, so we will lose these images if the content is still draft
Fix: Store uploaded images in document storage by ckeditor after upload it instead of process the storage by HTMLUploadImageProcessor service