### PR TITLE
TASK-57548: Adjust alignment of news list template

### DIFF
--- a/webapp/src/main/webapp/news-list-view/components/views/NewsListTemplateView.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsListTemplateView.vue
@@ -18,6 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
   <div id="article-list-view">
     <v-row>
       <v-col
+        class="article-col"
         v-for="(item, index) of newsInfo"
         :key="item">
         <div

--- a/webapp/src/main/webapp/news-list-view/components/views/NewsListTemplateView.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsListTemplateView.vue
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
   <div id="article-list-view">
     <v-row>
       <v-col
-        class="article-col"
+        class="flex-grow-0"
         v-for="(item, index) of newsInfo"
         :key="item">
         <div

--- a/webapp/src/main/webapp/skin/less/news.less
+++ b/webapp/src/main/webapp/skin/less/news.less
@@ -4504,9 +4504,6 @@ input.ignore-vuetify-classes.datePickerText.flex-grow-0 {
   overflow: hidden;
   background: white;
   padding: 15px;
-  .article-col {
-    flex-grow: 0;
-  }
   .article {
     position: relative;
     height: 70px;

--- a/webapp/src/main/webapp/skin/less/news.less
+++ b/webapp/src/main/webapp/skin/less/news.less
@@ -4504,11 +4504,14 @@ input.ignore-vuetify-classes.datePickerText.flex-grow-0 {
   overflow: hidden;
   background: white;
   padding: 15px;
+  .article-col {
+    flex-grow: 0;
+  }
   .article {
     position: relative;
     height: 70px;
     overflow: hidden;
-    max-width: 270px;
+    width: 270px;
     &:hover {
       img {
         transform: scale(1.08);
@@ -4637,7 +4640,7 @@ input.ignore-vuetify-classes.datePickerText.flex-grow-0 {
 }
 @media (max-width: 488px) {
   .article {
-    max-width: 100% !important;
+    width: 100% !important;
   }
 }
 


### PR DESCRIPTION
Prior to this fix, the news list template is badly displayed. After publishing some articles whose titles and summaries have different lengths, no alignment is applied on it.

After this fix, we will be able to display these articles correctly using the `Vuetify Grid System`.