### PR TITLE
TASK-56737 Add Space Identifier when bookmarking a news

### DIFF
--- a/webapp/src/main/webapp/news-details/components/ExoNewsFavoriteAction.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsFavoriteAction.vue
@@ -6,6 +6,7 @@
     :top="top"
     :right="right"
     :template-params="templateParams"
+    :space-id="spaceId"
     type="news"
     type-label="News"
     @removed="removed"
@@ -45,6 +46,9 @@ export default {
   computed: {
     newsId() {
       return this.news?.id;
+    },
+    spaceId() {
+      return this.news?.spaceId;
     },
   },
   created() {


### PR DESCRIPTION
Prior to this change, the bookmarked news didn't had a space identifier attached into it which avoids bookmarks deletion when the space is deleted as well. This change introduces the space identifier in re-usable favorite button properties.