### PR TITLE
Task-57143: Adjust display of news headlines template using a  small width container

### DIFF
--- a/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
+++ b/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
@@ -205,7 +205,10 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         <div id="newsTop"></div>
       </div>
 
-      <form id="newsForm" class="newsForm" onsubmit="event.preventDefault(); return false;">
+      <form
+        id="newsForm"
+        class="newsForm"
+        onsubmit="event.preventDefault(); return false;">
         <div class="newsFormInput">
           <div id="newsFormAttachment" class="newsFormAttachment">
             <div class="control-group attachments">

--- a/webapp/src/main/webapp/news-list-view/components/views/NewsLatestView.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsLatestView.vue
@@ -15,17 +15,44 @@ You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 -->
 <template>
-  <div id="news-latest-view" class="px-2 pb-2">
-    <div class="article-container">
-      <div
-        v-for="(item, index) of newsInfo"
-        :key="item"
-        class="article"
-        :id="`articleItem-${index}`">
-        <news-latest-view-item
-          :item="item"
-          :selected-option="selectedOption"
-          :key="index" />
+  <div
+    id="news-latest-view"
+    class="px-2 pb-2"
+    ref="newsLatestView">
+    <div v-if="!hasSmallWidthContainer">
+      <div class="article-container">
+        <div
+          v-for="(item, index) of newsInfo"
+          :key="item"
+          class="article"
+          :id="`articleItem-${index}`">
+          <news-latest-view-item
+            :item="item"
+            :selected-option="selectedOption"
+            :index="index"
+            :hasSmallWidthContainer="hasSmallWidthContainer"
+            :key="index" />
+        </div>
+      </div>
+    </div>
+
+    <div v-else>
+      <div class="article-container d-flex " style="height: 620px; flex-direction: column">
+        <v-row
+          v-for="(item, index) of newsInfo"
+          :style="{'min-height': index !== 0 ? 'auto' : '38%'}"
+          :key="index"
+          class="article ma-0"
+          :id="`articleItem-${index}`">
+          <v-col style="min-height:100% !important;" class="pa-0">
+            <news-latest-view-item
+              :item="item"
+              :selected-option="selectedOption"
+              :index="index"
+              :hasSmallWidthContainer="hasSmallWidthContainer"
+              :key="index" />
+          </v-col>
+        </v-row>
       </div>
     </div>
   </div>
@@ -67,6 +94,7 @@ export default {
     showArticleSpace: false,
     showArticleDate: false,
     showArticleReactions: false,
+    hasSmallWidthContainer: false
   }),
   computed: {
     spaceAvatarUrl() {
@@ -83,6 +111,9 @@ export default {
   },
   mounted() {
     this.$nextTick().then(() => this.$root.$emit('application-loaded'));
+    console.log(this.$refs.newsLatestView?.clientWidth, window.screen.width);
+    console.log((this.$refs.newsLatestView?.clientWidth *100 / window.screen.width ))
+    this.hasSmallWidthContainer = (this.$refs.newsLatestView?.clientWidth *100 / window.screen.width ) < 33;
   },
   methods: {
     getNewsList() {

--- a/webapp/src/main/webapp/news-list-view/components/views/NewsLatestView.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsLatestView.vue
@@ -30,26 +30,25 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
             :item="item"
             :selected-option="selectedOption"
             :index="index"
-            :hasSmallWidthContainer="hasSmallWidthContainer"
+            :has-small-width-container="hasSmallWidthContainer"
             :key="index" />
         </div>
       </div>
     </div>
-
     <div v-else>
-      <div class="article-container d-flex " style="height: 620px; flex-direction: column">
+      <div :class="`article-container ${hasSmallWidthContainer && 'd-flex flex-column article-small-container'}`">
         <v-row
           v-for="(item, index) of newsInfo"
           :style="{'min-height': index !== 0 ? 'auto' : '38%'}"
           :key="index"
           class="article ma-0"
           :id="`articleItem-${index}`">
-          <v-col style="min-height:100% !important;" class="pa-0">
+          <v-col class="pa-0">
             <news-latest-view-item
               :item="item"
               :selected-option="selectedOption"
               :index="index"
-              :hasSmallWidthContainer="hasSmallWidthContainer"
+              :has-small-width-container="hasSmallWidthContainer"
               :key="index" />
           </v-col>
         </v-row>
@@ -111,9 +110,7 @@ export default {
   },
   mounted() {
     this.$nextTick().then(() => this.$root.$emit('application-loaded'));
-    console.log(this.$refs.newsLatestView?.clientWidth, window.screen.width);
-    console.log((this.$refs.newsLatestView?.clientWidth *100 / window.screen.width ))
-    this.hasSmallWidthContainer = (this.$refs.newsLatestView?.clientWidth *100 / window.screen.width ) < 33;
+    this.hasSmallWidthContainer = (this.$refs.newsLatestView?.clientWidth *100 / window.screen.width) < 33;
   },
   methods: {
     getNewsList() {

--- a/webapp/src/main/webapp/news-list-view/components/views/NewsLatestViewItem.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsLatestViewItem.vue
@@ -1,16 +1,13 @@
 <!--
 Copyright (C) 2021 eXo Platform SAS.
-
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
-
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU Affero General Public License for more details.
-
 You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 -->
@@ -19,10 +16,10 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
     class="articleLink"
     target="_self"
     :href="item.url">
-    <div class="articleImage" :style="index > 0 && hasSmallWidthContainer && 'display: none'">
+    <div :class="`articleImage ${index > 0 && hasSmallWidthContainer && 'd-none'}`">
       <img :src="showArticleImage && item.illustrationURL !== null ? item.illustrationURL : '/news/images/news.png'" :alt="$t('news.latest.alt.articleImage')">
     </div>
-    <div :class="`articleInfos ${index > 0 && hasSmallWidthContainer && 'pa-0'}`" :style="index === 0 && hasSmallWidthContainer && 'margin: auto 15px;'">
+    <div :class="`articleInfos ${index > 0 && hasSmallWidthContainer && 'pa-0'} ${index === 0 && hasSmallWidthContainer && 'articleInfosSmallContainer'}`">
       <div class="articleSpace" v-if="!isHiddenSpace && showArticleSpace">
         <img
           class="spaceImage"

--- a/webapp/src/main/webapp/news-list-view/components/views/NewsLatestViewItem.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsLatestViewItem.vue
@@ -19,16 +19,16 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
     class="articleLink"
     target="_self"
     :href="item.url">
-    <div class="articleImage">
+    <div class="articleImage" :style="index > 0 && hasSmallWidthContainer && 'display: none'">
       <img :src="showArticleImage && item.illustrationURL !== null ? item.illustrationURL : '/news/images/news.png'" :alt="$t('news.latest.alt.articleImage')">
     </div>
-    <div class="articleInfos">
+    <div :class="`articleInfos ${index > 0 && hasSmallWidthContainer && 'pa-0'}`" :style="index === 0 && hasSmallWidthContainer && 'margin: auto 15px;'">
       <div class="articleSpace" v-if="!isHiddenSpace && showArticleSpace">
         <img
           class="spaceImage"
           :src="item.spaceAvatarUrl"
           :alt="$t('news.latest.alt.spaceImage')">
-        <span class="spaceName">{{ item.spaceDisplayName }}</span>
+        <span class="spaceName flex-shrink-1 text-truncate">{{ item.spaceDisplayName }}</span>
       </div>
       <span v-if="showArticleTitle" class="articleTitle">{{ item.title }}</span>
       <div class="articlePostTitle">
@@ -68,6 +68,16 @@ export default {
       type: Object,
       required: false,
       default: null
+    },
+    index: {
+      type: Number,
+      required: false,
+      default: null
+    },
+    hasSmallWidthContainer: {
+      type: Boolean,
+      required: false,
+      default: false
     },
     selectedOption: {
       type: Object,

--- a/webapp/src/main/webapp/skin/less/news.less
+++ b/webapp/src/main/webapp/skin/less/news.less
@@ -2759,6 +2759,9 @@
       height: 344px;
       overflow: hidden;
     }
+    .article-small-container {
+      height: 620px;
+    }
     .article {
       position: relative;
       overflow: hidden;
@@ -2799,6 +2802,9 @@
           color: @baseBackgroundDefault;
           text-shadow: 0 0 4px rgba(0, 0, 0, 0.86);
           margin: auto 15px 15px 15px;
+        }
+        .articleInfosSmallContainer {
+          margin: auto 15px;
         }
         .reactionIconStyle {
           color: @baseBackgroundDefault;


### PR DESCRIPTION
Prior to these changes, when putting the news headlines template in a small container or using mobile device, the display is wrong: only images are shown ,titles and summaries are note obviously displayed.

After these changes, the news headlines template will be well displayed vertically same as the responsive mode using small containers with keeping the same behavior in the normal cases or in case of mobile devices.