### PR TITLE
Task-57165: News mosaic template is ko if small width

### DIFF
--- a/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
+++ b/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
@@ -205,7 +205,10 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         <div id="newsTop"></div>
       </div>
 
-      <form id="newsForm" class="newsForm" onsubmit="event.preventDefault(); return false;">
+      <form
+        id="newsForm"
+        class="newsForm"
+        onsubmit="event.preventDefault(); return false;">
         <div class="newsFormInput">
           <div id="newsFormAttachment" class="newsFormAttachment">
             <div class="control-group attachments">

--- a/webapp/src/main/webapp/news-list-view/components/views/NewsMosaicView.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsMosaicView.vue
@@ -15,12 +15,12 @@ You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 -->
 <template>
-  <div id="top-news-mosaic">
+  <div id="top-news-mosaic" ref="top">
     <div :class="`mosaic-container ma-3 ${smallHeightClass}`">
       <div 
         v-for="(item, index) of news"
         :key="index"
-        class="article"
+        :class="isSmallWidth ? 'articleSmallWidth' : 'article'"
         :id="`articleItem-${index}`">
         <a
           class="articleLink"
@@ -76,6 +76,7 @@ export default {
         month: 'long',
         day: 'numeric',
       },
+      isSmallWidth: false
     };
   },
   created() {
@@ -83,13 +84,16 @@ export default {
     this.$root.$on('saved-news-settings', this.refreshNewsViews);
     this.getNewsList();
   },
+  mounted() {
+    this.isSmallWidth =  this.$refs.top?.clientWidth *100 / window.screen.width  < 33;
+  },
   computed: {
     isMobile() {
       return this.$vuetify.breakpoint.name === 'xs' || this.$vuetify.breakpoint.name === 'sm';
     },
     smallHeightClass() {
       return this.isMobile && this.news && this.news.length === 1 && 'small-mosaic-container';
-    }
+    },
   },
   methods: {
     getNewsList() {
@@ -101,6 +105,9 @@ export default {
           })
           .finally(() => this.initialized = false);
       }
+    },
+    minLength(lengthNews){
+      return lengthNews<5 && lengthNews>0 ? 100/lengthNews : 25;
     },
     refreshNewsViews(selectedTarget, selectedOption) {
       this.showArticleTitle = selectedOption.showArticleTitle;

--- a/webapp/src/main/webapp/news-list-view/components/views/NewsMosaicView.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsMosaicView.vue
@@ -107,7 +107,7 @@ export default {
       }
     },
     minLength(lengthNews){
-      return lengthNews<5 && lengthNews>0 ? 100/lengthNews : 25;
+      return lengthNews < 5 && lengthNews > 0 ? 100 / lengthNews : 25;
     },
     refreshNewsViews(selectedTarget, selectedOption) {
       this.showArticleTitle = selectedOption.showArticleTitle;

--- a/webapp/src/main/webapp/news-list-view/components/views/NewsMosaicView.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsMosaicView.vue
@@ -15,7 +15,7 @@ You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 -->
 <template>
-  <div id="top-news-mosaic" ref="top">
+  <div id="top-news-mosaic" ref="top-news-mosaic">
     <div :class="`mosaic-container ma-3 ${smallHeightClass}`">
       <div 
         v-for="(item, index) of news"
@@ -23,7 +23,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         :class="isSmallWidth ? 'articleSmallWidth' : 'article'"
         :id="`articleItem-${index}`">
         <a
-          class="articleLink"
+          class="articleLink d-block"
           target="_self"
           :href="item.url">
           <img :src="showArticleImage && item.illustrationURL !== null ? item.illustrationURL : '/news/images/news.png'" :alt="$t('news.latest.alt.articleImage')">
@@ -33,7 +33,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                 :value="new Date(item.publishDate.time)"
                 :format="dateFormat" />
             </div>
-            <div v-if="showArticleTitle" class="articleTitle">
+            <div v-if="showArticleTitle" :class="'text-truncate' + isSmallWidth ? 'articleTitle text-truncate':''">
               {{ item.title }}
             </div>
           </div>
@@ -85,7 +85,7 @@ export default {
     this.getNewsList();
   },
   mounted() {
-    this.isSmallWidth =  this.$refs.top?.clientWidth *100 / window.screen.width  < 33;
+    this.isSmallWidth =  this.$refs && this.$refs['top-news-mosaic'] && this.$refs['top-news-mosaic']?.clientWidth *100 / window.screen.width  < 33;
   },
   computed: {
     isMobile() {

--- a/webapp/src/main/webapp/skin/less/news.less
+++ b/webapp/src/main/webapp/skin/less/news.less
@@ -4738,6 +4738,22 @@ input.ignore-vuetify-classes.datePickerText.flex-grow-0 {
       -ms-grid-row-span: 1;
       grid-row: 2;
     }
+    &:nth-child(3) {
+      -ms-grid-column: 1;
+      -ms-grid-column-span: 2;
+      grid-column: ~"1/3";
+      -ms-grid-row: 3;
+      -ms-grid-row-span: 1;
+      grid-row: 3;
+    }
+    &:nth-child(4) {
+      -ms-grid-column: 1;
+      -ms-grid-column-span: 2;
+      grid-column: ~"1/3";
+      -ms-grid-row: 3;
+      -ms-grid-row-span: 1;
+      grid-row: 4;
+    }
     &:nth-child(n + 2) {
       .titleArea {
         -webkit-line-clamp: 5;
@@ -4780,7 +4796,7 @@ input.ignore-vuetify-classes.datePickerText.flex-grow-0 {
   .titleArea {
     position: absolute;
     bottom: 0;
-    margin: 15px;
+    padding: 15px;
     font-family: Helvetica, arial, sans-serif;
     font-size: 16px;
     letter-spacing: 0.2px;
@@ -4790,6 +4806,7 @@ input.ignore-vuetify-classes.datePickerText.flex-grow-0 {
     overflow: hidden;
     display: -webkit-box;
     -webkit-box-orient: vertical;
+    width: 100%;
   }
   .articleDate {
     font-size: 12px;

--- a/webapp/src/main/webapp/skin/less/news.less
+++ b/webapp/src/main/webapp/skin/less/news.less
@@ -4715,6 +4715,64 @@ input.ignore-vuetify-classes.datePickerText.flex-grow-0 {
       width: 100%;
     }
   }
+  .articleSmallWidth {
+    position: relative;
+    overflow: hidden;
+    &:nth-child(1) {
+      -ms-grid-column: 1;
+      -ms-grid-column-span: 2;
+      grid-column: ~"1/3";
+      -ms-grid-row: 3;
+      -ms-grid-row-span: 1;
+      grid-row: 1;
+    }
+    &:nth-child(2) {
+      -ms-grid-column: 1;
+      -ms-grid-column-span: 2;
+      grid-column: ~"1/3";
+      -ms-grid-row: 3;
+      -ms-grid-row-span: 1;
+      grid-row: 2;
+    }
+    &:nth-child(n + 2) {
+      .titleArea {
+        -webkit-line-clamp: 5;
+      }
+    }
+    &:nth-child(n + 5) {
+      display: none;
+    }
+    &:hover {
+      img {
+        -webkit-transform: scale(1.08);
+            -ms-transform: scale(1.08);
+                transform: scale(1.08);
+        -webkit-filter: brightness(0.25);
+                filter: brightness(0.25);
+      }
+    }
+    img {
+      max-width: 100%;
+      position: absolute;
+      left: 0;
+      right: 0;
+      top: 0;
+      bottom: 0;
+      height: 100%;
+      -o-object-fit: cover;
+        object-fit: cover;
+      width: 100%;
+      -webkit-transition: 0.4s;
+      -o-transition: 0.4s;
+      transition: 0.4s;
+      -webkit-filter: brightness(0.64);
+              filter: brightness(0.64);
+    }
+    a {
+      height: 100%;
+      width: 100%;
+    }
+  }
   .titleArea {
     position: absolute;
     bottom: 0;
@@ -4733,9 +4791,8 @@ input.ignore-vuetify-classes.datePickerText.flex-grow-0 {
     font-size: 12px;
     font-weight: normal;
     margin-bottom: 6px;
-  }
+  } 
 }
-
 /****** MOBILE VIEW ******/
 @media (max-width: 650px) {
   #top-news-mosaic {
@@ -4756,9 +4813,6 @@ input.ignore-vuetify-classes.datePickerText.flex-grow-0 {
         -ms-grid-row-span: 1;
         grid-row: 2;
       }
-    }
-    .mosaic-container {
-      height: 700px;
     }
     .small-mosaic-container {
       height: 300px;


### PR DESCRIPTION
Prior to this change, first publish 4 articles with names not truncated  , when i move latest new template in a small container or using mobile device to the right side or in a column , then  choose mosaic model , 
This is due to changing the width is small, the display is bad and names of articles are truncated.
After this change,  the article is readable , and names of articles are not truncated.