### PR TITLE
TASK-57174 : Long article title not displaying correctly in stream on mobile or small sliders

### DIFF
--- a/webapp/src/main/webapp/news-list-view/components/views/NewsSliderView.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsSliderView.vue
@@ -35,7 +35,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
           eager />
         <v-container class="slide-text-container d-flex text-center body-2">
           <div class="flex flex-column carouselNewsInfo">
-            <div class="flex flex-row" :class="!canPublishNews ? 'mt-9' : ''">
+            <div class="flex flex-row" :class="{'!canPublishNews ? `mt-9` : ``' : !$vuetify.breakpoint.xs}">
               <v-btn
                 v-if="$root.canPublishNews"
                 icon

--- a/webapp/src/main/webapp/skin/less/news.less
+++ b/webapp/src/main/webapp/skin/less/news.less
@@ -226,6 +226,10 @@
 
                 .spaceName {
                   color: @baseBackgroundDefault;
+                  display: -webkit-box;
+                  -webkit-line-clamp: 1;
+                  -webkit-box-orient: vertical;
+                  overflow: hidden;
                   font-size: 13px;
                   font-style: normal;
                 }


### PR DESCRIPTION
Prior to this change, the article title is displayed incorrectly hidden by main layout on mobile or small sliders.
To fix this, change the class `spaceName` in `news.less` and remove the marge on top in slider when it's mobile.