### PR TITLE
Task-57143: Adjust display of news headlines template using a small width container

### DIFF
--- a/webapp/src/main/webapp/news-list-view/components/views/NewsLatestView.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsLatestView.vue
@@ -15,12 +15,12 @@ You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 -->
 <template>
-  <div id="news-latest-view" class="px-2 pb-2">
-    <div class="article-container">
+  <div id="news-latest-view"  ref="news-latest-view" class="px-2 pb-2">
+    <div :class="hasSmallWidthContainer ? 'article-small-container':'article-container'">
       <div
         v-for="(item, index) of newsInfo"
         :key="item"
-        class="article"
+        :class="hasSmallWidthContainer ? 'hasSmallWidthContainer' : 'article'"
         :id="`articleItem-${index}`">
         <news-latest-view-item
           :item="item"
@@ -67,6 +67,7 @@ export default {
     showArticleSpace: false,
     showArticleDate: false,
     showArticleReactions: false,
+    hasSmallWidthContainer: false
   }),
   computed: {
     spaceAvatarUrl() {
@@ -83,6 +84,7 @@ export default {
   },
   mounted() {
     this.$nextTick().then(() => this.$root.$emit('application-loaded'));
+    this.hasSmallWidthContainer = (this.$refs['news-latest-view']?.clientWidth *100 / window.screen.width) < 33;
   },
   methods: {
     getNewsList() {

--- a/webapp/src/main/webapp/news-list-view/components/views/NewsLatestView.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsLatestView.vue
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
       <div
         v-for="(item, index) of newsInfo"
         :key="item"
-        :class="hasSmallWidthContainer ? 'hasSmallWidthContainer' : 'article'"
+        :class="hasSmallWidthContainer ? 'smallWidthContainer' : 'article'"
         :id="`articleItem-${index}`">
         <news-latest-view-item
           :item="item"

--- a/webapp/src/main/webapp/skin/less/news.less
+++ b/webapp/src/main/webapp/skin/less/news.less
@@ -2908,7 +2908,7 @@
         transform: scale(1.06);
       }
     }
-    .hasSmallWidthContainer {
+    .smallWidthContainer {
         position: relative;
         overflow: hidden;
         &:first-child {

--- a/webapp/src/main/webapp/skin/less/news.less
+++ b/webapp/src/main/webapp/skin/less/news.less
@@ -2759,6 +2759,11 @@
       height: 344px;
       overflow: hidden;
     }
+    .article-small-container{
+      display: grid;
+      height: 528px !important;
+      gap: 15px !important;
+    }
     .article {
       position: relative;
       overflow: hidden;
@@ -2766,21 +2771,21 @@
         .articleSpace {
           margin-bottom: 10px;
         }
-        hover {
+        &:hover {
           .articleTitle {
             text-decoration-thickness: 3px;
             text-decoration: underline;
             text-underline-offset: 3px;
           }
         }
-        focus {
+        &:focus {
           .articleTitle {
             text-decoration-thickness: 3px;
             text-decoration: underline;
             text-underline-offset: 3px;
           }
         }
-        active {
+        &:active {
           .articleTitle {
             text-decoration-thickness: 3px;
             text-decoration: underline;
@@ -2903,6 +2908,151 @@
         transform: scale(1.06);
       }
     }
+    .hasSmallWidthContainer {
+        position: relative;
+        overflow: hidden;
+        &:first-child {
+          .articleSpace {
+            margin-bottom: 10px;
+          }
+          hover {
+            .articleTitle {
+              text-decoration-thickness: 3px;
+              text-decoration: underline;
+              text-underline-offset: 3px;
+            }
+          }
+          focus {
+            .articleTitle {
+              text-decoration-thickness: 3px;
+              text-decoration: underline;
+              text-underline-offset: 3px;
+            }
+          }
+          active {
+            .articleTitle {
+              text-decoration-thickness: 3px;
+              text-decoration: underline;
+              text-underline-offset: 3px;
+            }
+          }
+          .articleTitle {
+            margin-bottom: 14px;
+          }
+        }
+        &:nth-child(1) {
+          grid-column: 1/3;
+          grid-row: 1/3;
+          .articleInfos {
+            position: relative;
+            color: @baseBackgroundDefault;
+            text-shadow: 0 0 4px rgba(0, 0, 0, 0.86);
+            margin: auto 15px 15px 15px;
+          }
+          .reactionIconStyle {
+            color: @baseBackgroundDefault;
+          }
+          .articleTitle {
+            font-size: 18px;
+            line-height: 32px;
+            color: @baseBackgroundDefault;
+            overflow: hidden;
+            display: -webkit-box;
+            -webkit-box-orient: vertical;
+            -webkit-line-clamp: 1;
+          }
+        }
+        &:nth-child(n + 2) {
+          grid-column: 1/3;
+          .articleImage {
+            position: relative;
+            display: inline-block;
+            float: left;
+            overflow: hidden;
+            height: 107px;
+            min-width: 107px;
+            img {
+              filter: brightness(1);
+            }
+          }
+          .articleInfos {
+            position: relative;
+            display: flex;
+            flex-direction: column;
+            justify-content: start;
+            height: 96px;
+            background: #fff;
+            margin: 0;
+            padding: 0 0 0 12px;
+          }
+          .articleTitle {
+            line-height: 20px;
+            overflow: hidden;
+            display: -webkit-box;
+            -webkit-box-orient: vertical;
+            -webkit-line-clamp: 1;
+          }
+        }
+        &:nth-child(n + 5) {
+          display: none;
+        }
+        &:nth-child(n + 2) {
+          .spaceImage {
+            display: none;
+          }
+        }
+        &:hover {
+          .articleTitle {
+            text-decoration-thickness: 2px;
+            text-decoration: underline;
+            text-underline-offset: 2px;
+          }
+          .articleImage {
+            img {
+              -ms-transform: scale(1.06);
+              -webkit-transform: scale(1.06);
+              transform: scale(1.06);
+            }
+          }
+        }
+        &:focus {
+          .articleTitle {
+            text-decoration-thickness: 2px;
+            text-decoration: underline;
+            text-underline-offset: 2px;
+          }
+        }
+        &:active {
+          .articleTitle {
+            text-decoration-thickness: 2px;
+            text-decoration: underline;
+            text-underline-offset: 2px;
+          }
+        }
+        .articleImage img {
+          max-width: 100%;
+          position: absolute;
+          left: 0;
+          right: 0;
+          top: 0;
+          bottom: 0;
+          height: 100%;
+          -o-object-fit: cover;
+          object-fit: cover;
+          width: 100%;
+          -webkit-transition: 0.4s;
+          -o-transition: 0.4s;
+          transition: 0.4s;
+          -webkit-filter: brightness(0.61);
+          filter: brightness(0.61);
+        }
+        &:hover .articleImage img {
+          -webkit-transform: scale(1.06);
+          -ms-transform: scale(1.06);
+          transform: scale(1.06);
+        }
+    }
+  }
     .articleLink {
       position: absolute;
       display: flex;
@@ -2927,7 +3077,7 @@
       display: flex;
       align-items: center;
       width: 100%;
-      line-height: 12px;
+      line-height: 1.5;
       overflow: hidden;
       white-space: nowrap;
       text-overflow: ellipsis;
@@ -2981,8 +3131,6 @@
       width: 100%;
     }
   }
-}
-
 /*========================= Skeleton CLV ======================*/
 .skeletonContainer {
   display: inline-flex;


### PR DESCRIPTION
Prior to these changes, when putting the news headlines template in a small container or using mobile device, the display is wrong: only images are shown ,titles and summaries are note obviously displayed.

After these changes, the news headlines template will be well displayed vertically same as the responsive mode using small containers with keeping the same behavior in the normal cases or in case of mobile devices.