### PR TITLE
TASK-51495: Fix Copy and paste a document from Google Doc into an aricle

### DIFF
--- a/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
+++ b/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
@@ -532,7 +532,7 @@ export default {
       CKEDITOR.plugins.addExternal('switchView','/news/js/ckeditor/plugins/switchView/','plugin.js');
       CKEDITOR.plugins.addExternal('attachFile','/news/js/ckeditor/plugins/attachment/','plugin.js');
       CKEDITOR.dtd.$removeEmpty['i'] = false;
-      let extraPlugins = 'sharedspace,simpleLink,suggester,font,justify,widget,video,switchView,attachFile';
+      let extraPlugins = 'sharedspace,simpleLink,suggester,font,justify,widget,video,switchView,attachFile,googleDocPastePlugin';
       let removePlugins = 'image,confirmBeforeReload,maximize,resize,embedsemantic';
       const windowWidth = $(window).width();
       const windowHeight = $(window).height();


### PR DESCRIPTION
ISSUES : When we copy a text from a google Doc and paste it in article ,The content is bolded automatically.
FIX : add googleDocPastePlugin plugin to extraPlugins of ckeditor which allows pasting content from google docs to ckeditor in the same format.
(cherry picked from commit c7c9e3d51dd34f857f50456ed0a29484cfdbef34)