### PR TITLE
Task-58319: Article names are black when using Mosaic template

### DIFF
--- a/webapp/src/main/webapp/skin/less/news.less
+++ b/webapp/src/main/webapp/skin/less/news.less
@@ -3095,8 +3095,6 @@
     .articleTitle {
       display: block;
       width: 100%;
-      font-size: 16px;
-      color: @textColorDefault;
       margin-bottom: 6px;
       transition: 0.3s;
     }


### PR DESCRIPTION
Problem: Article names are black when using Mosaic template.
Fix: delete color black for className.