### PR TITLE
Task-57154: Spaces names are forced in Upper characters in newslist 

### DIFF
--- a/webapp/src/main/webapp/news-list-view/components/views/NewsLatestViewItem.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsLatestViewItem.vue
@@ -28,7 +28,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
           class="spaceImage"
           :src="item.spaceAvatarUrl"
           :alt="$t('news.latest.alt.spaceImage')">
-        <span class="text-capitalize spaceName">{{ item.spaceDisplayName }}</span>
+        <span class="spaceName">{{ item.spaceDisplayName }}</span>
       </div>
       <span v-if="showArticleTitle" class="articleTitle">{{ item.title }}</span>
       <div class="articlePostTitle">

--- a/webapp/src/main/webapp/news-list-view/components/views/NewsSliderViewItem.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsSliderViewItem.vue
@@ -39,7 +39,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
           alt="Space icon" />
       </v-avatar>
       <a :href="spaceUrl" class="my-auto">
-        <span class="text-capitalize my-auto spaceName ml-2">{{ spaceDisplayName }}</span>
+        <span class="my-auto spaceName ml-2">{{ spaceDisplayName }}</span>
       </a>
     </div>
     <div v-if="showArticleDate" class="date-container d-flex">


### PR DESCRIPTION
Prior to this change, when a create spaces with space name containing more then one word then publish articles in those spaces
check news stream,
This is due to changing with upper characters on every word on snapshot Latest News template or slider template,
After this change, the name of space is displayed normally ( without upper characters on every word ).

(cherry picked from commit 58af43a5466efccdcf9dd680ea778aba757e0f30)