### PR TITLE
TASK-58627: Long article title not displaying correctly in stream on mobile or small sliders

### DIFF
--- a/webapp/src/main/webapp/news-list-view/components/views/NewsSliderView.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsSliderView.vue
@@ -47,8 +47,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
             <a
               v-if="showArticleTitle"
               :href="item.url"
-              class="flex flex-row flex-grow-1 align-center justify-center slider-header">
-              <span class="articleTitle text-h4 font-weight-medium white--text">
+              class="flex flex-row flex-grow-1 align-center justify-center headLinesTruncate slider-header">
+              <span class="text-h4 font-weight-medium white--text">
                 {{ item.title }}
               </span>
             </a>

--- a/webapp/src/main/webapp/skin/less/news.less
+++ b/webapp/src/main/webapp/skin/less/news.less
@@ -15,6 +15,15 @@
 /*============== Activity News ====================*/
 
 .VuetifyApp {
+  .headLinesTruncate {
+    color: @baseBackgroundDefault !important;
+    display: -webkit-box !important;
+    -webkit-line-clamp: 1 !important;
+    -webkit-box-orient: vertical !important;
+    overflow: hidden !important;
+    font-size: 13px !important;
+    font-style: normal !important;
+  }
   #newsDetailApp {
     padding: 10px 8%;
     .articleNotFound {
@@ -226,10 +235,6 @@
 
                 .spaceName {
                   color: @baseBackgroundDefault;
-                  display: -webkit-box;
-                  -webkit-line-clamp: 1;
-                  -webkit-box-orient: vertical;
-                  overflow: hidden;
                   font-size: 13px;
                   font-style: normal;
                 }


### PR DESCRIPTION
Prior to this change, the article title is displayed incorrectly hidden by main layout on mobile or small sliders.
To fix this, change the class `spaceName` in news.less and remove the marge on top in slider when it's mobile.