### PR TITLE
TASK-58627: Adjust sliderNewsContainer

### DIFF
--- a/webapp/src/main/webapp/skin/less/news.less
+++ b/webapp/src/main/webapp/skin/less/news.less
@@ -13,7 +13,11 @@
 
 
 /*============== Activity News ====================*/
-
+#SliderContainerChildren {
+  .PORTLET-FRAGMENT {
+    max-width:100%;
+  }
+}  
 .VuetifyApp {
   .headLinesTruncate {
     color: @baseBackgroundDefault !important;


### PR DESCRIPTION
`Prior` to this change, the content of `sliderNewsContainer` is not displaying correctly.
To fix this, remove the style (width) implied by the `sliderNewsContainer` container on the content.