### PR TITLE
TASK-56899: Enhance latest news portlet and news illustration images load time 

### DIFF
--- a/services/src/main/java/org/exoplatform/news/service/impl/NewsServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/service/impl/NewsServiceImpl.java
@@ -291,6 +291,7 @@ public class NewsServiceImpl implements NewsService {
       try {
         News news = getNewsById(target.getObjectId(), currentIdentity, false);
         news.setPublishDate(new Date(target.getCreatedDate()));
+        news.setIllustration(null);
         return news;
       } catch (Exception e) {
         return null;

--- a/services/src/main/java/org/exoplatform/news/storage/jcr/JcrNewsStorage.java
+++ b/services/src/main/java/org/exoplatform/news/storage/jcr/JcrNewsStorage.java
@@ -480,7 +480,8 @@ public class JcrNewsStorage implements NewsStorage {
       byte[] bytes = IOUtils.toByteArray(illustrationContentNode.getProperty("jcr:data").getStream());
       news.setIllustration(bytes);
       news.setIllustrationUpdateDate(illustrationContentNode.getProperty("exo:dateModified").getDate().getTime());
-      news.setIllustrationURL("/portal/rest/v1/news/" + news.getId() + "/illustration");
+      long lastModified = news.getIllustrationUpdateDate().getTime();
+      news.setIllustrationURL("/portal/rest/v1/news/" + news.getId() + "/illustration?v=" + lastModified);
     }
 
     news.setAttachments(newsAttachmentsService.getNewsAttachments(node));

--- a/services/src/test/java/org/exoplatform/news/rest/NewsRestResourcesV1Test.java
+++ b/services/src/test/java/org/exoplatform/news/rest/NewsRestResourcesV1Test.java
@@ -2299,7 +2299,7 @@ public class NewsRestResourcesV1Test {
     lenient().when(request.getRemoteUser()).thenReturn("john");
 
     // When
-    Response response = newsRestResourcesV1.getNewsIllustration(rsRequest, request, "1");
+    Response response = newsRestResourcesV1.getNewsIllustration(rsRequest, request, "1", 2316465L);
 
     // Then
     assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());

--- a/webapp/src/main/webapp/news-list-view/components/NewsListView.vue
+++ b/webapp/src/main/webapp/news-list-view/components/NewsListView.vue
@@ -93,7 +93,7 @@ export default {
   data: () => ({
     extensionApp: 'NewsList',
     extensionType: 'views',
-    newsList: ['emptyNews'],
+    newsList: [null],
     viewExtensions: {},
     loading: false,
     hasMore: false,
@@ -144,6 +144,7 @@ export default {
         showArticleDate: this.showArticleDate,
         seeAllUrl: this.seeAllUrl,
         hasMore: this.hasMore,
+        loading: this.loading,
       };
     },
   },

--- a/webapp/src/main/webapp/news-list-view/components/views/NewsSliderView.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsSliderView.vue
@@ -85,11 +85,15 @@ export default {
       required: false,
       default: 'snapshotSliderNews'
     },
+    newsList: {
+      type: Array,
+      default: () => {
+        return [];
+      }
+    },
   },
   data () {
     return {
-      news: [],
-      initialized: false,
       limit: 4,
       offset: 0,
       fullDateFormat: {
@@ -115,21 +119,15 @@ export default {
   created() {
     this.reset();
     this.$root.$on('saved-news-settings', this.refreshNewsViews);
-    this.getNewsList();
+  },
+  computed: {
+    news(){
+      return this.newsList && this.newsList.filter(news => !!news);
+    }
   },
   methods: {
     openDrawer() {
       this.$root.$emit('news-settings-drawer-open');
-    },
-    getNewsList() {
-      if (!this.initialized) {
-        this.$newsListService.getNewsList(this.newsTarget, this.offset, this.limit, true)
-          .then(newsList => {
-            this.news = newsList.news.filter(news => !!news);
-            this.initialized = true;
-          })
-          .finally(() => this.initialized = false);
-      }
     },
     refreshNewsViews(selectedTarget, selectedOption){
       this.showArticleSummary = selectedOption.showArticleSummary;

--- a/webapp/src/main/webapp/news/components/NewsApp.vue
+++ b/webapp/src/main/webapp/news/components/NewsApp.vue
@@ -221,12 +221,11 @@ export default {
         const newsPublicationDate = item.publicationDate != null ? new Date(item.publicationDate.time) : null;
         const newsUpdateDate = new Date(item.updateDate.time);
         const newsIllustration = item.illustrationURL == null ? '/news/images/news.png' : item.illustrationURL;
-        const newsIllustrationUpdatedTime = item.illustrationUpdateDate == null ? '' : item.illustrationUpdateDate.time;
         const activityId = item.activities ? item.activities.split(';')[0].split(':')[1] : '';
         result.push({
           newsId: item.id,
           newsText: this.getNewsText(item.summary, item.body),
-          illustrationURL: `${newsIllustration}?${newsIllustrationUpdatedTime}`,
+          illustrationURL: newsIllustration,
           title: item.title,
           updatedDate: this.isDraftsFilter ? newsPublicationDate : newsUpdateDate,
           spaceDisplayName: item.spaceDisplayName,

--- a/webapp/src/main/webapp/skin/less/news.less
+++ b/webapp/src/main/webapp/skin/less/news.less
@@ -3056,6 +3056,9 @@
           transform: scale(1.06);
         }
     }
+    .loader {
+      margin: auto
+    }
   }
     .articleLink {
       position: absolute;


### PR DESCRIPTION
Prior to this change, a duplicated rest calls to retrieve the latest news each one took a lot of time to finish, a huge size of the retrieved data because of the retrieved binary contents of the illustration images and a lack of CacheControl use in illustrations rest endpoint.
This PR should :

Fix the duplicated rest call for both latest news and news slider
Avoid retrieving the binary contents of the illustration images
Add CacheControl use while serving the news illustration images and use image/webp as mimeType for the cached images
content.