### PR TITLE
MEED-300: Fix Information message display for each news bookmarking from US

### DIFF
--- a/webapp/src/main/webapp/news-details/components/ExoNewsFavoriteAction.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsFavoriteAction.vue
@@ -75,11 +75,10 @@ export default {
       this.displayAlert(this.$t('Favorite.tooltip.ErrorAddingAsFavorite', {0: this.$t('news.label')}), 'error');
     },
     displayAlert(message, type) {
-      this.$root.$emit('news-notification-alert', {
-        activityId: this.activityId,
+      document.dispatchEvent(new CustomEvent('notification-alert', {detail: {
         message,
         type: type || 'success',
-      });
+      }}));
     },
   },
 };

--- a/webapp/src/main/webapp/news-extensions/components/favorites/NewsFavoriteItem.vue
+++ b/webapp/src/main/webapp/news-extensions/components/favorites/NewsFavoriteItem.vue
@@ -53,11 +53,10 @@ export default {
       this.displayAlert(this.$t('Favorite.tooltip.ErrorDeletingFavorite', {0: this.$t('news.label')}), 'error');
     },
     displayAlert(message, type) {
-      this.$root.$emit('news-notification-alert', {
-        activityId: this.id,
+      document.dispatchEvent(new CustomEvent('notification-alert', {detail: {
         message,
         type: type || 'success',
-      });
+      }}));
     },
   }
 };

--- a/webapp/src/main/webapp/news-list-view/components/views/NewsLatestView.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsLatestView.vue
@@ -15,7 +15,10 @@ You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 -->
 <template>
-  <div id="news-latest-view"  ref="news-latest-view" class="px-2 pb-2">
+  <div
+    id="news-latest-view"
+    ref="news-latest-view"
+    class="px-2 pb-2">
     <div :class="hasSmallWidthContainer ? 'article-small-container':'article-container'">
       <v-progress-circular
         v-if="loading"


### PR DESCRIPTION
Before this change, when clicking on the favorite button in news search card from the unified search there is no alert message displayed.
This PR allows to use the common notification alert for the news search card.