### PR TITLE
Task-59112 : Fix alert message when adding a news to favorite on search result

### DIFF
--- a/webapp/src/main/webapp/news-details/components/ExoNewsFavoriteAction.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsFavoriteAction.vue
@@ -75,11 +75,10 @@ export default {
       this.displayAlert(this.$t('Favorite.tooltip.ErrorAddingAsFavorite', {0: this.$t('news.label')}), 'error');
     },
     displayAlert(message, type) {
-      this.$root.$emit('news-notification-alert', {
-        activityId: this.activityId,
+      document.dispatchEvent(new CustomEvent('notification-alert', {detail: {
         message,
         type: type || 'success',
-      });
+      }}));
     },
   },
 };


### PR DESCRIPTION
ISSUE : when user clicking on favorite icon in news search card from the unified search is no alert message displayed .
FIX : update the displayAlert method to use the common notification alert for the news search card.