### PR TITLE
TASK-59071: Empty Email notification info area , after sharing a short message or  article from space stream to another (#633)

### DIFF
--- a/services/src/main/java/org/exoplatform/news/service/impl/NewsServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/service/impl/NewsServiceImpl.java
@@ -469,7 +469,7 @@ public class NewsServiceImpl implements NewsService {
     Identity spaceIdentity = identityManager.getOrCreateIdentity(SpaceIdentityProvider.NAME, space.getPrettyName());
 
     ExoSocialActivity activity = new ExoSocialActivityImpl();
-    activity.setTitle("");
+    activity.setTitle(news.getTitle());
     activity.setType("news");
     activity.setUserId(poster.getId());
     activity.isHidden(news.isActivityPosted());


### PR DESCRIPTION
Prior this change, when sharing post from space to other space , template mail not displayed the title or summary of news where shared , so the template email is applied to add a short message or an article , setTitle("") always empty so i cant get the title by getActivity(activityId) so i recovery the title
Task related :
Meeds-io/social#1727