### PR TITLE
TASK-59318: News information aren't displayed as intended

### DIFF
--- a/webapp/src/main/webapp/skin/less/news.less
+++ b/webapp/src/main/webapp/skin/less/news.less
@@ -3064,6 +3064,10 @@
     .loader {
       margin: auto
     }
+    .articleLink {
+      position: absolute !important;
+      display: flex !important;
+    }
   }
     .articleLink {
       text-decoration: none;


### PR DESCRIPTION
Prior to this change, items not displayed correctly in latest news post bloc in snapshot page to Headlines. To fix this, add styles in the articleLink CSS class.

(cherry picked from commit 3241388e20e57a7d227d937284204d000fbacd7e)