### PR TITLE
Task-59112: Revert backport commit of Task-59112

### DIFF
--- a/webapp/src/main/webapp/news-details/components/ExoNewsFavoriteAction.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsFavoriteAction.vue
@@ -80,9 +80,7 @@ export default {
         message,
         type: type || 'success',
       });
-
     },
-
   },
 };
 </script>

--- a/webapp/src/main/webapp/news-details/components/ExoNewsFavoriteAction.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsFavoriteAction.vue
@@ -75,11 +75,14 @@ export default {
       this.displayAlert(this.$t('Favorite.tooltip.ErrorAddingAsFavorite', {0: this.$t('news.label')}), 'error');
     },
     displayAlert(message, type) {
-      document.dispatchEvent(new CustomEvent('notification-alert', {detail: {
+      this.$root.$emit('news-notification-alert', {
+        activityId: this.activityId,
         message,
         type: type || 'success',
-      }}));
+      });
+
     },
+
   },
 };
 </script>


### PR DESCRIPTION
Prior this change, the [backport commit](https://github.com/exoplatform/news/commit/5ab014ade636e4918971c6c2e7f5b97c1ed91334) of Task-59112 causes a regression for dispalying alert message for favorite news detail and not fixes the initial problem. So this commit will revert the backport commit.