### PR TITLE
Patch-6.3.1-1 : 

### DIFF
--- a/patches-changelog.txt
+++ b/patches-changelog.txt
@@ -1,5 +1,9 @@
               2022-09-14 eXo Support <support@exoplatform.org> 
 
    # 2.3.1 Patches changelog: 
+   
+   * 2022-09-14: Patch-6.3.1:1, Author: Jihed Chabbeh<jchabbeh@exoplatform.com>
+
+   - https://github.com/exoplatform/news/commit/68014fa1ef580142ea16cef4cb212a0b69ea4dcf
 
 

--- a/webapp/src/main/webapp/skin/less/news.less
+++ b/webapp/src/main/webapp/skin/less/news.less
@@ -3064,6 +3064,10 @@
     .loader {
       margin: auto
     }
+    .articleLink {
+      position: absolute !important;
+      display: flex !important;
+    }
   }
     .articleLink {
       text-decoration: none;


### PR DESCRIPTION
Prior to this change, items not displayed correctly in latest news post bloc in snapshot page to Headlines. To fix this, add styles in the articleLink CSS class.

(cherry picked from commit https://github.com/exoplatform/news/commit/3241388e20e57a7d227d937284204d000fbacd7e)