### PR TITLE
fix: Prevent display of alert template when there is no related articles - TASK-56232

### DIFF
--- a/webapp/src/main/webapp/news-list-view/components/views/NewsAlertView.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsAlertView.vue
@@ -15,12 +15,12 @@ You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 -->
 <template>
-  <div id="critical-alerts-slider">
+  <div id="critical-alerts-slider" v-show="!emptyTemplate">
     <div class="alerts-header">
       <div class="alerts-icon">
         <v-icon>warning</v-icon>
       </div>
-      <span class="d-none d-md-block" v-if="!emptyTemplate && showHeader">{{ newsHeader }}</span>
+      <span class="d-none d-md-block" v-if="showHeader">{{ newsHeader }}</span>
     </div>
 
     <div class="alerts-viewer ps-5 flex-grow-1">
@@ -30,8 +30,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         cycle
         :show-arrows="false"
         interval="10000"
-        height="20"
-        v-if="!emptyTemplate">
+        height="20">
         <v-carousel-item
           v-for="(item,i) in news"
           :key="i">
@@ -53,14 +52,12 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
     <div class="slider-buttons d-flex pe-2">
       <v-btn
         @click="slider--"
-        icon
-        :disabled="emptyTemplate">
+        icon>
         <v-icon>chevron_left</v-icon>
       </v-btn>
       <v-btn
         @click="slider++"
-        icon
-        :disabled="emptyTemplate">
+        icon>
         <v-icon>chevron_right</v-icon>
       </v-btn>
       <v-btn
@@ -84,6 +81,7 @@ export default {
   },
   data () {
     return {
+      containerNewsAlertView: [],
       slider: 0,
       news: [],
       initialized: false,
@@ -120,6 +118,12 @@ export default {
     this.getNewsList();
   },
   methods: {
+    disabledContainerNewsAlertView(element,index){
+      const el = element.querySelector('#critical-alerts-slider');
+      if (el){
+        this.containerNewsAlertView[index].style.display='none';
+      }
+    },
     openDrawer() {
       this.$root.$emit('news-settings-drawer-open');
     },
@@ -130,7 +134,13 @@ export default {
             this.news = newsList.news.filter(news => !!news);
             this.initialized = true;
           })
-          .finally(() => this.initialized = false);
+          .finally(() => {
+            if (this.emptyTemplate) {
+              this.containerNewsAlertView = document.getElementsByClassName('UIWindow DefaultTheme UIDragObject UIResizeObject');
+              this.containerNewsAlertView.forEach((element,index) => this.disabledContainerNewsAlertView(element,index));
+            }
+            this.initialized = false;
+          });
       }
     },
     refreshNewsViews(selectedTarget, selectedOption) {


### PR DESCRIPTION
Prior to this change, if there is no articles related to such template, the whole template's bloc is displayed.
After this change, the Alerts block is no more displayed in this case.