### PR TITLE
fix: Fix news search with apostrophe and double quote - EXO-59689

### DIFF
--- a/services/src/main/java/org/exoplatform/news/queryBuilder/NewsQueryBuilder.java
+++ b/services/src/main/java/org/exoplatform/news/queryBuilder/NewsQueryBuilder.java
@@ -3,6 +3,7 @@ package org.exoplatform.news.queryBuilder;
 import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
+
 import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.news.filter.NewsFilter;
 import org.exoplatform.news.utils.NewsUtils;
@@ -51,9 +52,9 @@ public class NewsQueryBuilder {
                     .append("')) AND ");
           }
         }
-
         if (filter.getSearchText() != null && !filter.getSearchText().equals("")) {
-          sqlQuery.append("CONTAINS(.,'").append(filter.getSearchText()).append("') AND ");
+          String escapedQuoteSearchText = filter.getSearchText().replace("'", "''").replace("\"", "\"\"");
+          sqlQuery.append("CONTAINS(.,'").append(escapedQuoteSearchText).append("') AND ");
         }
         if (filter.isPublishedNews()) {
           sqlQuery.append("exo:pinned = 'true' AND ");


### PR DESCRIPTION

Prior to this change, news search based on a search text with apostrophe and double quote is not possible due to a malformed generated sql query. After this commit, we escape will escape apostrophe and double quote from the sql query in order to perform searching correctly.