### PR TITLE
fix: Fix missing number of reactions per period in contents analytics report - EXO-60102

### DIFF
--- a/services/src/main/java/org/exoplatform/news/listener/NewsActivityListener.java
+++ b/services/src/main/java/org/exoplatform/news/listener/NewsActivityListener.java
@@ -71,7 +71,7 @@ public class NewsActivityListener extends ActivityListenerPlugin {
 
   @Override
   public void likeActivity(ActivityLifeCycleEvent event) {
-    ExoSocialActivity activity = event.getActivity();
+    ExoSocialActivity activity = activityManager.getActivity(event.getActivity().getId());
     if (activity != null && activity.getTemplateParams() != null && activity.getTemplateParams().containsKey(NEWS_ID)) {
       org.exoplatform.services.security.Identity currentIdentity = ConversationState.getCurrent().getIdentity();
       try {
@@ -85,11 +85,11 @@ public class NewsActivityListener extends ActivityListenerPlugin {
 
   @Override
   public void saveComment(ActivityLifeCycleEvent event) {
-    ExoSocialActivity activity = event.getActivity();
+    ExoSocialActivity activity = activityManager.getActivity(event.getActivity().getParentId());
     if (activity != null && activity.getTemplateParams() != null && activity.getTemplateParams().containsKey(NEWS_ID)) {
       org.exoplatform.services.security.Identity currentIdentity = ConversationState.getCurrent().getIdentity();
       try {
-        News news = newsService.getNewsByActivityId(activity.getParentId(), currentIdentity);
+        News news = newsService.getNewsByActivityId(activity.getId(), currentIdentity);
         NewsUtils.broadcastEvent(NewsUtils.COMMENT_NEWS, currentIdentity.getUserId(), news);
       } catch (Exception e) {
         LOG.error("Error broadcast comment news event", e);


### PR DESCRIPTION
Prior to this change, the number of reactions per period in the content analysis report is not incremented when we like or comment on a post. This is caused by the event.getActivity() object passed to the NewsActivityListener whose templateParams is null and doesn't contain NEWS_ID param. After this fix, we retrieve the right stored news activity containing the needed template param based on the id of event.getActivity() which allows to broadcast the needed analytics events LIKE_NEWS and COMMENT_NEWS.

(cherry picked from commit https://github.com/exoplatform/news/commit/a4fdacc8b3a6c7457ab8a1d2b238c52a256539df)