### PR TITLE
fix: Display right views number and publication/modfication dates for an already posted article whith current draft publication state - EXO-57681 (#652)

### DIFF
--- a/services/src/main/java/org/exoplatform/news/storage/jcr/JcrNewsStorage.java
+++ b/services/src/main/java/org/exoplatform/news/storage/jcr/JcrNewsStorage.java
@@ -397,9 +397,9 @@ public class JcrNewsStorage implements NewsStorage {
     news.setOriginalBody(sanitizedBody);
     news.setAuthor(getStringProperty(node, "exo:author"));
     news.setCreationDate(getDateProperty(node, "exo:dateCreated"));
-    news.setPublicationDate(getPublicationDate(node));
+    news.setPublicationDate(getPublicationDate(originalNode));
     news.setUpdater(getLastUpdater(originalNode));
-    news.setUpdateDate(getLastUpdatedDate(node));
+    news.setUpdateDate(getLastUpdatedDate(originalNode));
     news.setDraftUpdater(getStringProperty(originalNode, EXO_NEWS_LAST_MODIFIER));
     news.setDraftUpdateDate(getDateProperty(node, "exo:dateModified"));
     news.setPath(getPath(node));
@@ -469,11 +469,11 @@ public class JcrNewsStorage implements NewsStorage {
     if (node.hasProperty(AuthoringPublicationConstant.START_TIME_PROPERTY)) {
       news.setSchedulePostDate(node.getProperty(AuthoringPublicationConstant.START_TIME_PROPERTY).getString());
     }
-    if (!node.hasProperty("exo:viewsCount")) {
+    if (!originalNode.hasProperty("exo:viewsCount")) {
       news.setViewsCount(0L);
     } 
     else {
-      news.setViewsCount(node.getProperty("exo:viewsCount").getLong());
+      news.setViewsCount(originalNode.getProperty("exo:viewsCount").getLong());
     }
     if (node.hasNode("illustration")) {
       Node illustrationContentNode = node.getNode("illustration").getNode("jcr:content");


### PR DESCRIPTION

Prior to this change, after editing an already posted article without saving, the displayed views number and the dates of publication and modification are those of the last published version instead of the current draft version. After this commit, we ensure to get these informations from the current draft version instead of the the last published version.

(cherry picked from commit https://github.com/exoplatform/news/commit/78502ef7a6ae3a7efca61c44f22aa8724f369c1b)