### PR TITLE
feat: News List template: use correct size for illustrations -EXO-60461

### DIFF
--- a/webapp/src/main/webapp/news-list-view/components/views/NewsCardsViewItem.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsCardsViewItem.vue
@@ -147,7 +147,7 @@ export default {
       return this.selectedOption && this.selectedOption.showArticleSpace;
     },
     articleImage() {
-      return (this.showArticleImage && this.item?.illustrationURL) || '/news/images/news.png';
+      return (this.showArticleImage && this.item?.illustrationURL.concat('&size=235x140').toString()) || '/news/images/news.png';
     },
     isHiddenSpace() {
       return this.item && !this.item.spaceMember && this.item.hiddenSpace;

--- a/webapp/src/main/webapp/news-list-view/components/views/NewsLatestViewItem.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsLatestViewItem.vue
@@ -19,8 +19,13 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
     class="articleLink"
     target="_self"
     :href="item.url">
-    <div class="articleImage">
-      <img :src="showArticleImage && item.illustrationURL !== null ? item.illustrationURL : '/news/images/news.png'" :alt="$t('news.latest.alt.articleImage')">
+    <div 
+      :id="`image-${item.id}`"
+      class="articleImage">
+      <img :src="showArticleImage && item.illustrationURL !== null 
+        ? $newsListService.illustrationURLResize(item.illustrationURL, `#news-latest-view #image-${item.id}`)
+        : '/news/images/news.png'" 
+        :alt="$t('news.latest.alt.articleImage')">
     </div>
     <div class="articleInfos">
       <div class="articleSpace" v-if="!isHiddenSpace && showArticleSpace">

--- a/webapp/src/main/webapp/news-list-view/components/views/NewsListTemplateViewItem.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsListTemplateViewItem.vue
@@ -105,7 +105,7 @@ export default {
       return this.selectedOption?.showArticleReactions;
     },
     articleImage() {
-      return (this.showArticleImage && this.item?.illustrationURL) || '/news/images/news.png';
+      return (this.showArticleImage && this.item?.illustrationURL.concat('&size=70x70').toString()) || '/news/images/news.png';
     },
   },
 };

--- a/webapp/src/main/webapp/news-list-view/components/views/NewsMosaicView.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsMosaicView.vue
@@ -26,7 +26,10 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
           class="articleLink d-block"
           target="_self"
           :href="item.url">
-          <img :src="showArticleImage && item.illustrationURL !== null ? item.illustrationURL : '/news/images/news.png'" :alt="$t('news.latest.alt.articleImage')">
+          <img :src="showArticleImage && item.illustrationURL !== null ? 
+            $newsListService.illustrationURLResize(item.illustrationURL, `#top-news-mosaic #articleItem-${index}`)
+            : '/news/images/news.png'" 
+            :alt="$t('news.latest.alt.articleImage')">
           <div class="titleArea">
             <div v-if="showArticleDate" class="articleDate">
               <date-format

--- a/webapp/src/main/webapp/news-list-view/components/views/NewsSliderView.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsSliderView.vue
@@ -31,7 +31,9 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         dark>
         <v-img
           class="articleImage fill-height"
-          :src="showArticleImage && item.illustrationURL !== null ? item.illustrationURL : '/news/images/news.png'"
+          :src="showArticleImage && item.illustrationURL !== null
+          ? $newsListService.illustrationURLResize(item.illustrationURL, '.sliderNewsItems')
+          : '/news/images/news.png'"
           eager />
         <v-container class="slide-text-container d-flex text-center body-2">
           <div class="flex flex-column carouselNewsInfo">

--- a/webapp/src/main/webapp/news-list-view/components/views/NewsStoriesViewItem.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsStoriesViewItem.vue
@@ -107,7 +107,7 @@ export default {
       return this.selectedOption && this.selectedOption.showArticleImage;
     },
     articleImage() {
-      return this.showArticleImage && this.item.illustrationURL !== null ? this.item.illustrationURL : '/news/images/news.png';
+      return this.showArticleImage && this.item.illustrationURL !== null ? this.item.illustrationURL.concat('&size=140x210').toString() : '/news/images/news.png';
     }
   }
 };

--- a/webapp/src/main/webapp/news-list-view/js/NewsListService.js
+++ b/webapp/src/main/webapp/news-list-view/js/NewsListService.js
@@ -52,3 +52,11 @@ export function saveSettings(saveSettingsURL, settings) {
     }
   });
 }
+
+export function illustrationURLResize(illustrationURL, querySelector) {
+  const element = querySelector ? document.querySelector(querySelector) : null;
+  if (element && illustrationURL) {
+    return illustrationURL.concat('&size=')
+      .concat(element.clientWidth).concat('x').concat(element.clientHeight).toString();
+  }
+}


### PR DESCRIPTION
Prior to this change, the size for illustrations in the templates lists news is still required at the original size of the image. After this change, the size of the illustrations is updated for the correct size.