### PR TITLE
feat: update illustration size : EXO-60463 (#659)

### DIFF
--- a/webapp/src/main/webapp/news/components/NewsAppItem.vue
+++ b/webapp/src/main/webapp/news/components/NewsAppItem.vue
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
   <div id="newsAppItem">
     <a
       :href="news.url"
-      :style="{ 'background-image': 'url(' + news.illustrationURL + '&size=300x300)' }"
+      :style="{ 'background-image': 'url(' + news.illustrationURL + '&size=150x150)' }"
       class="newsSmallIllustration"
       :target="news.target"></a>
     <div class="newsItemContent">


### PR DESCRIPTION
prior to this change, In the news application, the illustration is requested in size 300x300 but displayed in a square 150x150 after this change, the size updated to use the correct one