### PR TITLE
feat: News List template: use correct size for illustrations -EXO-60461

### DIFF
--- a/webapp/src/main/webapp/news-list-view/components/views/NewsCardsViewItem.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsCardsViewItem.vue
@@ -147,7 +147,10 @@ export default {
       return this.selectedOption && this.selectedOption.showArticleSpace;
     },
     articleImage() {
-      return (this.showArticleImage && this.item?.illustrationURL.concat('&size=235x140').toString()) || '/news/images/news.png';
+      return this.showArticleImage && this.item
+                                   && this.item.illustrationURL
+                                   && this.item.illustrationURL.concat('&size=235x140').toString()
+                                   || '/news/images/news.png';
     },
     isHiddenSpace() {
       return this.item && !this.item.spaceMember && this.item.hiddenSpace;

--- a/webapp/src/main/webapp/news-list-view/components/views/NewsListTemplateViewItem.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsListTemplateViewItem.vue
@@ -105,7 +105,10 @@ export default {
       return this.selectedOption?.showArticleReactions;
     },
     articleImage() {
-      return (this.showArticleImage && this.item?.illustrationURL.concat('&size=70x70').toString()) || '/news/images/news.png';
+      return this.showArticleImage && this.item
+                                   && this.item.illustrationURL
+                                   && this.item.illustrationURL.concat('&size=70x70').toString()
+                                   || '/news/images/news.png';
     },
   },
 };

--- a/webapp/src/main/webapp/news-list-view/components/views/NewsMosaicView.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsMosaicView.vue
@@ -21,13 +21,13 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         v-for="(item, index) of news"
         :key="index"
         :class="isSmallWidth ? 'articleSmallWidth' : 'article'"
-        :id="`articleItem-${index}`">
+        :id="`articleItem-${item.id}`">
         <a
           class="articleLink d-block"
           target="_self"
           :href="item.url">
           <img :src="showArticleImage && item.illustrationURL !== null ? 
-            $newsListService.illustrationURLResize(item.illustrationURL, `#top-news-mosaic #articleItem-${index}`)
+            $newsListService.illustrationURLResize(item.illustrationURL, `#top-news-mosaic #articleItem-${item.id}`)
             : '/news/images/news.png'" 
             :alt="$t('news.latest.alt.articleImage')">
           <div class="titleArea">


### PR DESCRIPTION
Prior to this change, When using:
- mosaic and headlines template, images are broken.
- news card and news list: news without images are not displayed.

After this change, the images are displayed correctly.