### PR TITLE
 fix: Prefetch news list rest call contains the target hardcoded : EXO-60823

### DIFF
--- a/webapp/src/main/webapp/WEB-INF/jsp/newsListView.jsp
+++ b/webapp/src/main/webapp/WEB-INF/jsp/newsListView.jsp
@@ -69,7 +69,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
     PortalRequestContext rcontext = PortalRequestContext.getCurrentInstance();
     PortalHttpServletResponseWrapper responseWrapper = ( PortalHttpServletResponseWrapper ) rcontext.getResponse();
-    String newsListUrl = "/portal/rest/v1/news/byTarget/snapshotLatestNews?offset=0&limit="+ limit + "&returnSize=true";
+    String newsListUrl = "/portal/rest/v1/news/byTarget/" + newsTarget + "?offset=0&limit=" + limit + "&returnSize=true";
     responseWrapper.addHeader("Link", "<" + newsListUrl + ">; rel=prefetch; as=fetch; crossorigin=use-credentials", false);
   %>
   <div class="news-list-view-app" id="<%= appId %>">


### PR DESCRIPTION
prior to this change, the target in the prefetch url is hardcoded. So the prefetched url could be wrong if the target in the news is different.
This commit change the hardcoded target to use the configured one.