### PR TITLE
feat: News detail page: use correct size for illustrations -EXO-60462

### DIFF
--- a/webapp/src/main/webapp/news-details/components/ExoNewsDetailsBody.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsDetailsBody.vue
@@ -12,7 +12,7 @@
       <div :class="[illustrationURL ? 'newsDetails-header' : '']" class="newsDetails-header">
         <div v-if="illustrationURL" class="illustration">
           <img
-            :src="illustrationURL"
+            :src="illustrationURL.concat('&size=0x400').toString()"
             class="newsDetailsImage illustrationPicture"
             :alt="newsTitle"
             longdesc="#newsSummary">

--- a/webapp/src/main/webapp/news-details/components/mobile/ExoNewsDetailsToolBarMobile.vue
+++ b/webapp/src/main/webapp/news-details/components/mobile/ExoNewsDetailsToolBarMobile.vue
@@ -69,7 +69,7 @@ export default {
       return this.news && this.news.spaceMember ? this.news.spaceUrl : `${eXo.env.portal.context}/${eXo.env.portal.portalName}`;
     },
     illustrationUrl() {
-      return this.news && this.news.illustrationURL ? this.news.illustrationURL : '/news/images/news.png';
+      return this.news && this.news.illustrationURL ? this.news.illustrationURL.concat('&size=0x128').toString() : '/news/images/news.png';
     },
     publicationState() {
       return this.news && this.news.publicationState;


### PR DESCRIPTION
Prior to this change, the size for illustrations in news detail page is still required at the original size of the image. After this change, the illustration is uploaded with a height of 400px and the width variable according to the aspect ratio of the original image but in the mobile case the height will be 128px while the height of news-details-toolbar is fixed at 128px.