### PR TITLE
feat: Resize news activity illustration - EXO-60323

### DIFF
--- a/webapp/src/main/webapp/news-extensions/extensions.js
+++ b/webapp/src/main/webapp/news-extensions/extensions.js
@@ -28,7 +28,7 @@ const newsActivityTypeExtensionOptions = {
   hideOnDelete: true,
   supportsThumbnail: true,
   windowTitlePrefixKey: 'news.window.title',
-  getThumbnail: (activity) => activity && activity.news && activity.news.illustrationURL || '/news/images/news.png',
+  getThumbnail: (activity) => activity && activity.news && activity.news.illustrationURL && `${activity.news.illustrationURL}&size=250x150`|| '/news/images/news.png',
   getThumbnailProperties: (activity) => !(activity && activity.news && activity.news.illustrationURL) && {
     height: '90px',
     width: '90px',


### PR DESCRIPTION
Prior to this change, new activity illustration is displayed with its original dimension which affects the perf due to the spent time to load the enormous images This PR should add a flag to resize news illustration activity to an appropriate size