### PR TITLE
fix : fix displaying news illustration - EXO-60831

### DIFF
--- a/webapp/src/main/webapp/news/components/NewsApp.vue
+++ b/webapp/src/main/webapp/news/components/NewsApp.vue
@@ -224,6 +224,7 @@ export default {
         result.push({
           newsId: item.id,
           newsText: this.getNewsText(item.summary, item.body),
+          illustrationURL: item.illustrationURL,
           title: item.title,
           updatedDate: this.isDraftsFilter ? newsPublicationDate : newsUpdateDate,
           spaceDisplayName: item.spaceDisplayName,


### PR DESCRIPTION
prior to this change, when looping the result the illustration is pushed null so all the news takes the default illustration.
After this change, news illustrations are well displayed