### PR TITLE
fix : improve displaying newslist UI - EXO-60939

### DIFF
--- a/webapp/src/main/webapp/news-list-view/components/views/NewsListTemplateView.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsListTemplateView.vue
@@ -19,10 +19,13 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
     <v-row>
       <v-col
         class="flex-grow-0"
+        cols="12"
+        xs="12"
+        md="6"
+        xl="4"
         v-for="(item, index) of newsInfo"
         :key="item">
         <div
-          class="article"
           :id="`article-item-${index}`">
           <news-list-template-view-item
             :item="item"

--- a/webapp/src/main/webapp/news-list-view/components/views/NewsListTemplateViewItem.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsListTemplateViewItem.vue
@@ -23,8 +23,14 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
       <img :src="articleImage" :alt="$t('news.latest.alt.articleImage')">
     </div>
     <div class="article-item-content">
-      <span v-if="showArticleTitle" class="article-title">{{ item.title }}</span>
-      <span v-if="showArticleSummary" class="article-title">{{ item.summary }}</span>
+      <span
+        v-if="showArticleTitle"
+        class="text-color text-body-2"
+        :class="extraClass">{{ item.title }}</span>
+      <span
+        v-if="showArticleSummary"
+        class="text-color text-body-2"
+        :class="extraClass">{{ item.summary }}</span>
       <div class="d-flex">
         <span v-if="showArticleAuthor" class="article-preTitle">{{ item.authorDisplayName }}</span>
         <v-icon
@@ -107,6 +113,9 @@ export default {
     articleImage() {
       return (this.showArticleImage && this.item?.illustrationURL) || '/news/images/news.png';
     },
+    extraClass() {
+      return (!this.showArticleSummary || !this.showArticleTitle) && 'text-truncate-2' || 'article-title' ;
+    }
   },
 };
 </script>


### PR DESCRIPTION
prior to this change, in the newsList template, there was too much empty space in the container, and the title is truncated in just one line. 
after this change, a UI improvement in displaying the newsList is added:
- Article titles should be truncated after  2 lines are reached. 
- edit padding to reduce unwanted white space