### PR TITLE
fix: Stories template : UI improvements - Exo-60938

### DIFF
--- a/webapp/src/main/webapp/news-list-view/components/NewsListView.vue
+++ b/webapp/src/main/webapp/news-list-view/components/NewsListView.vue
@@ -16,7 +16,11 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 -->
 <template>
   <v-app class="news-list-view-app position-relative">
-    <v-card flat class="list-view-card rounded-0">
+    <v-card 
+      height="100%"
+      flat
+      :class="viewTemplate === 'NewsStories' ? 'background-transparent' : ''"
+      class="list-view-card rounded-0">
       <v-card-text class="pa-0">
         <news-settings v-if="displayHeader" />
         <extension-registry-component
@@ -101,7 +105,11 @@ export default {
   }),
   computed: {
     displayHeader() {
-      return this.viewTemplate && (this.viewTemplate !== 'NewsSlider' && this.viewTemplate !== 'NewsAlert');
+      return this.viewTemplate && 
+            this.viewTemplate !== 'NewsSlider' && 
+            this.viewTemplate !== 'NewsAlert' && 
+            this.viewTemplate !== 'NewsStories' && 
+            (this.viewTemplate !== 'NewsMosaic' || this.isMobile);
     },
     selectedViewExtension() {
       if (this.viewTemplate) {

--- a/webapp/src/main/webapp/news-list-view/components/settings/NewsSettings.vue
+++ b/webapp/src/main/webapp/news-list-view/components/settings/NewsSettings.vue
@@ -15,7 +15,7 @@ You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 -->
 <template>
-  <div class="d-flex flex-row pa-2">
+  <div class="settings-container d-flex flex-row pa-2">
     <div class="d-flex latestNewsTitleContainer flex-column flex-grow-1 my-1">
       <span
         v-if="showHeader"
@@ -24,6 +24,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
     </div>
     <div class="d-flex flex-column me-2">
       <v-btn
+        class="button-open-settings"
         v-if="$root.canPublishNews"
         icon
         @click="openDrawer">
@@ -34,7 +35,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
       <v-btn
         depressed
         small
-        class="caption text-uppercase grey--text my-auto me-2"
+        class="button-see-all-news caption text-uppercase grey--text my-auto me-2"
         @click="seeAllNews">
         {{ $t('news.published.seeAll') }}
       </v-btn>

--- a/webapp/src/main/webapp/news-list-view/components/views/NewsStoriesViewItem.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsStoriesViewItem.vue
@@ -16,6 +16,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 -->
 <template>
   <div class="card">
+    <news-settings />
     <a
       class="articleLink"
       target="_self"

--- a/webapp/src/main/webapp/skin/less/newsListView.less
+++ b/webapp/src/main/webapp/skin/less/newsListView.less
@@ -15,7 +15,11 @@
     min-height: 100%;
     flex: 1 1 auto;
     max-width: 100%;
-
+    
+    .background-transparent {
+      background: transparent !important;
+    }
+    
     .list-view-card {
       height: 100%;
 
@@ -1765,10 +1769,24 @@ p.caption-title:after {
   -ms-flex-direction: column;
   flex-direction: column;
   position: relative;
-  background: transparent;
+  background: transparent !important;
   font-size: 14px;
   color: white;
   line-height: 18px;
+  .theme--light.v-card {
+    background: transparent !important;
+  }
+  .author-photo {
+    margin: 0 0 0 7px !important;
+  }
+  .author-date-container {
+    font-size: 11px !important;
+    position: absolute !important;
+    top: 25px !important;
+    .author-date {
+      margin: auto !important;
+    }
+  }
   .card {
     position: relative;
     border-radius: 6px;
@@ -1782,6 +1800,37 @@ p.caption-title:after {
     overflow: hidden;
     margin: 0 10px 0 0;
     float: left;
+    .settings-container{
+      position: absolute;
+      z-index: 1;
+      padding-bottom: 0 !important;
+      right: 0 !important;
+    }
+    div:has(> .button-see-all-news) {
+      margin-left: 8px !important;
+    }
+    div:has(> .button-open-settings) {
+      margin-right: 0 !important;
+    }
+    .button-see-all-news {
+      height: 18px !important;
+      padding: 0 9px !important;
+      margin-right: -6px !important;
+      span {
+        font-size: 10px !important;
+      }
+    }
+    .button-open-settings {
+      height: 18px;
+      width: 18px;
+      .mdi-cog {
+        height: 18px !important;
+        font-size: 18px !important;
+        width: 18px !important;
+        color: white !important;
+        text-shadow: 2px 2px 4px black;
+      }
+    }
     &:hover {
       -webkit-box-shadow: 0 3px 20px 0 rgba(0, 0, 0, 0.1);
       box-shadow: 0 3px 20px 0 rgba(0, 0, 0, 0.1);


### PR DESCRIPTION
After this change, we made some change in News stories template UI side:

1. Story card background should be transparent
2. Header should be hidden if show header option is disabled
3. Setting button should be placed inside container not on header level