### PR TITLE
fix: News Mosaic template : UI Improvements - EXO-60594

### DIFF
--- a/webapp/src/main/webapp/news-list-view/components/NewsListView.vue
+++ b/webapp/src/main/webapp/news-list-view/components/NewsListView.vue
@@ -134,6 +134,9 @@ export default {
         componentOptions: this.selectedViewExtension,
       };
     },
+    isMobile() {
+      return this.$vuetify.breakpoint.width < 651;
+    },
     viewComponentParams() {
       return {
         viewExtension: this.selectedViewExtension,

--- a/webapp/src/main/webapp/news-list-view/components/views/NewsMosaicView.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsMosaicView.vue
@@ -16,7 +16,11 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 -->
 <template>
   <div id="top-news-mosaic" ref="top-news-mosaic">
-    <div :class="`mosaic-container ma-3 ${smallHeightClass}`">
+    <news-settings 
+      v-if="!isSmallBreakpoint" 
+      :class="isMobile ? '' : 'settingNewsContainer'"
+      class="mt-3 mr-1"/>
+    <div :class="`mosaic-container ${smallHeightClass}`">
       <div 
         v-for="(item, index) of news"
         :key="index"
@@ -33,7 +37,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                 :value="new Date(item.publishDate.time)"
                 :format="dateFormat" />
             </div>
-            <div v-if="showArticleTitle" :class="'text-truncate' + isSmallWidth ? 'articleTitle text-truncate':''">
+            <div v-if="showArticleTitle" 
+              :class="styleArticleTitle()">
               {{ item.title }}
             </div>
           </div>
@@ -91,6 +96,9 @@ export default {
     isMobile() {
       return this.$vuetify.breakpoint.name === 'xs' || this.$vuetify.breakpoint.name === 'sm';
     },
+    isSmallBreakpoint() {
+      return this.$vuetify.breakpoint.width < 651;
+    },
     smallHeightClass() {
       return this.isMobile && this.news && this.news.length === 1 && 'small-mosaic-container';
     },
@@ -147,6 +155,9 @@ export default {
         seeAllUrl: this.seeAllUrl,
       };
     },
+    styleArticleTitle(){
+      return  (this.isSmallWidth ? 'articleTitle ' : '').concat(this.isSmallBreakpoint ? 'text-truncate' : 'articleTitleTruncate');
+    }
   }
 };
 </script>

--- a/webapp/src/main/webapp/skin/less/newsListView.less
+++ b/webapp/src/main/webapp/skin/less/newsListView.less
@@ -1547,11 +1547,19 @@ p.caption-title:after {
 #top-news-mosaic {
   background-color: white;
   overflow: hidden;
+  .settingNewsContainer {
+    position: absolute;
+    z-index: 2;right: 0;
+    i {
+      color: white !important;
+      text-shadow: 2px 2px 4px black;
+    }
+  }
   .mosaic-container {
     display: -ms-grid;
     display: grid;
     gap: 2px;
-    height: 335px;
+    height: 404px;
     overflow: hidden;
   }
   .article {
@@ -1569,6 +1577,12 @@ p.caption-title:after {
         font-weight: 600;
         line-height: 27px;
         -webkit-line-clamp: 5;
+        .articleTitleTruncate {
+          display: -webkit-box !important;
+          -webkit-line-clamp: 5 !important;
+          -webkit-box-orient: vertical !important;
+          overflow: hidden;
+        }
       }
     }
     &:nth-child(2) {
@@ -1578,6 +1592,24 @@ p.caption-title:after {
       -ms-grid-row: 1;
       -ms-grid-row-span: 1;
       grid-row: ~"1/2";
+      .articleTitleTruncate {
+        display: -webkit-box !important;
+        -webkit-line-clamp: 2 !important;
+        -webkit-box-orient: vertical !important;
+        overflow: hidden;
+      }
+    }
+    &:nth-child(3) .articleTitleTruncate {
+      display: -webkit-box !important;
+      -webkit-line-clamp: 2 !important;
+      -webkit-box-orient: vertical !important;
+      overflow: hidden;
+    }
+    &:nth-child(4) .articleTitleTruncate {
+      display: -webkit-box !important;
+      -webkit-line-clamp: 2 !important;
+      -webkit-box-orient: vertical !important;
+      overflow: hidden;
     }
     &:nth-child(n + 2) {
       .titleArea {


### PR DESCRIPTION
After this change, we made some change in News Mosaic template UI side

1. Title should be extended to 5 lines long in the big left side article card
2. Little cards title should be extended to 2 lines long in the other 3 right side cards.
3. Header should be hidden if "show header" option is disabled
4. Setting button should be placed inside container not on header level.