### PR TITLE
fix: fix displaying newsList container header when header and seeAll are disabled

### DIFF
--- a/webapp/src/main/webapp/news-list-view/components/settings/NewsSettings.vue
+++ b/webapp/src/main/webapp/news-list-view/components/settings/NewsSettings.vue
@@ -15,7 +15,7 @@ You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 -->
 <template>
-  <div class="settings-container d-flex flex-row pa-2">
+  <div v-if="showSettingsContainer" class="settings-container d-flex flex-row px-2 pt-1">
     <div class="d-flex latestNewsTitleContainer flex-column flex-grow-1 my-1">
       <span
         v-if="showHeader"
@@ -50,6 +50,11 @@ export default {
     showHeader: false,
     showSeeAll: false,
   }),
+  computed: {
+    showSettingsContainer(){
+      return this.showHeader || this.showSeeAll || this.$root.canPublishNews ;
+    }
+  },
   created() {
     this.$root.$on('saved-news-settings', (newsTarget, selectedOptions) => {
       this.newsHeader = selectedOptions.header;

--- a/webapp/src/main/webapp/news-list-view/components/views/NewsListTemplateView.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsListTemplateView.vue
@@ -15,10 +15,11 @@ You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 -->
 <template>
-  <div id="article-list-view">
+  <div id="article-list-view" :class="articleListExtraClass">
     <v-row>
       <v-col
         class="flex-grow-0"
+        :class="extraClass"
         cols="12"
         xs="12"
         md="6"
@@ -64,6 +65,14 @@ export default {
     showArticleDate: true,
     showArticleReactions: true,
   }),
+  computed: {
+    articleListExtraClass() {
+      return (!this.showHeader && !this.showSeeAll && !this.$root.canPublishNews ) && ' ' || 'py-0';
+    },
+    extraClass() {
+      return (!this.showHeader && !this.showSeeAll && !this.$root.canPublishNews ) && ' ' || 'pt-2';
+    }
+  },
   created() {
     this.reset();
     this.$root.$on('saved-news-settings', this.refreshNewsViews);


### PR DESCRIPTION
prior to this change, a large white space is displayed when Header and seeAll are disabled
prior to this change, when Header and seeAll are disabled the container is not displayed and no white space is displayed