### PR TITLE
fix : fix displaying news without illustration - EXO-60831 (#678)

### DIFF
--- a/webapp/src/main/webapp/news/components/NewsApp.vue
+++ b/webapp/src/main/webapp/news/components/NewsApp.vue
@@ -220,12 +220,11 @@ export default {
       data.forEach((item) => {
         const newsPublicationDate = item.publicationDate != null ? new Date(item.publicationDate.time) : null;
         const newsUpdateDate = new Date(item.updateDate.time);
-        const newsIllustration = item.illustrationURL == null ? '/news/images/news.png' : item.illustrationURL;
         const activityId = item.activities ? item.activities.split(';')[0].split(':')[1] : '';
         result.push({
           newsId: item.id,
           newsText: this.getNewsText(item.summary, item.body),
-          illustrationURL: newsIllustration,
+          illustrationURL: item.illustrationURL,
           title: item.title,
           updatedDate: this.isDraftsFilter ? newsPublicationDate : newsUpdateDate,
           spaceDisplayName: item.spaceDisplayName,

--- a/webapp/src/main/webapp/news/components/NewsAppItem.vue
+++ b/webapp/src/main/webapp/news/components/NewsAppItem.vue
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
   <div id="newsAppItem">
     <a
       :href="news.url"
-      :style="{ 'background-image': 'url(' + news.illustrationURL + '&size=150x150)' }"
+      :style="{ 'background-image': 'url(' + illustrationUrl + ')' }"
       class="newsSmallIllustration"
       :target="news.target"></a>
     <div class="newsItemContent">
@@ -160,7 +160,10 @@ export default {
     },
     newsAuthor() {
       return this.news && this.news.authorProfileURL && this.news.authorProfileURL.split('/').pop();
-    }
+    },
+    illustrationUrl() {
+      return this.news?.illustrationURL ? this.news.illustrationURL.concat('&size=150x150').toString() : '/news/images/news.png';
+    },
   },
   methods: {
     editLink(news) {


### PR DESCRIPTION
before this change, an empty background is displayed when the news is without illustration because the URL is wrong after this change, the background illustration is corrected and the news is well displayed