### PR TITLE
fix : improve displaying new list UI - EXO-60939 (#682) 

### DIFF
--- a/webapp/src/main/webapp/news-list-view/components/settings/NewsSettings.vue
+++ b/webapp/src/main/webapp/news-list-view/components/settings/NewsSettings.vue
@@ -15,7 +15,7 @@ You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 -->
 <template>
-  <div class="settings-container d-flex flex-row pa-2">
+  <div v-if="showSettingsContainer" class="settings-container d-flex flex-row px-2 pt-1">
     <div class="d-flex latestNewsTitleContainer flex-column flex-grow-1 my-1">
       <span
         v-if="showHeader"
@@ -50,6 +50,11 @@ export default {
     showHeader: false,
     showSeeAll: false,
   }),
+  computed: {
+    showSettingsContainer(){
+      return this.showHeader || this.showSeeAll || this.$root.canPublishNews ;
+    }
+  },
   created() {
     this.$root.$on('saved-news-settings', (newsTarget, selectedOptions) => {
       this.newsHeader = selectedOptions.header;

--- a/webapp/src/main/webapp/news-list-view/components/views/NewsListTemplateView.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsListTemplateView.vue
@@ -15,14 +15,18 @@ You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 -->
 <template>
-  <div id="article-list-view">
+  <div id="article-list-view" :class="articleListExtraClass">
     <v-row>
       <v-col
         class="flex-grow-0"
+        :class="extraClass"
+        cols="12"
+        xs="12"
+        md="6"
+        xl="4"
         v-for="(item, index) of newsInfo"
         :key="item">
         <div
-          class="article"
           :id="`article-item-${index}`">
           <news-list-template-view-item
             :item="item"
@@ -61,6 +65,14 @@ export default {
     showArticleDate: true,
     showArticleReactions: true,
   }),
+  computed: {
+    articleListExtraClass() {
+      return (!this.showHeader && !this.showSeeAll && !this.$root.canPublishNews ) && ' ' || 'py-0';
+    },
+    extraClass() {
+      return (!this.showHeader && !this.showSeeAll && !this.$root.canPublishNews ) && ' ' || 'pt-2';
+    }
+  },
   created() {
     this.reset();
     this.$root.$on('saved-news-settings', this.refreshNewsViews);

--- a/webapp/src/main/webapp/news-list-view/components/views/NewsListTemplateViewItem.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsListTemplateViewItem.vue
@@ -23,8 +23,14 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
       <img :src="articleImage" :alt="$t('news.latest.alt.articleImage')">
     </div>
     <div class="article-item-content">
-      <span v-if="showArticleTitle" class="article-title">{{ item.title }}</span>
-      <span v-if="showArticleSummary" class="article-title">{{ item.summary }}</span>
+      <span
+        v-if="showArticleTitle"
+        class="text-color text-body-2"
+        :class="extraClass">{{ item.title }}</span>
+      <span
+        v-if="showArticleSummary"
+        class="text-color text-body-2"
+        :class="extraClass">{{ item.summary }}</span>
       <div class="d-flex">
         <span v-if="showArticleAuthor" class="article-preTitle">{{ item.authorDisplayName }}</span>
         <v-icon
@@ -107,6 +113,9 @@ export default {
     articleImage() {
       return (this.showArticleImage && this.item?.illustrationURL) || '/news/images/news.png';
     },
+    extraClass() {
+      return (!this.showArticleSummary || !this.showArticleTitle) && 'text-truncate-2' || 'article-title' ;
+    }
   },
 };
 </script>


### PR DESCRIPTION
prior to this change, in the news list template, there was too much empty space in the container, and the title is truncated in just one line.
after this change, a UI improvement in displaying the news list is added:
-Article titles should be truncated after  2 lines are reached. 
-edit padding to reduce unwanted white space