### PR TITLE
feat: Remove the default redactor permission to post an article in a redactional space for the publisher of web contributors group - EXO-61216 -  Meeds-io/MIPs#35

### DIFF
--- a/services/src/main/java/org/exoplatform/news/service/impl/NewsServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/service/impl/NewsServiceImpl.java
@@ -141,8 +141,7 @@ public class NewsServiceImpl implements NewsService {
     return space != null
         && (spaceService.isSuperManager(currentIdentity.getUserId()) || spaceService.isManager(space, currentIdentity.getUserId())
             || spaceService.isRedactor(space, currentIdentity.getUserId())
-            || spaceService.isMember(space, currentIdentity.getUserId()) && (ArrayUtils.isEmpty(space.getRedactors())
-            || currentIdentity.isMemberOf(PLATFORM_WEB_CONTRIBUTORS_GROUP, PUBLISHER_MEMBERSHIP_NAME)));
+            || spaceService.isMember(space, currentIdentity.getUserId()) && ArrayUtils.isEmpty(space.getRedactors()));
   }
   
   /**


### PR DESCRIPTION

Prior to this change, any publisher of web contributors group can post an article in a redactional space even if they he hasn't explicitly redactor role in this space. After this modification, we will remove this implicit permission so the redactor role will be mandatory in order to post an article in a redactional space.