### PR TITLE
fix: News List template: use correct size for illustrations -EXO-60461

### DIFF
--- a/webapp/src/main/webapp/news-list-view/components/views/NewsCardsViewItem.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsCardsViewItem.vue
@@ -147,7 +147,10 @@ export default {
       return this.selectedOption && this.selectedOption.showArticleSpace;
     },
     articleImage() {
-      return (this.showArticleImage && this.item?.illustrationURL) || '/news/images/news.png';
+      return this.showArticleImage && this.item
+                                   && this.item.illustrationURL
+                                   && this.item.illustrationURL.concat('&size=235x140').toString()
+                                   || '/news/images/news.png';
     },
     isHiddenSpace() {
       return this.item && !this.item.spaceMember && this.item.hiddenSpace;

--- a/webapp/src/main/webapp/news-list-view/components/views/NewsLatestViewItem.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsLatestViewItem.vue
@@ -20,7 +20,9 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
     target="_self"
     :href="item.url">
     <div class="articleImage">
-      <img :src="showArticleImage && item.illustrationURL !== null ? item.illustrationURL : '/news/images/news.png'" :alt="$t('news.latest.alt.articleImage')">
+      <img 
+        :src="showArticleImage && item.illustrationURL !== null ? item.illustrationURL.concat('&size=1012x344').toString() : '/news/images/news.png'" 
+        :alt="$t('news.latest.alt.articleImage')">
     </div>
     <div class="articleInfos">
       <div class="articleSpace" v-if="!isHiddenSpace && showArticleSpace">

--- a/webapp/src/main/webapp/news-list-view/components/views/NewsListTemplateViewItem.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsListTemplateViewItem.vue
@@ -111,7 +111,10 @@ export default {
       return this.selectedOption?.showArticleReactions;
     },
     articleImage() {
-      return (this.showArticleImage && this.item?.illustrationURL) || '/news/images/news.png';
+      return this.showArticleImage && this.item
+                                   && this.item.illustrationURL
+                                   && this.item.illustrationURL.concat('&size=70x70').toString()
+                                   || '/news/images/news.png';
     },
     extraClass() {
       return (!this.showArticleSummary || !this.showArticleTitle) && 'text-truncate-2' || 'article-title' ;

--- a/webapp/src/main/webapp/news-list-view/components/views/NewsMosaicView.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsMosaicView.vue
@@ -30,7 +30,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
           class="articleLink d-block"
           target="_self"
           :href="item.url">
-          <img :src="showArticleImage && item.illustrationURL !== null ? item.illustrationURL : '/news/images/news.png'" :alt="$t('news.latest.alt.articleImage')">
+          <img :src="showArticleImage && item.illustrationURL !== null ? item.illustrationURL.concat('&size=1012x335').toString() : '/news/images/news.png'" :alt="$t('news.latest.alt.articleImage')">
           <div class="titleArea">
             <div v-if="showArticleDate" class="articleDate">
               <date-format

--- a/webapp/src/main/webapp/news-list-view/components/views/NewsSliderView.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsSliderView.vue
@@ -31,7 +31,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         dark>
         <v-img
           class="articleImage fill-height"
-          :src="showArticleImage && item.illustrationURL !== null ? item.illustrationURL : '/news/images/news.png'"
+          :src="showArticleImage && item.illustrationURL !== null ? item.illustrationURL.concat('&size=1420x222').toString() : '/news/images/news.png'"
           eager />
         <v-container class="slide-text-container d-flex text-center body-2">
           <div class="flex flex-column carouselNewsInfo">

--- a/webapp/src/main/webapp/news-list-view/components/views/NewsStoriesViewItem.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsStoriesViewItem.vue
@@ -108,7 +108,7 @@ export default {
       return this.selectedOption && this.selectedOption.showArticleImage;
     },
     articleImage() {
-      return this.showArticleImage && this.item.illustrationURL !== null ? this.item.illustrationURL : '/news/images/news.png';
+      return this.showArticleImage && this.item.illustrationURL !== null ? this.item.illustrationURL.concat('&size=140x210').toString() : '/news/images/news.png';
     }
   }
 };


### PR DESCRIPTION
Prior to this change, the size for illustrations in the templates lists news is still required at the original size of the image. After this change, the size of the illustrations is updated for the correct size.