### PR TITLE
feat: Remove the default redactor permission to post an article in a redactional space for the publisher of web contributors group - EXO-61216 - Meeds-io/MIPs#35

### DIFF
--- a/services/src/main/java/org/exoplatform/news/service/impl/NewsServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/service/impl/NewsServiceImpl.java
@@ -141,8 +141,7 @@ public class NewsServiceImpl implements NewsService {
     return space != null
         && (spaceService.isSuperManager(currentIdentity.getUserId()) || spaceService.isManager(space, currentIdentity.getUserId())
             || spaceService.isRedactor(space, currentIdentity.getUserId())
-            || spaceService.isMember(space, currentIdentity.getUserId()) && (ArrayUtils.isEmpty(space.getRedactors())
-            || currentIdentity.isMemberOf(PLATFORM_WEB_CONTRIBUTORS_GROUP, PUBLISHER_MEMBERSHIP_NAME)));
+            || spaceService.isMember(space, currentIdentity.getUserId()) && ArrayUtils.isEmpty(space.getRedactors()));
   }
   
   /**

--- a/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
+++ b/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
@@ -24,7 +24,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
       </div>
     </div>
     <div
-      v-show="canCreatNews && !loading"
+      v-show="canCreateNews && !loading"
       id="newsActivityComposer"
       class="newsComposer">
       <schedule-news-drawer
@@ -283,7 +283,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         :items="items" />
     </div>
 
-    <div v-show="(!canCreatNews && !loading) || unAuthorizedAccess" class="newsComposer">
+    <div v-show="(!canCreateNews && !loading) || unAuthorizedAccess" class="newsComposer">
       <div class="articleNotFound">
         <i class="iconNotFound"></i>
         <h3 class="restrictedAction">{{ $t('news.details.restricted') }}</h3>
@@ -365,7 +365,7 @@ export default {
       attachmentsChanged: false,
       imagesURLs: new Map(),
       uploading: false,
-      canCreatNews: false,
+      canCreateNews: false,
       loading: true,
       currentSpace: {},
       spaceURL: null,
@@ -475,9 +475,9 @@ export default {
       this.displayFormTitle();
 
       this.$newsServices.canUserCreateNews(this.currentSpace.id).then(canCreateNews => {
-        this.canCreatNews = canCreateNews;
+        this.canCreateNews = canCreateNews || this.newsId;
         this.$nextTick(() => {
-          if (this.canCreatNews) {
+          if (this.canCreateNews) {
             if (this.newsId) {
               this.initNewsComposerData(this.newsId);
             } else {


### PR DESCRIPTION

Prior to this change, any publisher of web contributors group can post an article in a redactional space even if they he hasn't explicitly redactor role in this space. After this modification, we will remove this implicit permission so the redactor role will be mandatory in order to post an article in a redactional space.