### PR TITLE
feat: Display allowed news targets in publish section of publishing drawers - EXO-60989 (#698)

### DIFF
--- a/services/src/main/java/org/exoplatform/news/rest/NewsTargetingRestResourcesV1.java
+++ b/services/src/main/java/org/exoplatform/news/rest/NewsTargetingRestResourcesV1.java
@@ -85,17 +85,35 @@ public class NewsTargetingRestResourcesV1 implements ResourceContainer, Startabl
   @GET
   @Produces(MediaType.APPLICATION_JSON)
   @RolesAllowed("users")
-  @Operation(summary = "Get all news targets by a giving type", method = "GET", description = "Get all news targets by a giving type")
+  @Operation(summary = "Get all news targets", method = "GET", description = "Get all news targets")
   @ApiResponses(value = {
     @ApiResponse(responseCode = "200", description = "Request fulfilled"),
     @ApiResponse(responseCode = "500", description = "Internal server error")
   })
-  public Response getTargets(@Context HttpServletRequest request) {
+  public Response getAllTargets(@Context HttpServletRequest request) {
     try {
-      List<NewsTargetingEntity> targets = newsTargetingService.getTargets();
+      List<NewsTargetingEntity> targets = newsTargetingService.getAllTargets();
       return Response.ok(targets).build();
     } catch (Exception e) {
       LOG.error("Error when getting the news targets", e);
+      return Response.serverError().build();
+    }
+  }
+
+  @Path("allowed")
+  @GET
+  @Produces(MediaType.APPLICATION_JSON)
+  @RolesAllowed("users")
+  @Operation(summary = "Get all allowed news targets of the current user", method = "GET", description = "Get all allowed news targets of the current user")
+  @ApiResponses(value = { @ApiResponse(responseCode = "200", description = "Request fulfilled"),
+      @ApiResponse(responseCode = "500", description = "Internal server error") })
+  public Response getAllowedTargets(@Context HttpServletRequest request) {
+    org.exoplatform.services.security.Identity currentIdentity = ConversationState.getCurrent().getIdentity();
+    try {
+      List<NewsTargetingEntity> allowedTargets = newsTargetingService.getAllowedTargets(currentIdentity);
+      return Response.ok(allowedTargets).build();
+    } catch (Exception e) {
+      LOG.error("Error when getting allowed news targets for the user " + currentIdentity.getUserId(), e);
       return Response.serverError().build();
     }
   }

--- a/services/src/main/java/org/exoplatform/news/service/NewsTargetingService.java
+++ b/services/src/main/java/org/exoplatform/news/service/NewsTargetingService.java
@@ -17,14 +17,13 @@
 package org.exoplatform.news.service;
 
 import java.util.List;
-import java.util.Map;
 
 import org.exoplatform.news.model.News;
 import org.exoplatform.news.rest.NewsTargetingEntity;
+import org.exoplatform.social.core.identity.model.Identity;
 import org.exoplatform.social.metadata.model.Metadata;
 import org.exoplatform.social.metadata.model.MetadataItem;
 import org.exoplatform.social.metadata.model.MetadataType;
-import org.exoplatform.social.core.identity.model.Identity;
 
 
 public interface NewsTargetingService {
@@ -32,11 +31,18 @@ public interface NewsTargetingService {
   public static final MetadataType METADATA_TYPE = new MetadataType(4, "newsTarget");
 
   /**
-   * Gets the {@link List} of all {@link News} targets which can be referenced from {@link News} list portlets
+   * Gets the {@link List} of all targets
    *
-   * @return {@link List} of all {@link News} targets
+   * @return {@link List} of all targets
    */
-  List<NewsTargetingEntity> getTargets();
+  List<NewsTargetingEntity> getAllTargets();
+  
+  /**
+   * Gets the {@link List} of allowed targets for a given currentIdentity
+   * @param userIdentity user {@link Identity} for which targets are allowed
+   * @return {@link List} of allowed targets
+   */
+  List<NewsTargetingEntity> getAllowedTargets(org.exoplatform.services.security.Identity userIdentity);
   
   /**
    * Delete the {@link News} target by a given {@link News} target name
@@ -128,5 +134,4 @@ public interface NewsTargetingService {
    * @throws IllegalArgumentException when user tries to update a not changed {@link News} target
    */
   Metadata updateNewsTargets(String originalTargetName, NewsTargetingEntity newsTargetingEntity, org.exoplatform.services.security.Identity currentIdentity) throws IllegalAccessException, IllegalStateException, IllegalArgumentException;
-
 }

--- a/services/src/main/java/org/exoplatform/news/service/impl/NewsTargetingServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/service/impl/NewsTargetingServiceImpl.java
@@ -20,9 +20,9 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
+
 import org.exoplatform.news.model.NewsTargetObject;
 import org.exoplatform.news.rest.NewsTargetingEntity;
 import org.exoplatform.news.rest.NewsTargetingPermissionsEntity;
@@ -50,9 +50,11 @@ public class NewsTargetingServiceImpl implements NewsTargetingService {
 
   private static final Log    LOG         = ExoLogger.getLogger(NewsTargetingServiceImpl.class);
 
-  public static final long    LIMIT       = 100;
-
   private static final String REFERENCED  = "referenced";
+
+  private static final String SPACE_TARGET_PERMISSION_PREFIX = "space:";
+
+  private static final String PUBLISHER_MEMBERSHIP_NAME       = "publisher";
 
   private MetadataService     metadataService;
 
@@ -70,13 +72,29 @@ public class NewsTargetingServiceImpl implements NewsTargetingService {
   }
 
   @Override
-  public List<NewsTargetingEntity> getTargets() {
-    List<Metadata> targets = metadataService.getMetadatas(METADATA_TYPE.getName(), LIMIT);
-    return targets.stream().map(this::toEntity).collect(Collectors.toList());
+  public List<NewsTargetingEntity> getAllTargets() {
+    List<Metadata> targets = metadataService.getMetadatas(METADATA_TYPE.getName(), 0);
+    return targets.stream().map(this::toEntity).toList();
+  }
+
+  @Override
+  public List<NewsTargetingEntity> getAllowedTargets(org.exoplatform.services.security.Identity userIdentity) {
+    List<Metadata> allTargetsMetadatas = metadataService.getMetadatas(METADATA_TYPE.getName(), 0);
+    List<Metadata> allowedTargetsMetadatas =
+                                           allTargetsMetadatas.stream()
+                                                              .filter(targetMetadata -> targetMetadata.getProperties()
+                                                                                                      .get(NewsUtils.TARGET_PERMISSIONS) == null
+                                                                  || isTargetAllowed(List.of(targetMetadata.getProperties()
+                                                                                                           .get(NewsUtils.TARGET_PERMISSIONS)
+                                                                                                           .split(",")),
+                                                                                     userIdentity))
+                                                              .toList();
+
+    return allowedTargetsMetadatas.stream().map(this::toEntity).toList();
   }
   
   @Override
-  public void deleteTargetByName(String targetName, org.exoplatform.services.security.Identity  currentIdentity) throws IllegalAccessException {
+  public void deleteTargetByName(String targetName, org.exoplatform.services.security.Identity currentIdentity) throws IllegalAccessException {
     if (currentIdentity != null && !NewsUtils.canManageNewsPublishTargets(currentIdentity)) {
       throw new IllegalArgumentException("User " + currentIdentity.getUserId()
           + " not authorized to delete news target with name " + targetName);
@@ -91,15 +109,15 @@ public class NewsTargetingServiceImpl implements NewsTargetingService {
     if (!NewsUtils.canPublishNews(currentIdentity)) {
       throw new IllegalAccessException("User " + currentIdentity.getUserId() + " not authorized to get referenced news targets");
     }
-    List<Metadata> referencedTargets = metadataService.getMetadatasByProperty(REFERENCED, String.valueOf(true), LIMIT);
-    return referencedTargets.stream().map(this::toEntity).collect(Collectors.toList());
+    List<Metadata> referencedTargets = metadataService.getMetadatasByProperty(REFERENCED, String.valueOf(true), 0);
+    return referencedTargets.stream().map(this::toEntity).toList();
   }
 
   @Override
   public List<String> getTargetsByNewsId(String newsId) {
     NewsTargetObject newsTargetObject = new NewsTargetObject(NewsUtils.NEWS_METADATA_OBJECT_TYPE, newsId, null);
     List<MetadataItem> newsTargets = metadataService.getMetadataItemsByMetadataTypeAndObject(METADATA_TYPE.getName(), newsTargetObject);
-    return newsTargets.stream().map(MetadataItem::getMetadata).map(Metadata::getName).collect(Collectors.toList());
+    return newsTargets.stream().map(MetadataItem::getMetadata).map(Metadata::getName).toList();
   }
 
   @Override
@@ -208,25 +226,31 @@ public class NewsTargetingServiceImpl implements NewsTargetingService {
       List<NewsTargetingPermissionsEntity> permissionsEntities = new ArrayList<>();
       for (String permission : permissionsList) {
         NewsTargetingPermissionsEntity permissionEntity = new NewsTargetingPermissionsEntity();
-        if (permission.contains("space:")) {
-          Space space = spaceService.getSpaceByPrettyName(List.of(permission.split(":")).get(1));
-          permissionEntity.setId("space:" + space.getDisplayName());
-          permissionEntity.setName(space.getDisplayName());
-          permissionEntity.setProviderId("space");
-          permissionEntity.setRemoteId(space.getPrettyName());
-          permissionEntity.setAvatar(space.getAvatarUrl());
+        if (permission.contains(SPACE_TARGET_PERMISSION_PREFIX)) {
+          Space space = spaceService.getSpaceById(permission.substring(6));
+          if (space != null) {
+            permissionEntity.setId(SPACE_TARGET_PERMISSION_PREFIX + space.getId());
+            permissionEntity.setName(space.getDisplayName());
+            permissionEntity.setProviderId("space");
+            permissionEntity.setRemoteId(space.getPrettyName());
+            permissionEntity.setAvatar(space.getAvatarUrl());
+          }
         } else {
           try {
             Group group = organizationService.getGroupHandler().findGroupById(permission);
-            permissionEntity.setId(group.getId());
-            permissionEntity.setName(group.getLabel());
-            permissionEntity.setProviderId("group");
-            permissionEntity.setRemoteId(group.getGroupName());
+            if (group != null) {
+              permissionEntity.setId(group.getId());
+              permissionEntity.setName(group.getLabel());
+              permissionEntity.setProviderId("group");
+              permissionEntity.setRemoteId(group.getGroupName());
+            }
           } catch (Exception e) {
             LOG.error("Could not find group from permission" + permission);
           }
         }
-        permissionsEntities.add(permissionEntity);
+        if (permissionEntity.getId() != null) {
+          permissionsEntities.add(permissionEntity);
+        }
       }
       newsTargetingEntity.setPermissions(permissionsEntities);
     }
@@ -242,5 +266,32 @@ public class NewsTargetingServiceImpl implements NewsTargetingService {
     metadata.setCreatorId(0);
     return metadata;
   }
-
+  
+  public boolean isTargetAllowed(List<String> targetPermissions, org.exoplatform.services.security.Identity userIdentity) {
+    boolean allowedTarget = true;
+    for (String targetPermission : targetPermissions) {
+      if (targetPermission.split(SPACE_TARGET_PERMISSION_PREFIX).length > 1) {
+        Space targetPermissionSpace = spaceService.getSpaceById(targetPermission.split(SPACE_TARGET_PERMISSION_PREFIX)[1]);
+        if (targetPermissionSpace != null && spaceService.isPublisher(targetPermissionSpace, userIdentity.getUserId())) {
+          allowedTarget = true;
+          break;
+        } else if (targetPermissionSpace != null && !spaceService.isPublisher(targetPermissionSpace, userIdentity.getUserId())) {
+          allowedTarget = false;
+        }
+      } else {
+        try {
+          Group targetPermissionGroup = organizationService.getGroupHandler().findGroupById(targetPermission);
+          if (targetPermissionGroup != null && userIdentity.isMemberOf(targetPermission, PUBLISHER_MEMBERSHIP_NAME)) {
+            allowedTarget = true;
+            break;
+          } else if (targetPermissionGroup != null && !userIdentity.isMemberOf(targetPermission, PUBLISHER_MEMBERSHIP_NAME)) {
+            allowedTarget = false;
+          }
+        } catch (Exception e) {
+          LOG.error("Could not find group from permission" + targetPermission);
+        }
+      }
+    }
+    return allowedTarget;
+  }
 }

--- a/services/src/test/java/org/exoplatform/news/rest/NewsTargetingRestResourcesV1Test.java
+++ b/services/src/test/java/org/exoplatform/news/rest/NewsTargetingRestResourcesV1Test.java
@@ -22,8 +22,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 import static org.junit.Assert.*;
-import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class NewsTargetingRestResourcesV1Test {
@@ -50,12 +49,33 @@ public class NewsTargetingRestResourcesV1Test {
     lenient().when(request.getRemoteUser()).thenReturn("john");
 
     // When
-    Response response = newsTargetingRestResourcesV1.getTargets(request);
+    Response response = newsTargetingRestResourcesV1.getAllTargets(request);
 
     // Then
     assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
   }
 
+  @Test
+  public void shouldReturnOkWhenGetAllowedTargets() {
+    // Given
+    NewsTargetingRestResourcesV1 newsTargetingRestResourcesV1 = new NewsTargetingRestResourcesV1(newsTargetingService, container);
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    lenient().when(request.getRemoteUser()).thenReturn("john");
+
+    // When
+    Response response = newsTargetingRestResourcesV1.getAllowedTargets(request);
+
+    // Then
+    assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+
+    when(newsTargetingRestResourcesV1.getAllowedTargets(request)).thenThrow(RuntimeException.class);
+
+    // When
+    response = newsTargetingRestResourcesV1.getAllowedTargets(request);
+
+    // Then
+    assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
+  }
   @Test
   public void shouldReturnOkWhenGetReferencedTargets() {
     // Given
@@ -68,6 +88,15 @@ public class NewsTargetingRestResourcesV1Test {
 
     // Then
     assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+
+    when(newsTargetingRestResourcesV1.getReferencedTargets(request)).thenThrow(RuntimeException.class);
+
+    // When
+    response = newsTargetingRestResourcesV1.getReferencedTargets(request);
+
+    // Then
+    assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
+
   }
 
   @Test
@@ -83,13 +112,21 @@ public class NewsTargetingRestResourcesV1Test {
     NewsTargetingEntity newsTargetingEntity = new NewsTargetingEntity();
     newsTargetingEntity.setName("test1");
     targets.add(newsTargetingEntity);
-    lenient().when(newsTargetingService.getTargets()).thenReturn(targets);
+    lenient().when(newsTargetingService.getAllTargets()).thenReturn(targets);
 
     // When
     Response response = newsTargetingRestResourcesV1.deleteTarget(request, targets.get(0).getName(), 0);
 
     // Then
     assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+
+    when(newsTargetingRestResourcesV1.deleteTarget(request, targets.get(0).getName(), 0)).thenThrow(RuntimeException.class);
+
+    // When
+    response = newsTargetingRestResourcesV1.deleteTarget(request, targets.get(0).getName(), 0);
+
+    // Then
+    assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
   }
 
   @Test
@@ -116,6 +153,16 @@ public class NewsTargetingRestResourcesV1Test {
 
     // Then
     assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+
+    when(newsTargetingRestResourcesV1.createNewsTarget(request, newsTargetingEntity)).thenThrow(RuntimeException.class);
+
+    // When
+    response = newsTargetingRestResourcesV1.createNewsTarget(request, newsTargetingEntity);
+
+    // Then
+    assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
+
+
   }
 
   @Test
@@ -143,6 +190,14 @@ public class NewsTargetingRestResourcesV1Test {
 
     // Then
     assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+
+    when(newsTargetingRestResourcesV1.updateNewsTarget(newsTargetingEntity, originalTargetName)).thenThrow(RuntimeException.class);
+
+    // When
+    response = newsTargetingRestResourcesV1.updateNewsTarget(newsTargetingEntity, originalTargetName);
+
+    // Then
+    assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
   }
 
 }

--- a/services/src/test/java/org/exoplatform/news/service/impl/NewsTargetingImplTest.java
+++ b/services/src/test/java/org/exoplatform/news/service/impl/NewsTargetingImplTest.java
@@ -1,26 +1,22 @@
-package org.exoplatform.news;
+package org.exoplatform.news.service.impl;
 
-import org.exoplatform.container.ExoContainerContext;
-import org.exoplatform.news.model.News;
-import org.exoplatform.news.model.NewsTargetObject;
-import org.exoplatform.news.rest.NewsTargetingEntity;
-import org.exoplatform.news.service.NewsTargetingService;
-import org.exoplatform.news.service.impl.NewsTargetingServiceImpl;
-import org.exoplatform.news.utils.NewsUtils;
-import org.exoplatform.services.organization.OrganizationService;
-import org.exoplatform.social.core.space.model.*;
-import org.exoplatform.services.security.Authenticator;
-import org.exoplatform.services.security.IdentityRegistry;
-import org.exoplatform.services.security.MembershipEntry;
-import org.exoplatform.social.core.identity.model.Identity;
-import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;
-import org.exoplatform.social.core.manager.IdentityManager;
-import org.exoplatform.social.core.space.spi.SpaceService;
-import org.exoplatform.social.metadata.MetadataService;
-import org.exoplatform.social.metadata.model.Metadata;
-import org.exoplatform.social.metadata.model.MetadataItem;
-import org.exoplatform.social.metadata.model.MetadataKey;
-import org.exoplatform.social.metadata.model.MetadataType;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -29,10 +25,26 @@ import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import java.util.*;
-
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import org.exoplatform.container.ExoContainerContext;
+import org.exoplatform.news.model.News;
+import org.exoplatform.news.model.NewsTargetObject;
+import org.exoplatform.news.rest.NewsTargetingEntity;
+import org.exoplatform.news.service.NewsTargetingService;
+import org.exoplatform.news.utils.NewsUtils;
+import org.exoplatform.services.organization.OrganizationService;
+import org.exoplatform.services.security.Authenticator;
+import org.exoplatform.services.security.IdentityRegistry;
+import org.exoplatform.services.security.MembershipEntry;
+import org.exoplatform.social.core.identity.model.Identity;
+import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;
+import org.exoplatform.social.core.manager.IdentityManager;
+import org.exoplatform.social.core.space.model.Space;
+import org.exoplatform.social.core.space.spi.SpaceService;
+import org.exoplatform.social.metadata.MetadataService;
+import org.exoplatform.social.metadata.model.Metadata;
+import org.exoplatform.social.metadata.model.MetadataItem;
+import org.exoplatform.social.metadata.model.MetadataKey;
+import org.exoplatform.social.metadata.model.MetadataType;
 
 
 @RunWith(PowerMockRunner.class)
@@ -84,7 +96,7 @@ public class NewsTargetingImplTest {
     newsTarget3.setCreatedDate(300);
     HashMap<String, String> testNewsProperties = new HashMap<>();
     testNewsProperties.put("label", "test news");
-    testNewsProperties.put(NewsUtils.TARGET_PERMISSIONS, "space:space1");
+    testNewsProperties.put(NewsUtils.TARGET_PERMISSIONS, "space:1");
     newsTarget3.setProperties(testNewsProperties);
     newsTarget3.setId(3);
     newsTargets.add(newsTarget3);
@@ -95,11 +107,11 @@ public class NewsTargetingImplTest {
     space.setPrettyName("space1");
     space.setAvatarUrl("");
 
-    when(spaceService.getSpaceByPrettyName("space1")).thenReturn(space);
-    when(metadataService.getMetadatas(metadataType.getName(), 100)).thenReturn(newsTargets);
+    when(spaceService.getSpaceById("1")).thenReturn(space);
+    when(metadataService.getMetadatas(metadataType.getName(), 0)).thenReturn(newsTargets);
 
     // When
-    List<NewsTargetingEntity> newsTargetingEntities = newsTargetingService.getTargets();
+    List<NewsTargetingEntity> newsTargetingEntities = newsTargetingService.getAllTargets();
 
     // Then
     assertNotNull(newsTargetingEntities);
@@ -156,7 +168,7 @@ public class NewsTargetingImplTest {
     sliderNews.setId(1);
     newsTargets.add(sliderNews);
 
-    when(metadataService.getMetadatasByProperty("referenced","true", 100)).thenReturn(newsTargets);
+    when(metadataService.getMetadatasByProperty("referenced","true", 0)).thenReturn(newsTargets);
     List<MembershipEntry> memberships = new LinkedList<>();
     MembershipEntry membershipEntry = new MembershipEntry("/platform/web-contributors", "publisher");
     memberships.add(membershipEntry);
@@ -331,7 +343,7 @@ public class NewsTargetingImplTest {
     newsTargetingEntity.setName("test1");
     targets.add(newsTargetingEntity);
 
-    when(newsTargetingService.getTargets()).thenReturn(targets);
+    when(newsTargetingService.getAllTargets()).thenReturn(targets);
     when(metadataService.getMetadataByKey(any())).thenReturn(sliderNews);
     newsTargetingService.deleteTargetByName(targets.get(0).getName(), identity);
 

--- a/webapp/src/main/webapp/components/targetSelector/ExoNewsTargetsSelector.vue
+++ b/webapp/src/main/webapp/components/targetSelector/ExoNewsTargetsSelector.vue
@@ -112,7 +112,7 @@ export default {
     }
   },
   created() {
-    this.getAllTargets();
+    this.getAllowedTargets();
     $(document).click(() => {
       if (this.$refs.chooseTargets && this.$refs.chooseTargets.isMenuActive) {
         this.$refs.chooseTargets.blur();
@@ -143,8 +143,8 @@ export default {
     addTarget() {
       this.$emit('selected-targets', this.selectedTargets);
     },
-    getAllTargets() {
-      this.$newsTargetingService.getAllTargets()
+    getAllowedTargets() {
+      this.$newsTargetingService.getAllowedTargets()
         .then(targets => {
           this.targets = targets.map(target => ({
             name: target.name,

--- a/webapp/src/main/webapp/news-publish-targets-management/components/NewsPublishTargetsManagementDrawer.vue
+++ b/webapp/src/main/webapp/news-publish-targets-management/components/NewsPublishTargetsManagementDrawer.vue
@@ -241,7 +241,7 @@ export default {
           && permission.profile.fullName
           && permission.profile.fullName.substring(0, permission.profile.fullName.lastIndexOf(' ('));
       return {
-        'id': permission.providerId === 'space' ? permission.id : permission.spaceId,
+        'id': permission.providerId === 'space' ? `space:${permission.spaceId}` : permission.spaceId,
         'profile': {
           'fullName': fullName,
         },

--- a/webapp/src/main/webapp/services/newsTargetingService.js
+++ b/webapp/src/main/webapp/services/newsTargetingService.js
@@ -26,6 +26,16 @@ export function getAllTargets() {
     }
   });
 }
+export function getAllowedTargets() {
+  return fetch(`${newsConstants.NEWS_API}/targeting/allowed`, {
+    credentials: 'include',
+    method: 'GET',
+  }).then((resp) => {
+    if (resp && resp.ok) {
+      return resp.json();
+    }
+  });
+}
 
 export function getReferencedTargets() {
   return fetch(`${newsConstants.NEWS_API}/targeting/referenced`, {


### PR DESCRIPTION
We will display the allowed news targets in the publish section of the different publishing drawers.