### PR TITLE
fix; displaying news list for large and small containers - EXO-61365 (#714)

### DIFF
--- a/webapp/src/main/webapp/news-list-view/components/views/NewsListTemplateView.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsListTemplateView.vue
@@ -22,8 +22,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         :class="extraClass"
         cols="12"
         xs="12"
-        md="6"
-        xl="4"
+        :md="mdCols"
+        :xl="lgCols"
         v-for="(item, index) of newsInfo"
         :key="item">
         <div
@@ -71,6 +71,15 @@ export default {
     },
     extraClass() {
       return (!this.showHeader && !this.showSeeAll && !this.$root.canPublishNews ) && ' ' || 'pt-2';
+    },
+    isMobile() {
+      return this.$vuetify.breakpoint.name === 'xs' || this.$vuetify.breakpoint.name === 'sm';
+    },
+    lgCols() {
+      return !this.isMobile && document.getElementById('article-list-view').offsetWidth < this.$vuetify.breakpoint?.thresholds.md && 12 || 3;
+    },
+    mdCols() {
+      return !this.isMobile && document.getElementById('article-list-view').offsetWidth < this.$vuetify.breakpoint?.thresholds.md && 12 || 6;
     }
   },
   created() {


### PR DESCRIPTION
prior to this change, the news list in small containers and x-large containers are not well displayed since it is displayed by columns after this change, the news list is well displayed, with incrementing columns for the x-large containers and decrementing to one column for the small containers