### PR TITLE
fix: news title UI - EXO-61363 (#716)

### DIFF
--- a/webapp/src/main/webapp/news-list-view/components/views/NewsLatestViewItem.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsLatestViewItem.vue
@@ -28,9 +28,9 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
           class="spaceImage"
           :src="item.spaceAvatarUrl"
           :alt="$t('news.latest.alt.spaceImage')">
-        <span class="spaceName">{{ item.spaceDisplayName }}</span>
+        <span class="spaceName text-color text-body-1">{{ item.spaceDisplayName }}</span>
       </div>
-      <span v-if="showArticleTitle" class="articleTitle">{{ item.title }}</span>
+      <span v-if="showArticleTitle" class="articleTitle text-color text-body-1">{{ item.title }}</span>
       <div class="articlePostTitle">
         <div class="reactions">
           <v-icon


### PR DESCRIPTION
prior to this change, the news title and summary are displayed with a font size of 14 px after this change, the news title and summary are displayed with a font size of 16 px