### PR TITLE
fix : News Headlines Template space Name and Title color for main displayed article  - EXO-61508

### DIFF
--- a/webapp/src/main/webapp/skin/less/newsListView.less
+++ b/webapp/src/main/webapp/skin/less/newsListView.less
@@ -332,17 +332,20 @@
         grid-row: ~"1/4";
         .articleInfos {
           position: relative;
-          color: @baseBackgroundDefault;
+          color: @baseBackgroundDefault !important;
           text-shadow: 0 0 4px rgba(0, 0, 0, 0.86);
           margin: auto 15px 15px 15px;
         }
         .reactionIconStyle {
           color: @baseBackgroundDefault;
         }
+        .spaceName {
+          color: @baseBackgroundDefault !important;
+        }
         .articleTitle {
           font-size: 24px;
           line-height: 32px;
-          color: @baseBackgroundDefault;
+          color: @baseBackgroundDefault !important;
           overflow: hidden;
           display: -webkit-box;
           -webkit-box-orient: vertical;


### PR DESCRIPTION
in News Headlines Template, space Name, and Title  color for the main displayed article should be white