### PR TITLE
fix: Template News Headlines images disabled case - EXO-61551

### DIFF
--- a/webapp/src/main/webapp/news-list-view/components/views/NewsLatestView.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsLatestView.vue
@@ -34,6 +34,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         <news-latest-view-item
           :item="item"
           :selected-option="selectedOption"
+          :index="index"
           :key="index" />
       </div>
     </div>

--- a/webapp/src/main/webapp/news-list-view/components/views/NewsLatestViewItem.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsLatestViewItem.vue
@@ -19,9 +19,9 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
     class="articleLink"
     target="_self"
     :href="item.url">
-    <div class="articleImage">
+    <div class="articleImage" v-if="showImage">
       <img 
-        :src="showArticleImage && item.illustrationURL !== null ? item.illustrationURL.concat('&size=1012x344').toString() : '/news/images/news.png'" 
+        :src="articleImg"
         :alt="$t('news.latest.alt.articleImage')">
     </div>
     <div class="articleInfos">
@@ -76,6 +76,11 @@ export default {
       required: false,
       default: null
     },
+    index: {
+      type: Number,
+      required: false,
+      default: null
+    },
   },
   data: ()=> ({
     dateFormat: {
@@ -92,6 +97,15 @@ export default {
     showArticleReactions: true,
   }),
   computed: {
+    articleImg(){
+      return this.showImage && this.img ;
+    },
+    showImage(){
+      return  this.showArticleImage || (!this.showArticleImage && !this.index );
+    },
+    img() {
+      return this.item.illustrationURL?.concat('&size=1012x344').toString() || '/news/images/news.png';
+    },
     displayDate() {
       return this.item.publishDate && this.item.publishDate.time && new Date(this.item.publishDate.time);
     },


### PR DESCRIPTION
Template Headlines: if images displayed are disabled in template settings, then display only the first article image, the rest shouldn't be displayed at all