### PR TITLE
fix: News List template: use correct size for illustrations -EXO-60461

### DIFF
--- a/webapp/src/main/webapp/news-list-view/components/views/NewsCardsViewItem.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsCardsViewItem.vue
@@ -147,7 +147,10 @@ export default {
       return this.selectedOption && this.selectedOption.showArticleSpace;
     },
     articleImage() {
-      return (this.showArticleImage && this.item?.illustrationURL) || '/news/images/news.png';
+      return this.showArticleImage && this.item
+                                   && this.item.illustrationURL
+                                   && this.item.illustrationURL.concat('&size=235x140').toString()
+                                   || '/news/images/news.png';
     },
     isHiddenSpace() {
       return this.item && !this.item.spaceMember && this.item.hiddenSpace;

--- a/webapp/src/main/webapp/news-list-view/components/views/NewsLatestView.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsLatestView.vue
@@ -33,6 +33,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         :class="hasSmallWidthContainer ? 'smallWidthContainer' : 'article'"
         :id="`articleItem-${index}`">
         <news-latest-view-item
+          :news = "newsInfo"
           :item="item"
           :selected-option="selectedOption"
           :index="index"

--- a/webapp/src/main/webapp/news-list-view/components/views/NewsLatestViewItem.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsLatestViewItem.vue
@@ -66,6 +66,11 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 <script>
 export default {
   props: {
+    news: {
+      type: Object,
+      required: false,
+      default: null
+    },
     item: {
       type: Object,
       required: false,
@@ -104,7 +109,7 @@ export default {
       return  this.showArticleImage || (!this.showArticleImage && !this.index );
     },
     img() {
-      return this.item.illustrationURL?.concat('&size=1012x344').toString() || '/news/images/news.png';
+      return this.illustrationURL() || '/news/images/news.png';
     },
     displayDate() {
       return this.item.publishDate && this.item.publishDate.time && new Date(this.item.publishDate.time);
@@ -134,6 +139,17 @@ export default {
       this.showArticleReactions = this.$root.showArticleReactions;
       this.seeAllUrl = this.$root.seeAllUrl;
     },
+    illustrationURL(){
+      if (this.news.length > 1) {
+        if (this.index === 0){
+          return this.item.illustrationURL?.concat('&size=700x344').toString();
+        } else {
+          return this.item.illustrationURL?.concat('&size=107x107').toString();
+        }
+      } else {
+        return this.item.illustrationURL?.concat('&size=1410x344').toString();
+      }
+    }
   }
 };
 </script>

--- a/webapp/src/main/webapp/news-list-view/components/views/NewsMosaicView.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsMosaicView.vue
@@ -30,7 +30,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
           class="articleLink d-block"
           target="_self"
           :href="item.url">
-          <img :src="showArticleImage && item.illustrationURL !== null ? item.illustrationURL : '/news/images/news.png'" :alt="$t('news.latest.alt.articleImage')">
+          <img :src="showArticleImage && item.illustrationURL !== null ? illustrationURL(item,index) : '/news/images/news.png'" :alt="$t('news.latest.alt.articleImage')">
           <div class="titleArea">
             <div v-if="showArticleDate" class="articleDate">
               <date-format
@@ -157,6 +157,17 @@ export default {
     },
     styleArticleTitle(){
       return  (this.isSmallWidth ? 'articleTitle ' : '').concat(this.isSmallBreakpoint ? 'text-truncate' : 'articleTitleTruncate');
+    },
+    illustrationURL(item,index){
+      if (this.news.length > 1) {
+        if (index === 0){
+          return item.illustrationURL.concat('&size=712x404').toString();
+        } else {
+          return item.illustrationURL.concat('&size=712x201').toString();
+        }
+      } else {
+        return item.illustrationURL.concat('&size=1426x404').toString();
+      }
     }
   }
 };

--- a/webapp/src/main/webapp/news-list-view/components/views/NewsSliderView.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsSliderView.vue
@@ -31,7 +31,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         dark>
         <v-img
           class="articleImage fill-height"
-          :src="showArticleImage && item.illustrationURL !== null ? item.illustrationURL : '/news/images/news.png'"
+          :src="showArticleImage && item.illustrationURL !== null ? item.illustrationURL.concat('&size=1420x222').toString() : '/news/images/news.png'"
           eager />
         <v-container class="slide-text-container d-flex text-center body-2">
           <div class="flex flex-column carouselNewsInfo">

--- a/webapp/src/main/webapp/news-list-view/components/views/NewsStoriesViewItem.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsStoriesViewItem.vue
@@ -108,7 +108,7 @@ export default {
       return this.selectedOption && this.selectedOption.showArticleImage;
     },
     articleImage() {
-      return this.showArticleImage && this.item.illustrationURL !== null ? this.item.illustrationURL : '/news/images/news.png';
+      return this.showArticleImage && this.item.illustrationURL !== null ? this.item.illustrationURL.concat('&size=140x210').toString() : '/news/images/news.png';
     }
   }
 };


### PR DESCRIPTION
Prior to this change, the size for illustrations in the templates lists news is still required at the original size of the image. After this change, the size of the illustrations is updated for the correct size.