### PR TITLE
fix: Unpublish news problem after editing news title - EXO-61538

### DIFF
--- a/services/src/main/java/org/exoplatform/news/service/impl/NewsServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/service/impl/NewsServiceImpl.java
@@ -185,7 +185,7 @@ public class NewsServiceImpl implements NewsService {
     boolean displayed = !(StringUtils.equals(news.getPublicationState(), PublicationDefaultStates.STAGED)
         || news.isArchived());
 
-        if (publish == news.isPublished() && canPublish && news.getTargets() != null
+        if (publish == news.isPublished() && news.isPublished() && canPublish && news.getTargets() != null
         && (oldTargets == null || !oldTargets.equals(news.getTargets()))) {
       newsTargetingService.deleteNewsTargets(news.getId(), updater);
       newsTargetingService.saveNewsTarget(news.getId(), displayed, news.getTargets(), updater);

--- a/services/src/main/java/org/exoplatform/news/storage/jcr/JcrNewsStorage.java
+++ b/services/src/main/java/org/exoplatform/news/storage/jcr/JcrNewsStorage.java
@@ -1104,7 +1104,7 @@ public class JcrNewsStorage implements NewsStorage {
     if (newsFolderNode == null) {
       throw new Exception("Unable to find the parent node of the current published node");
     }
-    Node publishedNode = newsFolderNode.getNode(newsNode.getName());
+    Node publishedNode = newsFolderNode.getNode(news.getTitle());
     if (publishedNode == null) {
       throw new Exception("Unable to find the current published node");
     }

--- a/services/src/main/resources/locale/portlet/news/News_en.properties
+++ b/services/src/main/resources/locale/portlet/news/News_en.properties
@@ -245,3 +245,6 @@ news.publishTargets.managementDrawer.btn.cancel=Cancel
 news.publishTargets.managementDrawer.placeholder.name=Enter the target name
 news.publishTargets.managementDrawer.placeholder.description=Enter a description here
 news.publishTargets.managementDrawer.sameNewsTargetWarning=A target with the same name already exists.
+
+news.composer.alert.error.UpdateTargets=Error while updating news targets
+news.composer.alert.success.UpdateTargets=News targets successfully updated

--- a/services/src/test/java/org/exoplatform/news/service/impl/NewsServiceImplTest.java
+++ b/services/src/test/java/org/exoplatform/news/service/impl/NewsServiceImplTest.java
@@ -1,6 +1,16 @@
 package org.exoplatform.news.service.impl;
 
+import org.exoplatform.commons.api.notification.NotificationContext;
+import org.exoplatform.commons.api.notification.NotificationMessageUtils;
+import org.exoplatform.commons.api.notification.model.PluginKey;
+import org.exoplatform.commons.api.notification.plugin.NotificationPluginUtils;
+import org.exoplatform.commons.api.notification.service.template.TemplateContext;
+import org.exoplatform.commons.notification.impl.NotificationContextImpl;
+import org.exoplatform.commons.notification.template.TemplateUtils;
 import org.exoplatform.commons.search.index.IndexingService;
+import org.exoplatform.commons.utils.CommonsUtils;
+import org.exoplatform.commons.utils.HTMLEntityEncoder;
+import org.exoplatform.commons.utils.PropertyManager;
 import org.exoplatform.news.model.News;
 import org.exoplatform.news.search.NewsESSearchConnector;
 import org.exoplatform.news.service.NewsService;
@@ -8,10 +18,16 @@ import org.exoplatform.news.service.NewsTargetingService;
 import org.exoplatform.news.storage.NewsStorage;
 import org.exoplatform.news.utils.NewsUtils;
 import org.exoplatform.portal.config.UserACL;
+import org.exoplatform.services.security.Identity;
+import org.exoplatform.social.core.identity.model.Profile;
+import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;
 import org.exoplatform.social.core.manager.ActivityManager;
 import org.exoplatform.social.core.manager.IdentityManager;
+import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceService;
+import org.exoplatform.social.notification.LinkProviderUtils;
 import org.exoplatform.upload.UploadService;
+import org.exoplatform.webui.utils.TimeConvertUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -22,6 +38,12 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.*;
 
 
@@ -84,5 +106,85 @@ public class NewsServiceImplTest {
         NewsUtils.broadcastEvent(anyString(), any(), any());
         verify(newsStorage, times(1)).markAsRead(news, "user");
 
+    }
+
+    @Test
+    public void testUpdateNews() throws Exception {
+        List<String> targets = new LinkedList<>();
+        targets.add("sliderNews");
+
+        News originalNews = new News();
+        originalNews.setTitle("title");
+        originalNews.setAuthor("root");
+        originalNews.setId("id123");
+        originalNews.setSpaceId("3");
+        originalNews.setActivities("3:39;");
+        originalNews.setActivityId("10");
+        originalNews.setPublished(false);
+        originalNews.setPublicationState("draft");
+
+        News news = new News();
+        news.setTitle("title");
+        news.setAuthor("root");
+        news.setId("id123");
+        news.setSpaceId("3");
+        news.setActivities("3:39;");
+        news.setActivityId("10");
+        news.setPublished(false);
+        news.setPublicationState("draft");
+        news.setCanPublish(false);
+
+        org.exoplatform.services.security.Identity identity = new Identity("1");
+        org.exoplatform.social.core.identity.model.Identity rootIdentity = new org.exoplatform.social.core.identity.model.Identity("1");
+        Profile currentProfile = new Profile();
+        currentProfile.setProperty(Profile.FULL_NAME, "root");
+        rootIdentity.setProfile(currentProfile);
+        when(identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "root")).thenReturn(rootIdentity);
+
+        Space space = new Space();
+        space.setId(news.getSpaceId());
+        space.setGroupId("/spaces/test_space");
+        space.setPrettyName("space_test");
+
+        
+        when(newsTargetingService.getTargetsByNewsId(news.getId())).thenReturn(Collections.emptyList());
+        when(newsStorage.getNewsById(news.getId(), false)).thenReturn(originalNews);
+        when(newsStorage.updateNews(any(News.class), anyString())).thenReturn(originalNews);
+        doNothing().when(newsStorage).unpublishNews(news.getId());
+        doNothing().when(newsStorage).publishNews(any(News.class));
+
+        PowerMockito.mockStatic(NewsUtils.class);
+        when(NewsUtils.processMentions(anyString())).thenReturn(new HashSet<>());
+        when(NewsUtils.getUserIdentity(anyString())).thenReturn(identity);
+        when(NewsUtils.canPublishNews(any(org.exoplatform.services.security.Identity.class))).thenReturn(true);
+
+        when(spaceService.getSpaceById(news.getSpaceId())).thenReturn(null);
+        assertThrows(IllegalArgumentException.class, () -> newsService.updateNews(news, "root", false, false));
+        when(spaceService.getSpaceById(news.getSpaceId())).thenReturn(space);
+
+        newsService.updateNews(news, "root", false, false);
+        verify(newsStorage, times(0)).unpublishNews(news.getId());
+        verify(newsStorage, times(0)).publishNews(any(News.class));
+
+        news.setPublished(true);
+        news.setPublicationState("archived");
+        news.setCanPublish(true);
+        newsService.updateNews(news, "root", null, true);
+        verify(newsStorage, times(0)).unpublishNews(news.getId());
+        verify(newsStorage, times(1)).publishNews(any(News.class));
+
+        when(newsTargetingService.getTargetsByNewsId(news.getId())).thenReturn(targets);
+        originalNews.setPublished(true);
+        when(newsStorage.getNewsById(news.getId(), false)).thenReturn(originalNews);
+        news.setTitle("title updated");
+        newsService.updateNews(news, "root", null, true);
+        verify(newsStorage, times(1)).unpublishNews(news.getId());
+        verify(newsStorage, times(2)).publishNews(any(News.class));
+
+        originalNews.setTitle("title updated");
+        when(newsStorage.getNewsById(news.getId(), false)).thenReturn(originalNews);
+        newsService.updateNews(news, "root", null, false);
+        verify(newsStorage, times(2)).unpublishNews(news.getId());
+        verify(newsStorage, times(2)).publishNews(any(News.class));
     }
 }

--- a/services/src/test/java/org/exoplatform/news/service/impl/NewsServiceImplTest.java
+++ b/services/src/test/java/org/exoplatform/news/service/impl/NewsServiceImplTest.java
@@ -146,7 +146,8 @@ public class NewsServiceImplTest {
         space.setGroupId("/spaces/test_space");
         space.setPrettyName("space_test");
 
-        
+        doNothing().when(newsTargetingService).deleteNewsTargets(anyString(), anyString());
+        doNothing().when(newsTargetingService).saveNewsTarget(anyString(), anyBoolean(), anyList(), anyString());
         when(newsTargetingService.getTargetsByNewsId(news.getId())).thenReturn(Collections.emptyList());
         when(newsStorage.getNewsById(news.getId(), false)).thenReturn(originalNews);
         when(newsStorage.updateNews(any(News.class), anyString())).thenReturn(originalNews);

--- a/webapp/src/main/webapp/news-details/components/ExoNewsEditPublishingDrawer.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsEditPublishingDrawer.vue
@@ -61,6 +61,12 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                 {{ $t('news.details.editPublishing.option') }}
               </label>
             </div>
+
+            <div v-if="allowedTargets.length === 0" class="d-flex flex-row grey--text ms-2">
+              <i class="fas fa-exclamation-triangle mx-2 mt-3"></i>
+              {{ $t('news.composer.stepper.selectedTarget.noTargetAllowed') }}
+            </div>
+
             <exo-news-targets-selector
               v-if="publish"
               id="chooseTargets"
@@ -196,11 +202,24 @@ export default {
       this.news.targets = this.selectedTargets;
       return this.$newsServices.updateNews(this.news, false).then(() => {
         this.editingNews = false;
+        const message = this.$t('news.composer.alert.success.UpdateTargets');
+        this.$root.$emit('news-notification-alert', {
+          message,
+          type: 'success',
+        });
         this.$emit('refresh-news', this.news.newsId);
         window.setTimeout(() => {
           this.drawer = false;
         }, 400);
-      });
+      })
+        .catch(() => {
+          this.editingNews = false;
+          const message = this.$t('news.composer.alert.error.UpdateTargets');
+          this.$root.$emit('news-notification-alert', {
+            message,
+            type: 'error',
+          });
+        });
     },
     removeTargets() {
       this.selectedTargets = [];


### PR DESCRIPTION
* fix: before this change, after changing the title of the published news, the Un-publishing of the news can't be done and the publish button keeps loading, since it can't find the shared news with its new title, it throws an exception that is not handled. After this change, once news title is edited, the published news is removed and the updated news is published and un-published news problem after editing news title - EXO-61538

(cherry picked from commit f8c35f2fcc58bf37cb93ae0717d680acfb0fb763)