### PR TITLE
fix: remove unused allowed target - EXO-61538

### DIFF
--- a/webapp/src/main/webapp/news-details/components/ExoNewsEditPublishingDrawer.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsEditPublishingDrawer.vue
@@ -61,12 +61,6 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                 {{ $t('news.details.editPublishing.option') }}
               </label>
             </div>
-
-            <div v-if="allowedTargets.length === 0" class="d-flex flex-row grey--text ms-2">
-              <i class="fas fa-exclamation-triangle mx-2 mt-3"></i>
-              {{ $t('news.composer.stepper.selectedTarget.noTargetAllowed') }}
-            </div>
-
             <exo-news-targets-selector
               v-if="publish"
               id="chooseTargets"


### PR DESCRIPTION
this backport [PR](https://github.com/exoplatform/news/pull/759) included an unused allowedtarget property.
It has to be removed to fix error opening publish drawer after editing a news article