### PR TITLE
fix: clean news title name when unpublishing news - EXO-61538

### DIFF
--- a/services/src/main/java/org/exoplatform/news/storage/jcr/JcrNewsStorage.java
+++ b/services/src/main/java/org/exoplatform/news/storage/jcr/JcrNewsStorage.java
@@ -1104,7 +1104,7 @@ public class JcrNewsStorage implements NewsStorage {
     if (newsFolderNode == null) {
       throw new Exception("Unable to find the parent node of the current published node");
     }
-    Node publishedNode = newsFolderNode.getNode(news.getTitle());
+    Node publishedNode = newsFolderNode.getNode(Utils.cleanName(news.getTitle()).trim());
     if (publishedNode == null) {
       throw new Exception("Unable to find the current published node");
     }


### PR DESCRIPTION
prior to this change, in some cases when the title have specialChar the foldernode can't be found
after this change, when getting the foldernode the title is cleaned