### PR TITLE
fix: News template headlines+list: Move container to side layout output issue. - EXO-61647

### DIFF
--- a/webapp/src/main/webapp/news-list-view/components/views/NewsLatestViewItem.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsLatestViewItem.vue
@@ -30,9 +30,9 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
           class="spaceImage"
           :src="item.spaceAvatarUrl"
           :alt="$t('news.latest.alt.spaceImage')">
-        <span class="spaceName text-body-1">{{ item.spaceDisplayName }}</span>
+        <span class="spaceName text-color text-body-1">{{ item.spaceDisplayName }}</span>
       </div>
-      <span v-if="showArticleTitle" class="articleTitle text-body-1">{{ item.title }}</span>
+      <span v-if="showArticleTitle" class="articleTitle text-color text-body-1">{{ item.title }}</span>
       <div class="articlePostTitle">
         <div class="reactions">
           <v-icon

--- a/webapp/src/main/webapp/skin/less/newsListView.less
+++ b/webapp/src/main/webapp/skin/less/newsListView.less
@@ -485,11 +485,14 @@
         .articleTitle {
           font-size: 18px;
           line-height: 32px;
-          color: @baseBackgroundDefault;
+          color: @baseBackgroundDefault !important;
           overflow: hidden;
           display: -webkit-box;
           -webkit-box-orient: vertical;
-          -webkit-line-clamp: 2;
+          -webkit-line-clamp: 1;
+        }
+        .spaceName{
+          color: @baseBackgroundDefault !important;
         }
       }
       &:nth-child(n + 2) {
@@ -722,7 +725,7 @@
         overflow: hidden !important;
         display: -webkit-box !important;
         -webkit-box-orient: vertical !important;
-        -webkit-line-clamp: 3 !important;
+        -webkit-line-clamp: 2 !important;
       }
     }
   }


### PR DESCRIPTION
Prior this change, when move the headlines news template on side layout, The styles has changed : the title isn't extended on 2 lines, the space and news title on main article are in black. After this change , The same style in main container maintained.