### PR TITLE
fix: for simple user the post button is disabled - EXO-61796 (#783)

### DIFF
--- a/webapp/src/main/webapp/schedule-news-drawer/components/ExoScheduleNewsDrawer.vue
+++ b/webapp/src/main/webapp/schedule-news-drawer/components/ExoScheduleNewsDrawer.vue
@@ -325,6 +325,9 @@ export default {
       }
     },
     selectedTargets(newVal, oldVal) {
+      if (!this.canPublishNews) {
+        return ;
+      }
       if (this.editScheduledNews ==='editScheduledNews' && this.publish) {
         if (newVal.length !== oldVal.length) {
           this.disabled = false;


### PR DESCRIPTION
before this change, for a simple user, the post button is disabled since no target is selected after this change, the check of the selected target is only for those who can publish a news