### PR TITLE
fix: News template headlines+list: Move container to side layout output issue. - EXO-61647

### DIFF
--- a/webapp/src/main/webapp/skin/less/newsListView.less
+++ b/webapp/src/main/webapp/skin/less/newsListView.less
@@ -467,7 +467,7 @@
           }
         }
         .articleTitle {
-          margin-bottom: 14px;
+          margin-bottom: 3px;
         }
       }
       &:nth-child(1) {
@@ -489,7 +489,7 @@
           overflow: hidden;
           display: -webkit-box;
           -webkit-box-orient: vertical;
-          -webkit-line-clamp: 1;
+          -webkit-line-clamp: 2;
         }
       }
       &:nth-child(n + 2) {


### PR DESCRIPTION
Prior this change, when move the headlines news template on side layout, The styles has changed : the title isn't extended on 2 lines, the space and news title on main article are in black. After this change , The same style in main container maintained.