### PR TITLE
feat: Fix wrong default audience value and default targets when edit publishing and scheduling - EXO-61777

### DIFF
--- a/services/src/main/java/org/exoplatform/news/service/impl/NewsServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/service/impl/NewsServiceImpl.java
@@ -387,6 +387,9 @@ public class NewsServiceImpl implements NewsService {
       newsTargetingService.deleteNewsTargets(news.getId());
       newsTargetingService.saveNewsTarget(news, displayed, news.getTargets(), currentIdentity.getUserId());
     }
+    if (!news.isPublished()) {
+      newsTargetingService.deleteNewsTargets(news.getId());
+    }
     news = newsStorage.scheduleNews(news);
     NewsUtils.broadcastEvent(NewsUtils.SCHEDULE_NEWS, currentIdentity.getUserId(), news);
     return news;

--- a/services/src/main/java/org/exoplatform/news/storage/jcr/JcrNewsStorage.java
+++ b/services/src/main/java/org/exoplatform/news/storage/jcr/JcrNewsStorage.java
@@ -728,7 +728,11 @@ public class JcrNewsStorage implements NewsStorage {
         scheduledNewsNode.setProperty(AuthoringPublicationConstant.START_TIME_PROPERTY, startPublishedDate);
         scheduledNewsNode.setProperty(LAST_PUBLISHER, getCurrentUserId());
         scheduledNewsNode.setProperty("exo:pinned", news.isPublished());
-        scheduledNewsNode.setProperty(NEWS_AUDIENCE_PROP, news.getAudience());
+        if (!news.isPublished() && scheduledNewsNode.hasProperty(NEWS_AUDIENCE_PROP)) {
+          scheduledNewsNode.getProperty(NEWS_AUDIENCE_PROP).remove();
+        } else {
+          scheduledNewsNode.setProperty(NEWS_AUDIENCE_PROP, news.getAudience());
+        }
         scheduledNewsNode.setProperty(NEWS_ACTIVITY_POSTED_MIXIN_PROP, news.isActivityPosted());
         scheduledNewsNode.save();
         publicationService.changeState(scheduledNewsNode, PublicationDefaultStates.STAGED, new HashMap<>());

--- a/webapp/src/main/webapp/components/targetSelector/ExoNewsTargetsSelector.vue
+++ b/webapp/src/main/webapp/components/targetSelector/ExoNewsTargetsSelector.vue
@@ -155,7 +155,7 @@ export default {
     }
   },
   created() {
-    this.selectedAudience = this.audience === 'all' ? this.$t('news.composer.stepper.audienceSection.allUsers') : this.$t('news.composer.stepper.audienceSection.onlySpaceMembers');
+    this.selectedAudience = !this.audience || this.audience === 'all' ? this.$t('news.composer.stepper.audienceSection.allUsers') : this.$t('news.composer.stepper.audienceSection.onlySpaceMembers');
     $(document).click(() => {
       if (this.$refs.chooseTargets && this.$refs.chooseTargets.isMenuActive) {
         this.$refs.chooseTargets.blur();

--- a/webapp/src/main/webapp/schedule-news-drawer/components/ExoScheduleNewsDrawer.vue
+++ b/webapp/src/main/webapp/schedule-news-drawer/components/ExoScheduleNewsDrawer.vue
@@ -329,7 +329,7 @@ export default {
         return ;
       }
       if (this.editScheduledNews ==='editScheduledNews' && this.publish) {
-        if (newVal.length !== oldVal.length) {
+        if (this.selectedTargets.length > 0 && newVal.length !== oldVal.length) {
           this.disabled = false;
         } else {
           this.disabled = true;


### PR DESCRIPTION
Prior to this change:

- When we unpublish a published article then publish it again, the displayed audience value is "only space members"
-  When we unpublish a scheduled article then publish it again, the displayed audience value is "only space members" and the old targets still displayed

After this commit, after unpublishing, we will ensure to reset the audience value to "all users" for published and scheduled articles, and reset the targets with empty values for scheduled articles. 