### PR TITLE
fix: News illustration is blur in mobile view - EXO-61893

### DIFF
--- a/webapp/src/main/webapp/news-extensions/extensions.js
+++ b/webapp/src/main/webapp/news-extensions/extensions.js
@@ -28,7 +28,7 @@ const newsActivityTypeExtensionOptions = {
   hideOnDelete: true,
   supportsThumbnail: true,
   windowTitlePrefixKey: 'news.window.title',
-  getThumbnail: (activity) => activity && activity.news && activity.news.illustrationURL && `${activity.news.illustrationURL}&size=250x150`|| '/news/images/news.png',
+  getThumbnail: (activity) => activity && activity.news && activity.news.illustrationURL && `${activity.news.illustrationURL}&size=305x285`|| '/news/images/news.png',
   getThumbnailProperties: (activity) => !(activity && activity.news && activity.news.illustrationURL) && {
     height: '90px',
     width: '90px',


### PR DESCRIPTION
Before this fix, the illustration image in news activity is blur in mobile. In fact, in mobile view the activity display a larger image than in desktop view, but the size used is still the desktop one, with the small size. So we have a blur effect. This fix update the size to use the mobile one as it is the larger