### PR TITLE
fix : When an illustration is requested with a size, the image is always resized - EXO-61217

### DIFF
--- a/services/src/main/java/org/exoplatform/news/model/News.java
+++ b/services/src/main/java/org/exoplatform/news/model/News.java
@@ -52,6 +52,8 @@ public class News {
 
   private Date                 illustrationUpdateDate;
 
+  private String                 illustrationMimeType;
+
   private String               illustrationURL;
 
   private Date                 creationDate;

--- a/services/src/main/java/org/exoplatform/news/storage/jcr/JcrNewsStorage.java
+++ b/services/src/main/java/org/exoplatform/news/storage/jcr/JcrNewsStorage.java
@@ -479,6 +479,7 @@ public class JcrNewsStorage implements NewsStorage {
       byte[] bytes = IOUtils.toByteArray(illustrationContentNode.getProperty("jcr:data").getStream());
       news.setIllustration(bytes);
       news.setIllustrationUpdateDate(illustrationContentNode.getProperty("exo:dateModified").getDate().getTime());
+      news.setIllustrationMimeType(illustrationContentNode.getProperty("jcr:mimeType").getString());
       long lastModified = news.getIllustrationUpdateDate().getTime();
       news.setIllustrationURL("/portal/rest/v1/news/" + news.getId() + "/illustration?v=" + lastModified);
     }


### PR DESCRIPTION
Before this fix, the cache is not well managed for news illustrations. This fix improve etag usage and cache configuration so that the cache is better used, and the image less recalculated In addition, in this fix, we return the correct image mimetype