### PR TITLE
fix: News illustration is blur in mobile view - EXO-61893

### DIFF
--- a/webapp/src/main/webapp/news-details/components/mobile/ExoNewsDetailsToolBarMobile.vue
+++ b/webapp/src/main/webapp/news-details/components/mobile/ExoNewsDetailsToolBarMobile.vue
@@ -69,7 +69,7 @@ export default {
       return this.news && this.news.spaceMember ? this.news.spaceUrl : `${eXo.env.portal.context}/${eXo.env.portal.portalName}`;
     },
     illustrationUrl() {
-      return this.news && this.news.illustrationURL ? this.news.illustrationURL.concat('&size=0x128').toString() : '/news/images/news.png';
+      return this.news && this.news.illustrationURL ? this.news.illustrationURL.concat('&size=315x128').toString() : '/news/images/news.png';
     },
     publicationState() {
       return this.news && this.news.publicationState;


### PR DESCRIPTION
Before this fix, the illustration image in news activity is blur in mobile. In fact, in mobile view the activity display a larger image than in desktop view, but the size used is still the desktop one, with the small size. So we have a blur effect. This fix update the size to use the mobile one as it is the larger