### PR TITLE
fix: Unread Activities - Doesn't work with news activities - EXO-61582

### DIFF
--- a/services/src/main/java/org/exoplatform/news/notification/plugin/MentionInNewsNotificationPlugin.java
+++ b/services/src/main/java/org/exoplatform/news/notification/plugin/MentionInNewsNotificationPlugin.java
@@ -58,6 +58,7 @@ public class MentionInNewsNotificationPlugin extends BaseNotificationPlugin {
     String illustrationUrl = ctx.value(PostNewsNotificationPlugin.ILLUSTRATION_URL);
     String authorAvatarUrl = ctx.value(PostNewsNotificationPlugin.AUTHOR_AVATAR_URL);
     String activityLink = ctx.value(PostNewsNotificationPlugin.ACTIVITY_LINK);
+    String newsId = ctx.value(PostNewsNotificationPlugin.NEWS_ID);
 
     return NotificationInfo.instance()
             .setFrom(currentUserName)
@@ -72,6 +73,7 @@ public class MentionInNewsNotificationPlugin extends BaseNotificationPlugin {
             .with(NotificationConstants.ACTIVITY_LINK, activityLink)
             .with(NotificationConstants.CONTEXT, context.getContext())
             .with(NotificationConstants.MENTIONED_IDS, String.valueOf(mentionedIds))
+            .with(NotificationConstants.NEWS_ID, newsId)
             .end();
   }
 }

--- a/services/src/main/java/org/exoplatform/news/notification/plugin/NewsSpaceWebNotificationPlugin.java
+++ b/services/src/main/java/org/exoplatform/news/notification/plugin/NewsSpaceWebNotificationPlugin.java
@@ -1,0 +1,69 @@
+package org.exoplatform.news.notification.plugin;
+
+import org.apache.commons.lang.StringUtils;
+import org.exoplatform.commons.api.notification.model.NotificationInfo;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.news.model.News;
+import org.exoplatform.news.notification.utils.NotificationConstants;
+import org.exoplatform.news.service.NewsService;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+import org.exoplatform.social.core.activity.model.ExoSocialActivity;
+import org.exoplatform.social.core.manager.ActivityManager;
+import org.exoplatform.social.core.manager.IdentityManager;
+import org.exoplatform.social.metadata.model.MetadataObject;
+import org.exoplatform.social.notification.model.SpaceWebNotificationItem;
+import org.exoplatform.social.notification.plugin.SpaceWebNotificationPlugin;
+
+public class NewsSpaceWebNotificationPlugin extends SpaceWebNotificationPlugin {
+
+    private static final Log LOG              = ExoLogger.getLogger(NewsSpaceWebNotificationPlugin.class);
+
+    public static final String ID = "NewsSpaceWebNotificationPlugin";
+
+    private ActivityManager activityManager;
+
+    private NewsService newsService;
+
+    public NewsSpaceWebNotificationPlugin(ActivityManager activityManager, NewsService newsService, IdentityManager identityManager, InitParams params) {
+        super(identityManager, params);
+        this.activityManager = activityManager;
+        this.newsService = newsService;
+    }
+
+    @Override
+    public SpaceWebNotificationItem getSpaceApplicationItem(NotificationInfo notification) {
+        String newsId = notification.getValueOwnerParameter(NotificationConstants.NEWS_ID);
+        News news = null;
+        try {
+            news = newsService.getNewsById(newsId, false);
+        } catch (Exception e) {
+            LOG.warn("Error retrieving news by id {}", newsId, e);
+            return null;
+        }
+        if (news == null) {
+            LOG.debug("News by id {} wasn't found. The space web notification will not be sent.", newsId);
+            return null;
+        }
+        String activityId = news.getActivityId();
+        if (StringUtils.isBlank(activityId)) {
+            return null;
+        }
+        ExoSocialActivity activity = activityManager.getActivity(activityId);
+        MetadataObject metadataObject;
+        if (activity.isComment()) {
+            ExoSocialActivity parentActivity = activityManager.getActivity(activity.getParentId());
+            metadataObject = parentActivity.getMetadataObject();
+        } else {
+            metadataObject = activity.getMetadataObject();
+        }
+        SpaceWebNotificationItem spaceWebNotificationItem = new SpaceWebNotificationItem(metadataObject.getType(),
+                metadataObject.getId(),
+                0,
+                metadataObject.getSpaceId());
+        if (activity.isComment()) {
+            spaceWebNotificationItem.addApplicationSubItem(activity.getId());
+        }
+        return spaceWebNotificationItem;
+    }
+}

--- a/services/src/main/java/org/exoplatform/news/notification/plugin/PostNewsNotificationPlugin.java
+++ b/services/src/main/java/org/exoplatform/news/notification/plugin/PostNewsNotificationPlugin.java
@@ -92,6 +92,7 @@ public class PostNewsNotificationPlugin extends BaseNotificationPlugin {
     String illustrationUrl = ctx.value(ILLUSTRATION_URL);
     String authorAvatarUrl = ctx.value(AUTHOR_AVATAR_URL);
     String activityLink = ctx.value(ACTIVITY_LINK);
+    String newsId = ctx.value(NEWS_ID);
 
     List<String> receivers = new ArrayList<String>();
     try {
@@ -111,6 +112,7 @@ public class PostNewsNotificationPlugin extends BaseNotificationPlugin {
                            .with(NotificationConstants.AUTHOR_AVATAR_URL, authorAvatarUrl)
                            .with(NotificationConstants.ACTIVITY_LINK, activityLink)
                            .with(NotificationConstants.CONTEXT, context.getContext())
+                           .with(NotificationConstants.NEWS_ID, newsId)
                            .key(getKey())
                            .end();
 

--- a/services/src/main/java/org/exoplatform/news/service/impl/NewsServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/service/impl/NewsServiceImpl.java
@@ -638,10 +638,10 @@ public class NewsServiceImpl implements NewsService {
       ctx.getNotificationExecutor().with(ctx.makeCommand(PluginKey.key(PostNewsNotificationPlugin.ID))).execute(ctx);
       Matcher matcher = MentionInNewsNotificationPlugin.MENTION_PATTERN.matcher(contentBody);
       if(matcher.find()) {
-        sendMentionInNewsNotification(contentAuthor, currentUser, contentTitle, contentBody, contentSpaceId, illustrationURL, authorAvatarUrl, activityLink, contentSpaceName);
+        sendMentionInNewsNotification(newsId, contentAuthor, currentUser, contentTitle, contentBody, contentSpaceId, illustrationURL, authorAvatarUrl, activityLink, contentSpaceName);
       }
     } else if (context.equals(NotificationConstants.NOTIFICATION_CONTEXT.MENTION_IN_NEWS)) {
-      sendMentionInNewsNotification(contentAuthor, currentUser, contentTitle, contentBody, contentSpaceId, illustrationURL, authorAvatarUrl, activityLink, contentSpaceName);
+      sendMentionInNewsNotification(newsId, contentAuthor, currentUser, contentTitle, contentBody, contentSpaceId, illustrationURL, authorAvatarUrl, activityLink, contentSpaceName);
     } else if (context.equals(NotificationConstants.NOTIFICATION_CONTEXT.PUBLISH_IN_NEWS)) {
       if (news.getAudience() != null) {
         ctx.append(PostNewsNotificationPlugin.AUDIENCE, news.getAudience());
@@ -650,7 +650,7 @@ public class NewsServiceImpl implements NewsService {
     }
   }
   
-  private void sendMentionInNewsNotification(String contentAuthor, String currentUser, String contentTitle, String contentBody, String contentSpaceId, String illustrationURL, String authorAvatarUrl, String activityLink, String contentSpaceName) {
+  private void sendMentionInNewsNotification(String newsId, String contentAuthor, String currentUser, String contentTitle, String contentBody, String contentSpaceId, String illustrationURL, String authorAvatarUrl, String activityLink, String contentSpaceName) {
     Set<String> mentionedIds = NewsUtils.processMentions(contentBody);
     NotificationContext mentionNotificationCtx = NotificationContextImpl.cloneInstance()
             .append(MentionInNewsNotificationPlugin.CONTEXT, NotificationConstants.NOTIFICATION_CONTEXT.MENTION_IN_NEWS)
@@ -662,7 +662,8 @@ public class NewsServiceImpl implements NewsService {
             .append(PostNewsNotificationPlugin.ILLUSTRATION_URL, illustrationURL)
             .append(PostNewsNotificationPlugin.AUTHOR_AVATAR_URL, authorAvatarUrl)
             .append(PostNewsNotificationPlugin.ACTIVITY_LINK, activityLink)
-            .append(MentionInNewsNotificationPlugin.MENTIONED_IDS, mentionedIds);
+            .append(MentionInNewsNotificationPlugin.MENTIONED_IDS, mentionedIds)
+            .append(PostNewsNotificationPlugin.NEWS_ID, newsId);
     mentionNotificationCtx.getNotificationExecutor().with(mentionNotificationCtx.makeCommand(PluginKey.key(MentionInNewsNotificationPlugin.ID))).execute(mentionNotificationCtx);
   }
   

--- a/services/src/test/java/org/exoplatform/news/notification/plugin/NewsSpaceWebNotificationPluginTest.java
+++ b/services/src/test/java/org/exoplatform/news/notification/plugin/NewsSpaceWebNotificationPluginTest.java
@@ -1,0 +1,89 @@
+package org.exoplatform.news.notification.plugin;
+
+import org.exoplatform.commons.api.notification.model.NotificationInfo;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.container.xml.ValuesParam;
+import org.exoplatform.news.model.News;
+import org.exoplatform.news.notification.utils.NotificationConstants;
+import org.exoplatform.news.service.NewsService;
+import org.exoplatform.social.core.activity.model.ExoSocialActivity;
+import org.exoplatform.social.core.activity.model.ExoSocialActivityImpl;
+import org.exoplatform.social.core.identity.model.Identity;
+import org.exoplatform.social.core.manager.ActivityManager;
+import org.exoplatform.social.core.manager.IdentityManager;
+import org.exoplatform.social.metadata.model.MetadataObject;
+import org.exoplatform.social.notification.model.SpaceWebNotificationItem;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class NewsSpaceWebNotificationPluginTest {
+
+    private static final String                       ACTIVITY_NOTIFICATION_PLUGIN_ID = "ACTIVITY_NOTIFICATION";
+
+    private static final String                       USERNAME                        = "username";
+
+    @Mock
+    private IdentityManager                           identityManager;
+
+    @Mock
+    private ActivityManager                           activityManager;
+
+    @Mock
+    private InitParams                                initParams;
+
+    @Mock
+    private NewsService newsService;
+
+    private static NewsSpaceWebNotificationPlugin newsSpaceWebNotificationPlugin;
+
+    @Before
+    public void setUp() throws Exception {
+        ValuesParam pluginIdsValues = new ValuesParam();
+        pluginIdsValues.setValues(Arrays.asList(ACTIVITY_NOTIFICATION_PLUGIN_ID));
+        when(initParams.getValuesParam("notification.plugin.ids")).thenReturn(pluginIdsValues);
+        newsSpaceWebNotificationPlugin = new NewsSpaceWebNotificationPlugin(activityManager, newsService, identityManager, initParams);
+    }
+
+    @Test
+    public void testGetSpaceApplicationItem() throws Exception {
+        NotificationInfo notificationInfo = mock(NotificationInfo.class);
+        Identity userIdentity = mock(Identity.class);
+        String activityId = "activityId";
+        ExoSocialActivity activity = mock(ExoSocialActivity.class);
+        MetadataObject metadataObject = mock(MetadataObject.class);
+        News news = mock(News.class);
+        long spaceId = 12l;
+        long userIdentityId = 15l;
+        String newsId = "newsId";
+        String metadataObjectType = ExoSocialActivityImpl.DEFAULT_ACTIVITY_METADATA_OBJECT_TYPE;
+        String metadataObjectId = activityId;
+        when(notificationInfo.getValueOwnerParameter(NotificationConstants.NEWS_ID)).thenReturn(newsId);
+        when(newsService.getNewsById(newsId, false)).thenReturn(news);
+        when(news.getActivityId()).thenReturn(activityId);
+        when(identityManager.getOrCreateUserIdentity(USERNAME)).thenReturn(userIdentity);
+        when(userIdentity.getId()).thenReturn(String.valueOf(userIdentityId));
+        when(activityManager.getActivity(activityId)).thenReturn(activity);
+        when(activity.getMetadataObject()).thenReturn(metadataObject);
+        when(metadataObject.getType()).thenReturn(metadataObjectType);
+        when(metadataObject.getId()).thenReturn(metadataObjectId);
+        when(metadataObject.getSpaceId()).thenReturn(spaceId);
+
+        SpaceWebNotificationItem spaceApplicationItem = newsSpaceWebNotificationPlugin.getSpaceApplicationItem(notificationInfo, USERNAME);
+        assertNotNull(spaceApplicationItem);
+        assertEquals(activityId, spaceApplicationItem.getApplicationItemId());
+        assertEquals(metadataObjectType, spaceApplicationItem.getApplicationName());
+        assertEquals(spaceId, spaceApplicationItem.getSpaceId());
+        assertEquals(userIdentityId, spaceApplicationItem.getUserId());
+    }
+}

--- a/webapp/src/main/webapp/WEB-INF/conf/news/notification/configuration.xml
+++ b/webapp/src/main/webapp/WEB-INF/conf/news/notification/configuration.xml
@@ -166,6 +166,23 @@
   </external-component-plugins>
 
   <external-component-plugins>
+    <target-component>org.exoplatform.social.notification.service.SpaceWebNotificationService</target-component>
+    <component-plugin>
+      <name>NewsSpaceWebNotificationPlugin</name>
+      <set-method>addPlugin</set-method>
+      <type>org.exoplatform.news.notification.plugin.NewsSpaceWebNotificationPlugin</type>
+      <init-params>
+        <values-param>
+          <name>notification.plugin.ids</name>
+          <value>PublishNewsNotificationPlugin</value>
+          <value>MentionInNewsNotificationPlugin</value>
+          <value>PostNewsNotificationPlugin</value>
+        </values-param>
+      </init-params>
+    </component-plugin>
+  </external-component-plugins>
+
+  <external-component-plugins>
     <target-component>org.exoplatform.commons.api.notification.channel.ChannelManager</target-component>
     <component-plugin>
       <name>web.channel.content</name>
@@ -178,11 +195,6 @@
         </value-param>
       </init-params>
     </component-plugin>
-  </external-component-plugins>
-
-
-  <external-component-plugins>
-    <target-component>org.exoplatform.commons.api.notification.channel.ChannelManager</target-component>
     <component-plugin>
       <name>web.channel.content</name>
       <set-method>registerTemplateProvider</set-method>
@@ -194,10 +206,6 @@
         </value-param>
       </init-params>
     </component-plugin>
-  </external-component-plugins>
-
-  <external-component-plugins>
-    <target-component>org.exoplatform.commons.api.notification.channel.ChannelManager</target-component>
     <component-plugin>
       <name>web.channel.content</name>
       <set-method>registerTemplateProvider</set-method>
@@ -206,6 +214,17 @@
         <value-param>
           <name>channel-id</name>
           <value>PUSH_CHANNEL</value>
+        </value-param>
+      </init-params>
+    </component-plugin>
+    <component-plugin>
+      <name>web.channel.content</name>
+      <set-method>registerTemplateProvider</set-method>
+      <type>org.exoplatform.news.notification.provider.PushTemplateProvider</type>
+      <init-params>
+        <value-param>
+          <name>channel-id</name>
+          <value>SPACE_WEB_CHANNEL</value>
         </value-param>
       </init-params>
     </component-plugin>


### PR DESCRIPTION
Prior this changes, when a member of a space post an article the red bullet for undread activities doesn't display for other members of that space. after this change , the red bullet for unread news display correctly.