### PR TITLE
fix: Standardize font styles/size between notes and news pages - EXO-61667.

### DIFF
--- a/webapp/src/main/webapp/skin/less/newsDetails.less
+++ b/webapp/src/main/webapp/skin/less/newsDetails.less
@@ -148,6 +148,33 @@
         height: 100%;
       }
     }
+    span {
+      
+      h1 {
+        font-size: 34px !important;
+        font-weight: 400 !important;
+      }
+      
+      h2 {
+        font-size: 28px !important;
+        font-weight: 400 !important;
+      }
+      
+      h3 {
+        font-size: 21.84px !important;
+        font-weight: 400 !important;
+      }
+      
+      p, li {
+        font-size:18.6667px !important;
+        font-weight: normal !important;
+      }
+      
+      blockquote p{
+        font-size: 17.5px !important;
+        font-weight: 300 !important;
+      }
+    }
   }
 
   .newsAttachmentsTitle {


### PR DESCRIPTION
Prior to this change, font styles and size were not standardized between different views in notes and news. After this change, some css style are applied on headline ,bulleted-list, numbered-list and block quote to be standardize with notes pages.