### PR TITLE
fix: Standardize font styles/size between notes and news pages - EXO-61667

### DIFF
--- a/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
+++ b/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
@@ -548,6 +548,11 @@ export default {
         extraPlugins = `${extraPlugins},tagSuggester`;
       }
       CKEDITOR.addCss('.cke_editable { font-size: 14pt; font-family: Helvetica, regular, sans-serif; }');
+      CKEDITOR.addCss('h1 { font-size: 34px;font-weight: 400;}');
+      CKEDITOR.addCss('h2 { font-size: 28px;font-weight: 400;}');
+      CKEDITOR.addCss('h3 { font-size: 21.84px;font-weight: 400;}');
+      CKEDITOR.addCss('p,li { font-size: 18.6667px;}');
+      CKEDITOR.addCss('blockquote p  { font-size: 17.5px;font-weight: 300;}');
       // this line is mandatory when a custom skin is defined
 
       CKEDITOR.basePath = '/commons-extension/ckeditor/';

--- a/webapp/src/main/webapp/skin/less/newsDetails.less
+++ b/webapp/src/main/webapp/skin/less/newsDetails.less
@@ -77,6 +77,34 @@
       color: @grayDark;
       opacity: 0.4;
     }
+    
+    .newsContent .newsBody span {
+      
+      h1 {
+        font-size: 34px !important;
+        font-weight: 400 !important;
+      }
+      
+      h2 {
+        font-size: 28px !important;
+        font-weight: 400 !important;
+      }
+      
+      h3 {
+        font-size: 21.84px !important;
+        font-weight: 400 !important;
+      }
+      
+      p, li {
+        font-size:18.6667px !important;
+        font-weight: normal !important;
+      }
+      
+      blockquote p{
+        font-size: 17.5px !important;
+        font-weight: 300 !important;
+      }
+    }
   }
 }
 
@@ -146,6 +174,33 @@
         left: auto ~'; /** orientation=rt */ ';
         width: 100%;
         height: 100%;
+      }
+    }
+    span {
+      
+      h1 {
+        font-size: 34px !important;
+        font-weight: 400 !important;
+      }
+      
+      h2 {
+        font-size: 28px !important;
+        font-weight: 400 !important;
+      }
+      
+      h3 {
+        font-size: 21.84px !important;
+        font-weight: 400 !important;
+      }
+      
+      p, li {
+        font-size:18.6667px !important;
+        font-weight: normal !important;
+      }
+      
+      blockquote p{
+        font-size: 17.5px !important;
+        font-weight: 300 !important;
       }
     }
   }
@@ -278,6 +333,31 @@
           width: 100%;
           height: 100%;
         }
+      }
+      
+      h1 {
+        font-size: 34px !important;
+        font-weight: 400 !important;
+      }
+      
+      h2 {
+        font-size: 28px !important;
+        font-weight: 400 !important;
+      }
+      
+      h3 {
+        font-size: 21.84px !important;
+        font-weight: 400 !important;
+      }
+      
+      p, li {
+        font-size:18.6667px !important;
+        font-weight: normal !important;
+      }
+      
+      blockquote p{
+        font-size: 17.5px !important;
+        font-weight: 300 !important;
       }
     }
 


### PR DESCRIPTION
Prior to this change, font styles and size were not standardized between different views in notes and news. After this change, some css style are applied on headline ,bulleted-list, numbered-list and block quote to be standardize with notes pages.