### PR TITLE
fix: No attachment when a news is published later - EXO-62227 

### DIFF
--- a/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
+++ b/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
@@ -388,6 +388,7 @@ export default {
       switchView: false,
       spaceDisplayName: '',
       unAuthorizedAccess: false,
+      endUplodingFileTimeout: 50,
     };
   },
   computed: {
@@ -453,8 +454,9 @@ export default {
     'news.attachments': function() {
       if (this.initDone && this.news.attachments !== this.originalNews.attachments) {
         this.attachmentsChanged = true;
-        this.autoSave();
+        this.waitForEndUploding();
       }
+
     },
     'news.illustration': function() {
       if (this.initIllustrationDone) {
@@ -1107,6 +1109,16 @@ export default {
         attachFileButton.style.display = 'none';
         this.switchView = false;
       }
+    },
+    waitForEndUploding() {
+      window.setTimeout(() => {
+        if (this.uploading) {
+          this.waitForEndUploding();
+        }
+        else {
+          this.autoSave();
+        }
+      }, this.endUplodingFileTimeout);
     }
   }
 };


### PR DESCRIPTION
Prior to this change, if we wanted to create a news item with an attached file, the news would be created without the attachment. The problem was that if we had a slow internet connection, the auto-save function would be executed before the file was finished uploading. As a result, the news would be saved without the attachment.

This change implements a "waitForEndUploading" method, which will automatically save the news after the file has finished uploading.