### PR TITLE
fix: publish news notification is received when editing a published news - EXO-62469

### DIFF
--- a/services/src/main/java/org/exoplatform/news/service/NewsService.java
+++ b/services/src/main/java/org/exoplatform/news/service/NewsService.java
@@ -75,9 +75,10 @@ public interface NewsService {
    *
    * @param news to be published
    * @param publisher of the News
+   * @param broadcast if to broadcast send notification
    * @throws Exception when error
    */
-  void publishNews(News news, String publisher) throws Exception;
+  void publishNews(News news, String publisher, boolean broadcast) throws Exception;
   
   /**
    * Unpublish a News

--- a/services/src/main/java/org/exoplatform/news/service/NewsService.java
+++ b/services/src/main/java/org/exoplatform/news/service/NewsService.java
@@ -75,10 +75,9 @@ public interface NewsService {
    *
    * @param news to be published
    * @param publisher of the News
-   * @param broadcast if to broadcast send notification
    * @throws Exception when error
    */
-  void publishNews(News news, String publisher, boolean broadcast) throws Exception;
+  void publishNews(News news, String publisher) throws Exception;
   
   /**
    * Unpublish a News

--- a/services/src/main/java/org/exoplatform/news/service/impl/NewsServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/service/impl/NewsServiceImpl.java
@@ -442,6 +442,7 @@ public class NewsServiceImpl implements NewsService {
   public void publishNews(News publishedNews, String publisher) throws Exception {
     News news = getNewsById(publishedNews.getId(), false);
     boolean displayed = !(StringUtils.equals(news.getPublicationState(), PublicationDefaultStates.STAGED) || news.isArchived());
+    newsStorage.publishNews(news);
     if (publishedNews.getTargets() != null) {
       newsTargetingService.deleteNewsTargets(news, publisher);
       newsTargetingService.saveNewsTarget(news, displayed, publishedNews.getTargets(), publisher);
@@ -460,6 +461,7 @@ public class NewsServiceImpl implements NewsService {
    */
   @Override
   public void unpublishNews(String newsId, String publisher) throws Exception {
+    newsStorage.unpublishNews(newsId);
     News news = getNewsById(newsId, false);
     newsTargetingService.deleteNewsTargets(news, publisher);
   }

--- a/services/src/main/java/org/exoplatform/news/service/impl/NewsServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/service/impl/NewsServiceImpl.java
@@ -166,16 +166,16 @@ public class NewsServiceImpl implements NewsService {
         if (news.getTargets() == null || news.getTargets().isEmpty()) {
           news.setTargets(oldTargets);
         }
-        publishNews(news, updater, false);
+        publish(news, updater);
       }
       // publish & unpublish cases without editing title
       else if (!publish && (oldTargets != null && !oldTargets.isEmpty())) {
         unpublishNews(news.getId(), updater);
-      } else if (publish && (publish != news.isPublished()) && canPublish && !news.getPublicationState().equals("draft")) {
+      } else if (publish && (publish != originalNews.isPublished()) && canPublish && !news.getPublicationState().equals("draft") && !originalNews.getPublicationState().equals("draft")) {
         if (news.getTargets() == null || news.getTargets().isEmpty()) {
           news.setTargets(oldTargets);
         }
-        publishNews(news, updater, true);
+        publishNews(news, updater);
       }
     } catch (Exception e) {
       throw new Exception("error while publish/unpublish news", e);
@@ -432,7 +432,7 @@ public class NewsServiceImpl implements NewsService {
     updateNews(news, poster, null, news.isPublished());
     sendNotification(poster, news, NotificationConstants.NOTIFICATION_CONTEXT.POST_NEWS);
     if (news.isPublished()) {
-      publishNews(news, poster, true);
+      publishNews(news, poster);
     }
     NewsUtils.broadcastEvent(NewsUtils.POST_NEWS_ARTICLE, news.getId(), news);//Gamification
     NewsUtils.broadcastEvent(NewsUtils.POST_NEWS, news.getAuthor(), news);//Analytics
@@ -454,7 +454,17 @@ public class NewsServiceImpl implements NewsService {
    * {@inheritDoc}
    */
   @Override
-  public void publishNews(News publishedNews, String publisher, boolean broadcast) throws Exception {
+  public void publishNews(News publishedNews, String publisher) throws Exception {
+    News news = publish(publishedNews, publisher);
+    try {
+      news.setAudience(publishedNews.getAudience());//TODO waiting to fix sending notification when the article is already published PR#749
+      sendNotification(publisher, news, NotificationConstants.NOTIFICATION_CONTEXT.PUBLISH_NEWS);
+    } catch (Error | Exception e) {
+      LOG.warn("Error sending notification when publishing news with Id " + news.getId(), e);
+    }
+  }
+
+  private News publish(News publishedNews ,String publisher) throws Exception {
     News news = getNewsById(publishedNews.getId(), false);
     boolean displayed = !(StringUtils.equals(news.getPublicationState(), PublicationDefaultStates.STAGED) || news.isArchived());
     newsStorage.publishNews(news);
@@ -462,16 +472,8 @@ public class NewsServiceImpl implements NewsService {
       newsTargetingService.deleteNewsTargets(news, publisher);
       newsTargetingService.saveNewsTarget(news, displayed, publishedNews.getTargets(), publisher);
     }
-
     NewsUtils.broadcastEvent(NewsUtils.PUBLISH_NEWS, news.getId(), news);
-    try {
-      news.setAudience(publishedNews.getAudience());//TODO waiting to fix sending notification when the article is already published PR#749
-      if(broadcast) {
-        sendNotification(publisher, news, NotificationConstants.NOTIFICATION_CONTEXT.PUBLISH_NEWS);
-      }
-    } catch (Error | Exception e) {
-      LOG.warn("Error sending notification when publishing news with Id " + news.getId(), e);
-    }
+    return news;
   }
 
   /**

--- a/services/src/main/java/org/exoplatform/news/storage/NewsStorage.java
+++ b/services/src/main/java/org/exoplatform/news/storage/NewsStorage.java
@@ -12,6 +12,8 @@ public interface NewsStorage {
   
   News createNews(News news) throws Exception;
 
+  void publishNews(News news) throws Exception;
+
   String getNewsIllustration(News news) throws Exception;
   
   News updateNews(News news, String updater) throws Exception;
@@ -27,6 +29,8 @@ public interface NewsStorage {
   void markAsRead(News news, String userId) throws Exception;
   
   boolean isCurrentUserInNewsViewers(String newsId, String userId) throws Exception;
+
+  void unpublishNews(String newsId) throws Exception;
 
   void shareNews(News news, Space space, Identity userIdentity, String sharedActivityId) throws IllegalAccessException, ObjectNotFoundException;
   

--- a/services/src/main/java/org/exoplatform/news/storage/NewsStorage.java
+++ b/services/src/main/java/org/exoplatform/news/storage/NewsStorage.java
@@ -11,9 +11,7 @@ import org.exoplatform.social.core.space.model.Space;
 public interface NewsStorage {
   
   News createNews(News news) throws Exception;
-  
-  void publishNews(News news) throws Exception;
-  
+
   String getNewsIllustration(News news) throws Exception;
   
   News updateNews(News news, String updater) throws Exception;
@@ -29,9 +27,7 @@ public interface NewsStorage {
   void markAsRead(News news, String userId) throws Exception;
   
   boolean isCurrentUserInNewsViewers(String newsId, String userId) throws Exception;
-  
-  void unpublishNews(String newsId) throws Exception;
-  
+
   void shareNews(News news, Space space, Identity userIdentity, String sharedActivityId) throws IllegalAccessException, ObjectNotFoundException;
   
   void deleteNews(String newsId, boolean isDraft) throws Exception;

--- a/services/src/main/java/org/exoplatform/news/storage/jcr/JcrNewsStorage.java
+++ b/services/src/main/java/org/exoplatform/news/storage/jcr/JcrNewsStorage.java
@@ -1120,6 +1120,10 @@ public class JcrNewsStorage implements NewsStorage {
     if (newsNode == null) {
       throw new ItemNotFoundException("Unable to find a node with an UUID equal to: " + newsId);
     }
+    boolean isPublished = newsNode.getProperty("exo:pinned").getBoolean();
+    if (isPublished) {
+      newsNode.setProperty("exo:pinned", false);
+    }
     newsNode.setProperty("exo:archived", true);
     newsNode.save();
   }

--- a/services/src/test/java/org/exoplatform/news/service/impl/NewsServiceImplTest.java
+++ b/services/src/test/java/org/exoplatform/news/service/impl/NewsServiceImplTest.java
@@ -170,22 +170,18 @@ public class NewsServiceImplTest {
         news.setPublished(true);
         news.setPublicationState("archived");
         news.setCanPublish(true);
-        newsService.updateNews(news, "root", null, true);
-        verify(newsStorage, times(0)).unpublishNews(news.getId());
-        verify(newsStorage, times(1)).publishNews(any(News.class));
-
         when(newsTargetingService.getTargetsByNewsId(news.getId())).thenReturn(targets);
         originalNews.setPublished(true);
         when(newsStorage.getNewsById(news.getId(), false)).thenReturn(originalNews);
         news.setTitle("title updated");
         newsService.updateNews(news, "root", null, true);
         verify(newsStorage, times(1)).unpublishNews(news.getId());
-        verify(newsStorage, times(2)).publishNews(any(News.class));
+        verify(newsStorage, times(1)).publishNews(any(News.class));
 
         originalNews.setTitle("title updated");
         when(newsStorage.getNewsById(news.getId(), false)).thenReturn(originalNews);
         newsService.updateNews(news, "root", null, false);
         verify(newsStorage, times(2)).unpublishNews(news.getId());
-        verify(newsStorage, times(2)).publishNews(any(News.class));
+        verify(newsStorage, times(1)).publishNews(any(News.class));
     }
 }

--- a/services/src/test/java/org/exoplatform/news/service/impl/NewsServiceImplTest.java
+++ b/services/src/test/java/org/exoplatform/news/service/impl/NewsServiceImplTest.java
@@ -1,16 +1,6 @@
 package org.exoplatform.news.service.impl;
 
-import org.exoplatform.commons.api.notification.NotificationContext;
-import org.exoplatform.commons.api.notification.NotificationMessageUtils;
-import org.exoplatform.commons.api.notification.model.PluginKey;
-import org.exoplatform.commons.api.notification.plugin.NotificationPluginUtils;
-import org.exoplatform.commons.api.notification.service.template.TemplateContext;
-import org.exoplatform.commons.notification.impl.NotificationContextImpl;
-import org.exoplatform.commons.notification.template.TemplateUtils;
 import org.exoplatform.commons.search.index.IndexingService;
-import org.exoplatform.commons.utils.CommonsUtils;
-import org.exoplatform.commons.utils.HTMLEntityEncoder;
-import org.exoplatform.commons.utils.PropertyManager;
 import org.exoplatform.news.model.News;
 import org.exoplatform.news.search.NewsESSearchConnector;
 import org.exoplatform.news.service.NewsService;
@@ -25,9 +15,7 @@ import org.exoplatform.social.core.manager.ActivityManager;
 import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceService;
-import org.exoplatform.social.notification.LinkProviderUtils;
 import org.exoplatform.upload.UploadService;
-import org.exoplatform.webui.utils.TimeConvertUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -167,6 +155,26 @@ public class NewsServiceImplTest {
         when(spaceService.getSpaceById(news.getSpaceId())).thenReturn(space);
 
         newsService.updateNews(news, "root", false, false);
+        verify(newsStorage, times(1)).updateNews(any(News.class), anyString());
+        verify(newsTargetingService, times(0)).deleteNewsTargets(any(News.class), anyString());
+        verify(newsTargetingService, times(0)).saveNewsTarget(any(News.class), anyBoolean(), anyList(), anyString());
+
+        when(newsStorage.getNewsById(news.getId(), false)).thenReturn(originalNews);
+        news.setTitle("title updated");
+        newsService.updateNews(news, "root", null, false);
+        verify(newsStorage, times(2)).updateNews(any(News.class), anyString());
+        verify(newsTargetingService, times(0)).deleteNewsTargets(any(News.class), anyString());
+        verify(newsTargetingService, times(0)).saveNewsTarget(any(News.class), anyBoolean(), anyList(), anyString());
+
+        news.setSummary("summary updated");
+        newsService.updateNews(news, "root", null, false);
+        verify(newsStorage, times(3)).updateNews(any(News.class), anyString());
+        verify(newsTargetingService, times(0)).deleteNewsTargets(any(News.class), anyString());
+        verify(newsTargetingService, times(0)).saveNewsTarget(any(News.class), anyBoolean(), anyList(), anyString());
+
+        news.setBody("body updated");
+        newsService.updateNews(news, "root", null, false);
+        verify(newsStorage, times(4)).updateNews(any(News.class), anyString());
         verify(newsTargetingService, times(0)).deleteNewsTargets(any(News.class), anyString());
         verify(newsTargetingService, times(0)).saveNewsTarget(any(News.class), anyBoolean(), anyList(), anyString());
 
@@ -174,6 +182,7 @@ public class NewsServiceImplTest {
         news.setPublicationState("archived");
         news.setCanPublish(true);
         newsService.updateNews(news, "root", null, true);
+        verify(newsStorage, times(5)).updateNews(any(News.class), anyString());
         verify(newsTargetingService, times(2)).deleteNewsTargets(any(News.class), anyString());
         verify(newsTargetingService, times(2)).saveNewsTarget(any(News.class), anyBoolean(), anyList(), anyString());
 
@@ -181,10 +190,9 @@ public class NewsServiceImplTest {
         originalNews.setPublished(true);
         originalNews.setTargets(oldTargets);
         when(newsStorage.getNewsById(news.getId(), false)).thenReturn(originalNews);
-        news.setTitle("title updated");
         newsService.updateNews(news, "root", null, false);
+        verify(newsStorage, times(6)).updateNews(any(News.class), anyString());
         verify(newsTargetingService, times(3)).deleteNewsTargets(any(News.class), anyString());
         verify(newsTargetingService, times(2)).saveNewsTarget(any(News.class), anyBoolean(), anyList(), anyString());
-
     }
 }

--- a/services/src/test/java/org/exoplatform/news/service/impl/NewsServiceImplTest.java
+++ b/services/src/test/java/org/exoplatform/news/service/impl/NewsServiceImplTest.java
@@ -121,7 +121,7 @@ public class NewsServiceImplTest {
         originalNews.setActivities("3:39;");
         originalNews.setActivityId("10");
         originalNews.setPublished(false);
-        originalNews.setPublicationState("draft");
+        originalNews.setPublicationState("archived");
 
         News news = new News();
         news.setTitle("title");
@@ -170,18 +170,22 @@ public class NewsServiceImplTest {
         news.setPublished(true);
         news.setPublicationState("archived");
         news.setCanPublish(true);
+        newsService.updateNews(news, "root", null, true);
+        verify(newsStorage, times(0)).unpublishNews(news.getId());
+        verify(newsStorage, times(1)).publishNews(any(News.class));
+
         when(newsTargetingService.getTargetsByNewsId(news.getId())).thenReturn(targets);
         originalNews.setPublished(true);
         when(newsStorage.getNewsById(news.getId(), false)).thenReturn(originalNews);
         news.setTitle("title updated");
         newsService.updateNews(news, "root", null, true);
         verify(newsStorage, times(1)).unpublishNews(news.getId());
-        verify(newsStorage, times(1)).publishNews(any(News.class));
+        verify(newsStorage, times(2)).publishNews(any(News.class));
 
         originalNews.setTitle("title updated");
         when(newsStorage.getNewsById(news.getId(), false)).thenReturn(originalNews);
         newsService.updateNews(news, "root", null, false);
         verify(newsStorage, times(2)).unpublishNews(news.getId());
-        verify(newsStorage, times(1)).publishNews(any(News.class));
+        verify(newsStorage, times(2)).publishNews(any(News.class));
     }
 }

--- a/services/src/test/java/org/exoplatform/news/storage/jcr/JcrNewsStorageTest.java
+++ b/services/src/test/java/org/exoplatform/news/storage/jcr/JcrNewsStorageTest.java
@@ -1077,59 +1077,6 @@ public class JcrNewsStorageTest {
     verify(illustrationNode, times(1)).remove();
   }
 
-  @Test
-  public void shouldPublishNews() throws Exception {
-    // Given
-
-    DataDistributionType dataDistributionType = mock(DataDistributionType.class);
-    when(dataDistributionManager.getDataDistributionType(DataDistributionMode.NONE)).thenReturn(dataDistributionType);
-    JcrNewsStorage jcrNewsStorage = buildJcrNewsStorage();
-
-    JcrNewsStorage jcrNewsStorageSpy = Mockito.spy(jcrNewsStorage);
-    ExtendedNode newsNode = mock(ExtendedNode.class);
-    Node publishedRootNode = mock(Node.class);
-    Node newsFolderNode = mock(Node.class);
-    Node applicationDataNode = mock(Node.class);
-    Node newsRootNode = mock(Node.class);
-
-    News news = new News();
-    news.setTitle("published title");
-    news.setAudience("all");
-    news.setSummary("published summary");
-    news.setBody("published body");
-    news.setUploadId(null);
-    String sDate1 = "22/08/2019";
-    Date date1 = new SimpleDateFormat("dd/MM/yyyy").parse(sDate1);
-    news.setCreationDate(date1);
-    news.setPublished(true);
-    news.setId("id123");
-
-    when(sessionProviderService.getSystemSessionProvider(any())).thenReturn(sessionProvider);
-    when(repositoryService.getCurrentRepository()).thenReturn(repository);
-    when(repository.getConfiguration()).thenReturn(repositoryEntry);
-    when(repositoryEntry.getDefaultWorkspaceName()).thenReturn("collaboration");
-    when(sessionProvider.getSession(any(), any())).thenReturn(session);
-    when(session.getNodeByUUID(nullable(String.class))).thenReturn(newsNode);
-    when(dataDistributionType.getOrCreateDataNode(any(Node.class), nullable(String.class))).thenReturn(newsFolderNode);
-    when(newsNode.canAddMixin(eq("exo:privilegeable"))).thenReturn(true);
-    Mockito.doReturn(news).when(jcrNewsStorageSpy).getNewsById("id123", false);
-    when(session.getItem(nullable(String.class))).thenReturn(applicationDataNode);
-    when(applicationDataNode.hasNode(eq("News"))).thenReturn(true);
-    when(applicationDataNode.getNode(eq("News"))).thenReturn(newsRootNode);
-    when(newsRootNode.hasNode(eq("Pinned"))).thenReturn(true);
-    when(newsRootNode.getNode(eq("Pinned"))).thenReturn(publishedRootNode);
-//TODO to be moved with newsService tests
-//    Mockito.doNothing()
-//           .when(jcrNewsStorageSpy)
-//           .sendNotification(news, NotificationConstants.NOTIFICATION_CONTEXT.PUBLISH_IN_NEWS, session);
-
-    // When
-    jcrNewsStorageSpy.publishNews(news);
-
-    // Then
-    verify(newsNode, times(1)).save();
-    verify(newsNode, times(1)).setProperty(eq("exo:pinned"), eq(true));
-  }
 
   @Test
   public void shouldCreateNewsDraftAndPublishIt() throws Exception {
@@ -1185,7 +1132,6 @@ public class JcrNewsStorageTest {
     when(poster.getId()).thenReturn("root");
     JcrNewsStorage jcrNewsStorageSpy = Mockito.spy(jcrNewsStorage);
 
-    Mockito.doNothing().when(jcrNewsStorageSpy).publishNews(createdNewsDraft);
     Mockito.doReturn(createdNewsDraft).when(jcrNewsStorageSpy).createNews(news);
     Mockito.doNothing().when(publicationServiceImpl).changeState(newsNode, PublicationDefaultStates.PUBLISHED, new HashMap<>());
 //TODO to be moved with newsService tests


### PR DESCRIPTION
prior to this change, when editing published news, notification of publishing news is received since it is republished 
after this change, avoid sending a new notification if the news is already published and no more create symlink for published news