### PR TITLE
fix: publish news notification is received when editing a published news - EXO-62469 (#815)

### DIFF
--- a/services/src/main/java/org/exoplatform/news/storage/NewsStorage.java
+++ b/services/src/main/java/org/exoplatform/news/storage/NewsStorage.java
@@ -11,9 +11,9 @@ import org.exoplatform.social.core.space.model.Space;
 public interface NewsStorage {
   
   News createNews(News news) throws Exception;
-  
+
   void publishNews(News news) throws Exception;
-  
+
   String getNewsIllustration(News news) throws Exception;
   
   News updateNews(News news, String updater) throws Exception;
@@ -29,9 +29,9 @@ public interface NewsStorage {
   void markAsRead(News news, String userId) throws Exception;
   
   boolean isCurrentUserInNewsViewers(String newsId, String userId) throws Exception;
-  
+
   void unpublishNews(String newsId) throws Exception;
-  
+
   void shareNews(News news, Space space, Identity userIdentity, String sharedActivityId) throws IllegalAccessException, ObjectNotFoundException;
   
   void deleteNews(String newsId, boolean isDraft) throws Exception;

--- a/services/src/test/java/org/exoplatform/news/storage/jcr/JcrNewsStorageTest.java
+++ b/services/src/test/java/org/exoplatform/news/storage/jcr/JcrNewsStorageTest.java
@@ -1110,7 +1110,6 @@ public class JcrNewsStorageTest {
     when(repositoryEntry.getDefaultWorkspaceName()).thenReturn("collaboration");
     when(sessionProvider.getSession(any(), any())).thenReturn(session);
     when(session.getNodeByUUID(nullable(String.class))).thenReturn(newsNode);
-    when(dataDistributionType.getOrCreateDataNode(any(Node.class), nullable(String.class))).thenReturn(newsFolderNode);
     when(newsNode.canAddMixin(eq("exo:privilegeable"))).thenReturn(true);
     Mockito.doReturn(news).when(jcrNewsStorageSpy).getNewsById("id123", false);
     when(session.getItem(nullable(String.class))).thenReturn(applicationDataNode);


### PR DESCRIPTION
prior to this change, when editing published news, notification of publishing news is received since it is republished after this change, avoid sending a new notification if the news is already published and no more create a symlink for the published news