### PR TITLE
fix: Standardize font styles/size between notes and news pages - EXO-61667 (#810)

### DIFF
--- a/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
+++ b/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
@@ -549,7 +549,12 @@ export default {
       if (eXo.env.portal.activityTagsEnabled) {
         extraPlugins = `${extraPlugins},tagSuggester`;
       }
-      CKEDITOR.addCss('.cke_editable { font-size: 14pt; font-family: Helvetica, regular, sans-serif; }');
+      CKEDITOR.addCss('.cke_editable { font-size: 14pt; font-family: Helvetica, regular, sans-serif; line-height: 1.4 !important;}');
+      CKEDITOR.addCss('h1 { font-size: 34px;font-weight: 400;}');
+      CKEDITOR.addCss('h2 { font-size: 28px;font-weight: 400;}');
+      CKEDITOR.addCss('h3 { font-size: 21.84px;font-weight: 400;}');
+      CKEDITOR.addCss('p,li { font-size: 18.6667px;}');
+      CKEDITOR.addCss('blockquote p  { font-size: 17.5px;font-weight: 300;}');
       // this line is mandatory when a custom skin is defined
 
       CKEDITOR.basePath = '/commons-extension/ckeditor/';

--- a/webapp/src/main/webapp/skin/less/newsDetails.less
+++ b/webapp/src/main/webapp/skin/less/newsDetails.less
@@ -77,6 +77,39 @@
       color: @grayDark;
       opacity: 0.4;
     }
+    
+    .newsContent .newsBody span {
+      
+      h1 {
+        font-size: 34px !important;
+        font-weight: 400 !important;
+      }
+      
+      h2 {
+        font-size: 28px !important;
+        font-weight: 400 !important;
+      }
+      
+      h3 {
+        font-size: 21.84px !important;
+        font-weight: 400 !important;
+      }
+      
+      p, li {
+        font-size:18.6667px !important;
+        font-weight: normal !important;
+        line-height: 1.4 !important;
+      }
+      
+      blockquote p{
+        font-size: 17.5px !important;
+        font-weight: 300 !important;
+      }
+      
+      ul li {
+        list-style-type: disc;
+      }
+    }
   }
 }
 
@@ -146,6 +179,35 @@
         left: auto ~'; /** orientation=rt */ ';
         width: 100%;
         height: 100%;
+      }
+    }
+    span {
+      line-height: 1.4 !important;
+      
+      h1 {
+        font-size: 34px !important;
+        font-weight: 400 !important;
+      }
+      
+      h2 {
+        font-size: 28px !important;
+        font-weight: 400 !important;
+      }
+      
+      h3 {
+        font-size: 21.84px !important;
+        font-weight: 400 !important;
+      }
+      
+      p, li {
+        font-size:18.6667px !important;
+        font-weight: normal !important;
+        line-height: 1.4 !important;
+      }
+      
+      blockquote p{
+        font-size: 17.5px !important;
+        font-weight: 300 !important;
       }
     }
   }
@@ -247,7 +309,7 @@
       padding-top: 20px;
       padding-bottom: 30px;
       letter-spacing: .1px;
-      line-height: 1.6em;
+      line-height: 1.4;
       font-size: 14pt;
       max-width: 80%;
       margin: auto;
@@ -278,6 +340,36 @@
           width: 100%;
           height: 100%;
         }
+      }
+      
+      h1 {
+        font-size: 34px !important;
+        font-weight: 400 !important;
+      }
+      
+      h2 {
+        font-size: 28px !important;
+        font-weight: 400 !important;
+      }
+      
+      h3 {
+        font-size: 21.84px !important;
+        font-weight: 400 !important;
+      }
+      
+      p, li {
+        font-size:18.6667px !important;
+        font-weight: normal !important;
+        line-height: 1.4 !important;
+      }
+      
+      blockquote p{
+        font-size: 17.5px !important;
+        font-weight: 300 !important;
+      }
+      
+      ul li {
+        list-style-type: disc;
       }
     }
 


### PR DESCRIPTION
Prior to this change, font styles and size were not standardized between different views in notes and news. After this change, some css style are applied on headline ,bulleted-list, numbered-list and block quote to be standardize with notes pages.