### PR TITLE
fix: Illustration image is sent in raw format in rest service for getting associated activity - EXO-63263

### DIFF
--- a/services/src/main/java/org/exoplatform/news/activity/processor/ActivityNewsProcessor.java
+++ b/services/src/main/java/org/exoplatform/news/activity/processor/ActivityNewsProcessor.java
@@ -46,6 +46,7 @@ public class ActivityNewsProcessor extends BaseActivityProcessorPlugin {
 
         activity.setMetadataObjectId(news.getId());
         activity.setMetadataObjectType(NewsUtils.NEWS_METADATA_OBJECT_TYPE);
+        news.setIllustration(null);
       } catch (Exception e) {
         LOG.warn("Error retrieving news with id {}",
                  activity.getTemplateParams().get("newsId"),


### PR DESCRIPTION
Before this fix, the illustration is sent in raw when getting associated activity of the news. This illustration is not used, as we have and use the illustrationUrl This fix empties the illustration field to return the activity