### PR TITLE
fix: Illustration image is sent in raw format in rest service for getting associated activity - EXO-63263

### DIFF
--- a/patches-changelog.txt
+++ b/patches-changelog.txt
@@ -1,5 +1,13 @@
               2023-03-16 eXo Support <support@exoplatform.org> 
 
    # 2.3.4 Patches changelog: 
+   
+* 2023-02-17: Patch-6.3.4:1, Author: Jihed Chabbeh<jchabbeh@exoplatform.com>
 
+  -  https://github.com/exoplatform/web-conferencing/commit/fcbf298f227f8a557dbe5cecbbb321e9f7ad4ad1
 
+  -  https://github.com/Meeds-io/gatein-portal/pull/536
+
+* 2023-03-16: Patch-6.3.4:2, Author: Jihed Chabbeh<jchabbeh@exoplatform.com>
+
+  -  https://github.com/exoplatform/news/pull/832

--- a/services/src/main/java/org/exoplatform/news/activity/processor/ActivityNewsProcessor.java
+++ b/services/src/main/java/org/exoplatform/news/activity/processor/ActivityNewsProcessor.java
@@ -46,6 +46,7 @@ public class ActivityNewsProcessor extends BaseActivityProcessorPlugin {
 
         activity.setMetadataObjectId(news.getId());
         activity.setMetadataObjectType(NewsUtils.NEWS_METADATA_OBJECT_TYPE);
+        news.setIllustration(null);
       } catch (Exception e) {
         LOG.warn("Error retrieving news with id {}",
                  activity.getTemplateParams().get("newsId"),


### PR DESCRIPTION
Before this fix, the illustration is sent in raw when getting associated activity of the news. This illustration is not used, as we have and use the illustration URL This fix empties the illustration field to return the activity

cherry-picked from [PR](https://github.com/exoplatform/news/pull/832)