### PR TITLE
Feat: display views count on news list template -EXO-63953 (#847)

### DIFF
--- a/webapp/src/main/webapp/news-list-view/components/views/NewsListTemplateViewItem.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsListTemplateViewItem.vue
@@ -58,6 +58,10 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
             mdi-comment
           </v-icon>
           <div class="comments-count me-2">{{ item.commentsCount }}</div>
+          <v-icon class="reactions-icon-style me-1" size="12">
+            mdi-eye
+          </v-icon>
+          <div class="viewCount">{{ item.viewsCount }}</div>           
         </div>
       </div>
     </div>


### PR DESCRIPTION
prior to this change only likes and comments count are displayed for news list template after this change views count is displayed in addition to likes & comments

(cherry picked from commit dc5d38633df73baeaf190cef21a51ad2d7aaf3ee)