### PR TITLE
fix: The search for news using the news tag text does not display any results - EXO-64009

### DIFF
--- a/services/src/main/java/org/exoplatform/news/connector/NewsSearchConnector.java
+++ b/services/src/main/java/org/exoplatform/news/connector/NewsSearchConnector.java
@@ -1,6 +1,7 @@
 package org.exoplatform.news.connector;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
@@ -66,6 +67,10 @@ public class NewsSearchConnector extends SearchServiceConnector {
             repositoryService.getCurrentRepository());
 
     if (filter.getSearchText() != null) {
+      // search text composed by one keyword maybe it is the tag text
+      if (filter.getSearchText().split(" ").length <= 1){
+        filter.setTagNames(new ArrayList<>(Arrays.asList(filter.getSearchText().trim())));
+      }
       filter.setSearchText(this.addFuzzySyntaxAndOR(filter.getSearchText().trim().toLowerCase()));
     }
     List<SearchResult> res = new ArrayList<>();

--- a/services/src/main/java/org/exoplatform/news/connector/NewsSearchConnector.java
+++ b/services/src/main/java/org/exoplatform/news/connector/NewsSearchConnector.java
@@ -1,7 +1,6 @@
 package org.exoplatform.news.connector;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
@@ -67,10 +66,6 @@ public class NewsSearchConnector extends SearchServiceConnector {
             repositoryService.getCurrentRepository());
 
     if (filter.getSearchText() != null) {
-      // search text composed by one keyword maybe it is the tag text
-      if (filter.getSearchText().split(" ").length <= 1){
-        filter.setTagNames(new ArrayList<>(Arrays.asList(filter.getSearchText().trim())));
-      }
       filter.setSearchText(this.addFuzzySyntaxAndOR(filter.getSearchText().trim().toLowerCase()));
     }
     List<SearchResult> res = new ArrayList<>();

--- a/services/src/main/java/org/exoplatform/news/queryBuilder/NewsQueryBuilder.java
+++ b/services/src/main/java/org/exoplatform/news/queryBuilder/NewsQueryBuilder.java
@@ -56,8 +56,15 @@ public class NewsQueryBuilder {
           String escapedQuoteSearchText = filter.getSearchText().replace("'", "''").replace("\"", "\"\"");
           sqlQuery.append("CONTAINS(.,'").append(escapedQuoteSearchText).append("')");
           if (!filter.getTagNames().isEmpty()){
-            sqlQuery.append(" OR exo:body LIKE '%#").append(filter.getTagNames().get(0)).append("%' AND ");
-          } else sqlQuery.append("AND");
+            sqlQuery.append(" OR (");
+            for (String tagName : filter.getTagNames()) {
+              sqlQuery.append(" exo:body LIKE '%#").append(tagName).append("%'");
+              if (filter.getTagNames().indexOf(tagName) != filter.getTagNames().size() -1) {
+                sqlQuery.append(" OR");
+              }
+            }
+            sqlQuery.append(" ) AND ");
+          } else sqlQuery.append("AND ");
         }
         if (filter.isPublishedNews()) {
           sqlQuery.append("exo:pinned = 'true' AND ");

--- a/services/src/main/java/org/exoplatform/news/queryBuilder/NewsQueryBuilder.java
+++ b/services/src/main/java/org/exoplatform/news/queryBuilder/NewsQueryBuilder.java
@@ -54,7 +54,10 @@ public class NewsQueryBuilder {
         }
         if (filter.getSearchText() != null && !filter.getSearchText().equals("")) {
           String escapedQuoteSearchText = filter.getSearchText().replace("'", "''").replace("\"", "\"\"");
-          sqlQuery.append("CONTAINS(.,'").append(escapedQuoteSearchText).append("') AND ");
+          sqlQuery.append("CONTAINS(.,'").append(escapedQuoteSearchText).append("')");
+          if (!filter.getTagNames().isEmpty()){
+            sqlQuery.append(" OR exo:body LIKE '%#").append(filter.getTagNames().get(0)).append("%' AND ");
+          } else sqlQuery.append("AND");
         }
         if (filter.isPublishedNews()) {
           sqlQuery.append("exo:pinned = 'true' AND ");

--- a/services/src/main/java/org/exoplatform/news/rest/NewsRestResourcesV1.java
+++ b/services/src/main/java/org/exoplatform/news/rest/NewsRestResourcesV1.java
@@ -34,7 +34,12 @@ import javax.ws.rs.core.UriInfo;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.social.metadata.favorite.model.Favorite;
+import org.exoplatform.social.metadata.tag.TagService;
+import org.exoplatform.social.metadata.tag.model.TagFilter;
+import org.exoplatform.social.metadata.tag.model.TagName;
+import org.exoplatform.social.rest.api.RestUtils;
 import org.picocontainer.Startable;
 
 import org.exoplatform.commons.exception.ObjectNotFoundException;
@@ -476,6 +481,10 @@ public class NewsRestResourcesV1 implements ResourceContainer, Startable {
       //Set text to search news with
       if (StringUtils.isNotEmpty(text)) {
         String lang = request.getLocale().getLanguage();
+        TagService tagService = CommonsUtils.getService(TagService.class);
+        long userIdentityId = RestUtils.getCurrentUserIdentityId();
+        List<TagName> tagNames = tagService.findTags(new TagFilter(text, 0), userIdentityId);
+        if (tagNames != null && !tagNames.isEmpty()) newsFilter.setTagNames(tagNames.stream().map(e -> e.getName()).toList());
         news = newsService.searchNews(newsFilter, lang);
       } else {
         org.exoplatform.services.security.Identity currentIdentity = ConversationState.getCurrent().getIdentity();

--- a/services/src/test/java/org/exoplatform/news/queryBuilder/NewsQueryBuilderTest.java
+++ b/services/src/test/java/org/exoplatform/news/queryBuilder/NewsQueryBuilderTest.java
@@ -44,7 +44,7 @@ public class NewsQueryBuilderTest {
     filter.setSearchText("text");
     filter.setOrder("jcr:score");
     filter.setAuthor("john");
-    filter.setTagNames(Arrays.asList(new String[]{"text"}));
+    filter.setTagNames(Arrays.asList(new String[]{"text","tex"}));
     List<String> spaces = new ArrayList<>();
     spaces.add("1");
     filter.setSpaces(spaces);
@@ -61,7 +61,7 @@ public class NewsQueryBuilderTest {
 
     // then
     assertNotNull(query);
-    assertEquals("SELECT * FROM exo:news WHERE ( exo:archived IS NULL OR exo:archived = 'false' OR ( exo:archived = 'true' AND  exo:author = 'john')) AND CONTAINS(.,'text') OR exo:body LIKE '%#text%' AND exo:pinned = 'true' AND ( exo:spaceId = '1') AND exo:author = 'john' AND (publication:currentState = 'published' OR (publication:currentState = 'draft' AND exo:activities <> '' )) AND jcr:path LIKE '/Groups/spaces/%' ORDER BY jcr:score DESC",
+    assertEquals("SELECT * FROM exo:news WHERE ( exo:archived IS NULL OR exo:archived = 'false' OR ( exo:archived = 'true' AND  exo:author = 'john')) AND CONTAINS(.,'text') OR ( exo:body LIKE '%#text%' OR exo:body LIKE '%#tex%' ) AND exo:pinned = 'true' AND ( exo:spaceId = '1') AND exo:author = 'john' AND (publication:currentState = 'published' OR (publication:currentState = 'draft' AND exo:activities <> '' )) AND jcr:path LIKE '/Groups/spaces/%' ORDER BY jcr:score DESC",
                  query.toString());
   }
 
@@ -93,7 +93,7 @@ public class NewsQueryBuilderTest {
 
     // then
     assertNotNull(query);
-    assertEquals("SELECT * FROM exo:news WHERE ( exo:archived IS NULL OR exo:archived = 'false' OR ( exo:archived = 'true' AND  exo:author = 'john')) AND CONTAINS(.,'text') OR exo:body LIKE '%#text%' AND exo:pinned = 'true' AND ( exo:spaceId = '1' OR exo:spaceId = '2' OR exo:spaceId = '3') AND exo:author = 'john' AND (publication:currentState = 'published' OR (publication:currentState = 'draft' AND exo:activities <> '' )) AND jcr:path LIKE '/Groups/spaces/%' ORDER BY jcr:score DESC",
+    assertEquals("SELECT * FROM exo:news WHERE ( exo:archived IS NULL OR exo:archived = 'false' OR ( exo:archived = 'true' AND  exo:author = 'john')) AND CONTAINS(.,'text') OR ( exo:body LIKE '%#text%' ) AND exo:pinned = 'true' AND ( exo:spaceId = '1' OR exo:spaceId = '2' OR exo:spaceId = '3') AND exo:author = 'john' AND (publication:currentState = 'published' OR (publication:currentState = 'draft' AND exo:activities <> '' )) AND jcr:path LIKE '/Groups/spaces/%' ORDER BY jcr:score DESC",
                  query.toString());
   }
 

--- a/services/src/test/java/org/exoplatform/news/queryBuilder/NewsQueryBuilderTest.java
+++ b/services/src/test/java/org/exoplatform/news/queryBuilder/NewsQueryBuilderTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mockStatic;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.junit.AfterClass;
@@ -43,6 +44,7 @@ public class NewsQueryBuilderTest {
     filter.setSearchText("text");
     filter.setOrder("jcr:score");
     filter.setAuthor("john");
+    filter.setTagNames(Arrays.asList(new String[]{"text"}));
     List<String> spaces = new ArrayList<>();
     spaces.add("1");
     filter.setSpaces(spaces);
@@ -59,7 +61,7 @@ public class NewsQueryBuilderTest {
 
     // then
     assertNotNull(query);
-    assertEquals("SELECT * FROM exo:news WHERE ( exo:archived IS NULL OR exo:archived = 'false' OR ( exo:archived = 'true' AND  exo:author = 'john')) AND CONTAINS(.,'text') AND exo:pinned = 'true' AND ( exo:spaceId = '1') AND exo:author = 'john' AND (publication:currentState = 'published' OR (publication:currentState = 'draft' AND exo:activities <> '' )) AND jcr:path LIKE '/Groups/spaces/%' ORDER BY jcr:score DESC",
+    assertEquals("SELECT * FROM exo:news WHERE ( exo:archived IS NULL OR exo:archived = 'false' OR ( exo:archived = 'true' AND  exo:author = 'john')) AND CONTAINS(.,'text') OR exo:body LIKE '%#text%' AND exo:pinned = 'true' AND ( exo:spaceId = '1') AND exo:author = 'john' AND (publication:currentState = 'published' OR (publication:currentState = 'draft' AND exo:activities <> '' )) AND jcr:path LIKE '/Groups/spaces/%' ORDER BY jcr:score DESC",
                  query.toString());
   }
 
@@ -72,6 +74,7 @@ public class NewsQueryBuilderTest {
     filter.setSearchText("text");
     filter.setOrder("jcr:score");
     filter.setAuthor("john");
+    filter.setTagNames(Arrays.asList(new String[]{"text"}));
     List<String> spaces = new ArrayList<>();
     spaces.add("1");
     spaces.add("2");
@@ -90,7 +93,7 @@ public class NewsQueryBuilderTest {
 
     // then
     assertNotNull(query);
-    assertEquals("SELECT * FROM exo:news WHERE ( exo:archived IS NULL OR exo:archived = 'false' OR ( exo:archived = 'true' AND  exo:author = 'john')) AND CONTAINS(.,'text') AND exo:pinned = 'true' AND ( exo:spaceId = '1' OR exo:spaceId = '2' OR exo:spaceId = '3') AND exo:author = 'john' AND (publication:currentState = 'published' OR (publication:currentState = 'draft' AND exo:activities <> '' )) AND jcr:path LIKE '/Groups/spaces/%' ORDER BY jcr:score DESC",
+    assertEquals("SELECT * FROM exo:news WHERE ( exo:archived IS NULL OR exo:archived = 'false' OR ( exo:archived = 'true' AND  exo:author = 'john')) AND CONTAINS(.,'text') OR exo:body LIKE '%#text%' AND exo:pinned = 'true' AND ( exo:spaceId = '1' OR exo:spaceId = '2' OR exo:spaceId = '3') AND exo:author = 'john' AND (publication:currentState = 'published' OR (publication:currentState = 'draft' AND exo:activities <> '' )) AND jcr:path LIKE '/Groups/spaces/%' ORDER BY jcr:score DESC",
                  query.toString());
   }
 


### PR DESCRIPTION
Before to this change on news app when we searched for news by typing the text of the tag, no results were displayed. The issue was that the news query was not built to include the filter by the tag text.

This change will find the tag names by the search text to assume that the searched text is a tag text and  update the build query method to enable filtering by the tag text.