### PR TITLE
fix: The search for news using the news tag text does not display any results - EXO-64009 (#850)

### DIFF
--- a/services/src/main/java/org/exoplatform/news/queryBuilder/NewsQueryBuilder.java
+++ b/services/src/main/java/org/exoplatform/news/queryBuilder/NewsQueryBuilder.java
@@ -54,7 +54,17 @@ public class NewsQueryBuilder {
         }
         if (filter.getSearchText() != null && !filter.getSearchText().equals("")) {
           String escapedQuoteSearchText = filter.getSearchText().replace("'", "''").replace("\"", "\"\"");
-          sqlQuery.append("CONTAINS(.,'").append(escapedQuoteSearchText).append("') AND ");
+          sqlQuery.append("CONTAINS(.,'").append(escapedQuoteSearchText).append("')");
+          if (!filter.getTagNames().isEmpty()){
+            sqlQuery.append(" OR (");
+            for (String tagName : filter.getTagNames()) {
+              sqlQuery.append(" exo:body LIKE '%#").append(tagName).append("%'");
+              if (filter.getTagNames().indexOf(tagName) != filter.getTagNames().size() -1) {
+                sqlQuery.append(" OR");
+              }
+            }
+            sqlQuery.append(" ) AND ");
+          } else sqlQuery.append("AND ");
         }
         if (filter.isPublishedNews()) {
           sqlQuery.append("exo:pinned = 'true' AND ");

--- a/services/src/main/java/org/exoplatform/news/rest/NewsRestResourcesV1.java
+++ b/services/src/main/java/org/exoplatform/news/rest/NewsRestResourcesV1.java
@@ -34,7 +34,12 @@ import javax.ws.rs.core.UriInfo;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.social.metadata.favorite.model.Favorite;
+import org.exoplatform.social.metadata.tag.TagService;
+import org.exoplatform.social.metadata.tag.model.TagFilter;
+import org.exoplatform.social.metadata.tag.model.TagName;
+import org.exoplatform.social.rest.api.RestUtils;
 import org.picocontainer.Startable;
 
 import org.exoplatform.commons.exception.ObjectNotFoundException;
@@ -476,6 +481,10 @@ public class NewsRestResourcesV1 implements ResourceContainer, Startable {
       //Set text to search news with
       if (StringUtils.isNotEmpty(text)) {
         String lang = request.getLocale().getLanguage();
+        TagService tagService = CommonsUtils.getService(TagService.class);
+        long userIdentityId = RestUtils.getCurrentUserIdentityId();
+        List<TagName> tagNames = tagService.findTags(new TagFilter(text, 0), userIdentityId);
+        if (tagNames != null && !tagNames.isEmpty()) newsFilter.setTagNames(tagNames.stream().map(e -> e.getName()).toList());
         news = newsService.searchNews(newsFilter, lang);
       } else {
         org.exoplatform.services.security.Identity currentIdentity = ConversationState.getCurrent().getIdentity();

--- a/services/src/main/java/org/exoplatform/news/rest/NewsRestResourcesV1.java
+++ b/services/src/main/java/org/exoplatform/news/rest/NewsRestResourcesV1.java
@@ -34,12 +34,10 @@ import javax.ws.rs.core.UriInfo;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.social.metadata.favorite.model.Favorite;
 import org.exoplatform.social.metadata.tag.TagService;
 import org.exoplatform.social.metadata.tag.model.TagFilter;
 import org.exoplatform.social.metadata.tag.model.TagName;
-import org.exoplatform.social.rest.api.RestUtils;
 import org.picocontainer.Startable;
 
 import org.exoplatform.commons.exception.ObjectNotFoundException;
@@ -481,8 +479,8 @@ public class NewsRestResourcesV1 implements ResourceContainer, Startable {
       //Set text to search news with
       if (StringUtils.isNotEmpty(text)) {
         String lang = request.getLocale().getLanguage();
-        TagService tagService = CommonsUtils.getService(TagService.class);
-        long userIdentityId = RestUtils.getCurrentUserIdentityId();
+        TagService tagService = container.getComponentInstanceOfType(TagService.class);
+        long userIdentityId = Long.parseLong(identityManager.getOrCreateUserIdentity(authenticatedUser).getId());
         List<TagName> tagNames = tagService.findTags(new TagFilter(text, 0), userIdentityId);
         if (tagNames != null && !tagNames.isEmpty()) newsFilter.setTagNames(tagNames.stream().map(e -> e.getName()).toList());
         news = newsService.searchNews(newsFilter, lang);

--- a/services/src/test/java/org/exoplatform/news/queryBuilder/NewsQueryBuilderTest.java
+++ b/services/src/test/java/org/exoplatform/news/queryBuilder/NewsQueryBuilderTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.exoplatform.commons.utils.CommonsUtils;
@@ -38,6 +39,7 @@ public class NewsQueryBuilderTest {
     filter.setSearchText("text");
     filter.setOrder("jcr:score");
     filter.setAuthor("john");
+    filter.setTagNames(Arrays.asList(new String[]{"text","tex"}));
     List<String> spaces = new ArrayList<>();
     spaces.add("1");
     filter.setSpaces(spaces);
@@ -54,7 +56,7 @@ public class NewsQueryBuilderTest {
 
     // then
     assertNotNull(query);
-    assertEquals("SELECT * FROM exo:news WHERE ( exo:archived IS NULL OR exo:archived = 'false' OR ( exo:archived = 'true' AND  exo:author = 'john')) AND CONTAINS(.,'text') AND exo:pinned = 'true' AND ( exo:spaceId = '1') AND exo:author = 'john' AND (publication:currentState = 'published' OR (publication:currentState = 'draft' AND exo:activities <> '' )) AND jcr:path LIKE '/Groups/spaces/%' ORDER BY jcr:score DESC",
+    assertEquals("SELECT * FROM exo:news WHERE ( exo:archived IS NULL OR exo:archived = 'false' OR ( exo:archived = 'true' AND  exo:author = 'john')) AND CONTAINS(.,'text') OR ( exo:body LIKE '%#text%' OR exo:body LIKE '%#tex%' ) AND exo:pinned = 'true' AND ( exo:spaceId = '1') AND exo:author = 'john' AND (publication:currentState = 'published' OR (publication:currentState = 'draft' AND exo:activities <> '' )) AND jcr:path LIKE '/Groups/spaces/%' ORDER BY jcr:score DESC",
                  query.toString());
   }
 
@@ -67,6 +69,7 @@ public class NewsQueryBuilderTest {
     filter.setSearchText("text");
     filter.setOrder("jcr:score");
     filter.setAuthor("john");
+    filter.setTagNames(Arrays.asList(new String[]{"text"}));
     List<String> spaces = new ArrayList<>();
     spaces.add("1");
     spaces.add("2");
@@ -85,7 +88,7 @@ public class NewsQueryBuilderTest {
 
     // then
     assertNotNull(query);
-    assertEquals("SELECT * FROM exo:news WHERE ( exo:archived IS NULL OR exo:archived = 'false' OR ( exo:archived = 'true' AND  exo:author = 'john')) AND CONTAINS(.,'text') AND exo:pinned = 'true' AND ( exo:spaceId = '1' OR exo:spaceId = '2' OR exo:spaceId = '3') AND exo:author = 'john' AND (publication:currentState = 'published' OR (publication:currentState = 'draft' AND exo:activities <> '' )) AND jcr:path LIKE '/Groups/spaces/%' ORDER BY jcr:score DESC",
+    assertEquals("SELECT * FROM exo:news WHERE ( exo:archived IS NULL OR exo:archived = 'false' OR ( exo:archived = 'true' AND  exo:author = 'john')) AND CONTAINS(.,'text') OR ( exo:body LIKE '%#text%' ) AND exo:pinned = 'true' AND ( exo:spaceId = '1' OR exo:spaceId = '2' OR exo:spaceId = '3') AND exo:author = 'john' AND (publication:currentState = 'published' OR (publication:currentState = 'draft' AND exo:activities <> '' )) AND jcr:path LIKE '/Groups/spaces/%' ORDER BY jcr:score DESC",
                  query.toString());
   }
 

--- a/services/src/test/java/org/exoplatform/news/rest/NewsRestResourcesV1Test.java
+++ b/services/src/test/java/org/exoplatform/news/rest/NewsRestResourcesV1Test.java
@@ -8,14 +8,12 @@ import static org.mockito.Mockito.*;
 import java.text.SimpleDateFormat;
 import java.util.*;
 
-import javax.enterprise.inject.New;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.Request;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 import javax.ws.rs.ext.RuntimeDelegate;
 
-import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.news.model.NewsAttachment;
 import org.exoplatform.news.service.NewsService;
 import org.exoplatform.news.storage.NewsAttachmentsStorage;
@@ -26,8 +24,6 @@ import org.exoplatform.social.metadata.favorite.FavoriteService;
 import org.exoplatform.social.metadata.tag.TagService;
 import org.exoplatform.social.metadata.tag.model.TagFilter;
 import org.exoplatform.social.metadata.tag.model.TagName;
-import org.exoplatform.social.rest.api.RestUtils;
-import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -44,18 +40,12 @@ import org.exoplatform.social.core.manager.ActivityManager;
 import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceService;
-import org.mockito.MockedStatic;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class NewsRestResourcesV1Test {
 
   public static final String JOHN = "john";
-
-  private static final MockedStatic<CommonsUtils> COMMONS_UTILS = mockStatic(CommonsUtils.class);
-
-  private static final MockedStatic<RestUtils> REST_UTILS = mockStatic(RestUtils.class);
-
   @Mock
   NewsService            newsService;
 
@@ -106,14 +96,6 @@ public class NewsRestResourcesV1Test {
                                                                                                                              null);
     when(identityManager.getOrCreateUserIdentity(JOHN)).thenReturn(userIdentity);
   }
-
-
-  @AfterClass
-  public static void afterRunBare() throws Exception { // NOSONAR
-    COMMONS_UTILS.close();
-    REST_UTILS.close();
-  }
-
 
   @Test
   public void shouldGetNewsWhenNewsExistsAndUserIsMemberOfTheSpace() throws Exception {
@@ -1574,8 +1556,7 @@ public class NewsRestResourcesV1Test {
     allNews.add(news1);
     allNews.add(news2);
     allNews.add(news3);
-    COMMONS_UTILS.when(()-> CommonsUtils.getService(TagService.class)).thenReturn(tagService);
-    REST_UTILS.when(()-> RestUtils.getCurrentUserIdentityId()).thenReturn(1L);
+    when(container.getComponentInstanceOfType(TagService.class)).thenReturn(tagService);
     when(tagService.findTags(new TagFilter(text, 0), 1L)).thenReturn(new ArrayList<>());
     lenient().when(newsService.searchNews(any(), any())).thenReturn(allNews);
     lenient().when(spaceService.isMember(any(Space.class), any())).thenReturn(true);
@@ -1630,8 +1611,7 @@ public class NewsRestResourcesV1Test {
     allNews.add(news1);
     allNews.add(news2);
     allNews.add(news3);
-    COMMONS_UTILS.when(()-> CommonsUtils.getService(TagService.class)).thenReturn(tagService);
-    REST_UTILS.when(()-> RestUtils.getCurrentUserIdentityId()).thenReturn(1L);
+    when(container.getComponentInstanceOfType(TagService.class)).thenReturn(tagService);
     when(tagService.findTags(new TagFilter(text, 0), 1L)).thenReturn(new ArrayList<>());
     lenient().when(newsService.searchNews(any(), any())).thenReturn(allNews);
     lenient().when(spaceService.isMember(any(Space.class), any())).thenReturn(true);
@@ -1679,8 +1659,7 @@ public class NewsRestResourcesV1Test {
     List<News> allNews = new ArrayList<>();
     allNews.add(news1);
     allNews.add(news2);
-    COMMONS_UTILS.when(()-> CommonsUtils.getService(TagService.class)).thenReturn(tagService);
-    REST_UTILS.when(()-> RestUtils.getCurrentUserIdentityId()).thenReturn(1L);
+    when(container.getComponentInstanceOfType(TagService.class)).thenReturn(tagService);
     when(tagService.findTags(new TagFilter(tagText, 0), 1L)).thenReturn(Arrays.asList(new TagName("tagText")));
     lenient().when(newsService.searchNews(any(), any())).thenReturn(allNews);
     lenient().when(spaceService.isMember(any(Space.class), any())).thenReturn(true);
@@ -1731,8 +1710,7 @@ public class NewsRestResourcesV1Test {
     allNews.add(news1);
     allNews.add(news2);
     allNews.add(news3);
-    COMMONS_UTILS.when(()-> CommonsUtils.getService(TagService.class)).thenReturn(tagService);
-    REST_UTILS.when(()-> RestUtils.getCurrentUserIdentityId()).thenReturn(1L);
+    when(container.getComponentInstanceOfType(TagService.class)).thenReturn(tagService);
     when(tagService.findTags(new TagFilter(text, 0), 1L)).thenReturn(new ArrayList<>());
     lenient().when(newsService.searchNews(any(), any())).thenReturn(allNews);
     lenient().when(spaceService.isMember(any(Space.class), any())).thenReturn(true);
@@ -1916,8 +1894,7 @@ public class NewsRestResourcesV1Test {
     allNews.add(news1);
     allNews.add(news2);
     allNews.add(news3);
-    COMMONS_UTILS.when(()-> CommonsUtils.getService(TagService.class)).thenReturn(tagService);
-    REST_UTILS.when(()-> RestUtils.getCurrentUserIdentityId()).thenReturn(1L);
+    when(container.getComponentInstanceOfType(TagService.class)).thenReturn(tagService);
     when(tagService.findTags(new TagFilter(text, 0), 1L)).thenReturn(new ArrayList<>());
     lenient().when(newsService.searchNews(any(), any())).thenReturn(allNews);
     lenient().when(spaceService.isMember(any(Space.class), any())).thenReturn(true);


### PR DESCRIPTION
Before to this change on news app when we searched for news by typing the text of the tag, no results were displayed. The issue was that the news query was not built to include the filter by the tag text.

This change will find the tag names by the search text to assume that the searched text is a tag text and update the build query method to enable filtering by the tag text.