### PR TITLE
fix: Ordred list not dispalyed on news details article - EXO-64061

### DIFF
--- a/webapp/src/main/webapp/skin/less/newsDetails.less
+++ b/webapp/src/main/webapp/skin/less/newsDetails.less
@@ -123,6 +123,11 @@
       list-style-type: disc;
     }
   }
+  ol {
+    li {
+      list-style-type: inherit !important;
+    }
+  }
 
   .newsTitle {
     padding-bottom: 10px;


### PR DESCRIPTION
Before this change, the ordered list displayed as simple text in the news article. The problem was that we had another style that ignored the default style of the list element. This change addresses this issue