### PR TITLE
fix : enable to display the published news images for non space members - EXO-64339

### DIFF
--- a/services/src/main/java/org/exoplatform/news/storage/jcr/JcrNewsStorage.java
+++ b/services/src/main/java/org/exoplatform/news/storage/jcr/JcrNewsStorage.java
@@ -339,6 +339,7 @@ public class JcrNewsStorage implements NewsStorage {
     Node newsNode = session.getNodeByUUID(news.getId());
     newsNode.setProperty("exo:pinned", true);
     newsNode.save();
+    updateNewsImagesPermissions(news, sessionProvider, null);
   }
 
   @Override
@@ -1218,8 +1219,15 @@ public class JcrNewsStorage implements NewsStorage {
         if (image.canAddMixin(EXO_PRIVILEGEABLE)) {
           image.addMixin(EXO_PRIVILEGEABLE);
         }
-        image.setPermission("*:" + space.getGroupId(), SHARE_NEWS_PERMISSIONS);
-        image.save();
+        // share with space
+        if (space != null) {
+          image.setPermission("*:" + space.getGroupId(), SHARE_NEWS_PERMISSIONS);
+          image.save();
+        } else {
+          // make news images public
+          image.setPermission("*:/platform/users", SHARE_NEWS_PERMISSIONS);
+          image.save();
+        }
       }
     }
   }

--- a/services/src/test/java/org/exoplatform/news/storage/jcr/JcrNewsStorageTest.java
+++ b/services/src/test/java/org/exoplatform/news/storage/jcr/JcrNewsStorageTest.java
@@ -3,9 +3,15 @@ package org.exoplatform.news.storage.jcr;
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
+import static org.exoplatform.news.storage.jcr.JcrNewsStorage.EXO_PRIVILEGEABLE;
+ import java.util.ArrayList;
+ import java.util.Calendar;
+ import java.util.Date;
+ import java.util.HashMap;
+ import java.util.List;
 
 import java.text.SimpleDateFormat;
-import java.util.*;
+
 
 import javax.jcr.*;
 import javax.jcr.version.*;
@@ -1128,6 +1134,16 @@ public class JcrNewsStorageTest {
     // Then
     verify(newsNode, times(1)).save();
     verify(newsNode, times(1)).setProperty(eq("exo:pinned"), eq(true));
+
+    //
+    ExtendedNode newsImageNode = mock(ExtendedNode.class);
+    news.setBody("news body with image src=\"/portal/rest/images/repository/collaboration/123\"");
+    when(jcrNewsStorageSpy.getNodeById("123", sessionProvider)).thenReturn(newsImageNode);
+    when(newsImageNode.canAddMixin(EXO_PRIVILEGEABLE)).thenReturn(true);
+    // When
+    jcrNewsStorageSpy.publishNews(news);
+    verify(newsImageNode, times(1)).setPermission("*:/platform/users", JcrNewsStorage.SHARE_NEWS_PERMISSIONS);
+    verify(newsImageNode, times(1)).save();
   }
 
   @Test


### PR DESCRIPTION
This change is going to enable to display the published news images for non space members.