### PR TITLE
fix: Add content title for News analytics - EXO-61869

### DIFF
--- a/services/src/main/java/org/exoplatform/news/listener/AnalyticsNewsListener.java
+++ b/services/src/main/java/org/exoplatform/news/listener/AnalyticsNewsListener.java
@@ -90,6 +90,7 @@ public class AnalyticsNewsListener extends Listener<String, News> {
     statisticData.setOperation(operation);
     statisticData.setUserId(userId);
     statisticData.addParameter("contentId", news.getId());
+    statisticData.addParameter("contentTitle", news.getTitle());
     statisticData.addParameter("contentAuthor", news.getAuthor());
     statisticData.addParameter("contentLastModifier", news.getUpdater());
     statisticData.addParameter("contentType", "News");

--- a/webapp/src/main/resources/locale/portlet/Analytics_en.properties
+++ b/webapp/src/main/resources/locale/portlet/Analytics_en.properties
@@ -15,3 +15,4 @@ analytics.commentContent=Comment content
 analytics.shareContent=Share content
 analytics.likeContent=Like content
 analytics.deletedContent=Deleted content
+analytics.field.label.contentTitle=Content: Title

--- a/webapp/src/main/resources/locale/portlet/Analytics_fr.properties
+++ b/webapp/src/main/resources/locale/portlet/Analytics_fr.properties
@@ -15,3 +15,4 @@ analytics.commentContent=Contenu comment\u00E9
 analytics.shareContent=Contenu partag\u00E9
 analytics.likeContent=Contenu aim\u00E9
 analytics.deletedContent=Contenu supprim\u00E9
+analytics.field.label.contentTitle=Contenu: Titre


### PR DESCRIPTION
This fix introduces content title to the news analytics

(cherry picked from commit 5e80d218b0491219ff3befa176c0d63e73633f29)