### PR TITLE
fix : Fix news filtering by space with search terms - EXO-64778 

### DIFF
--- a/services/src/main/java/org/exoplatform/news/queryBuilder/NewsQueryBuilder.java
+++ b/services/src/main/java/org/exoplatform/news/queryBuilder/NewsQueryBuilder.java
@@ -55,7 +55,7 @@ public class NewsQueryBuilder {
         if (filter.getSearchText() != null && !filter.getSearchText().equals("")) {
           String escapedQuoteSearchText = filter.getSearchText().replace("'", "''").replace("\"", "\"\"");
           sqlQuery.append("CONTAINS(.,'").append(escapedQuoteSearchText).append("')");
-          if (!filter.getTagNames().isEmpty()){
+          if (filter.getTagNames() != null && !filter.getTagNames().isEmpty()){
             sqlQuery.append(" OR (");
             for (String tagName : filter.getTagNames()) {
               sqlQuery.append(" exo:body LIKE '%#").append(tagName).append("%'");


### PR DESCRIPTION
Before this change, when we attempted to filter news by search term and selected space, the space filter was not being applied. This issue was caused by a null pointer exception during the construction of the search news query. This fix addresses this issue