### PR TITLE
fix: Fix auto saving of an article edited using its public link - EXO-65336

### DIFF
--- a/webapp/src/main/webapp/news-details-app/components/ExoNewsDetailsApp.vue
+++ b/webapp/src/main/webapp/news-details-app/components/ExoNewsDetailsApp.vue
@@ -9,6 +9,7 @@
       id="newsFullDetails"
       :news="news"
       :news-id="newsId"
+      :activity-id="news.activityId"
       :show-edit-button="showEditButton"
       :show-publish-button="showPublishButton"
       :show-delete-button="showDeleteButton" />


### PR DESCRIPTION
Before this change, when we were editing an article using its public link, the article would be updated without clicking the save button. This issue was due to the missing activity ID, which is used by the auto-save feature to save the draft article. This fix addresses this issue.

(cherry picked from commit 1719a8b88cab4e20e91290a2acd6320da7732618)