### PR TITLE
fix: suggest all spaces for the spaces administrator group - EXO-65113

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -14,9 +14,8 @@
       "devDependencies": {
         "babel-loader": "^8.3.0",
         "eslint": "^8.12.0",
-        "eslint-config-meedsio": "^1.0.5",
+        "eslint-config-meedsio": "^1.0.4",
         "eslint-plugin-vue": "^8.6.0",
-        "eslint-plugin-vuejs-accessibility": "^2.1.0",
         "eslint-webpack-plugin": "^3.1.1",
         "vue": "^2.6.14",
         "vue-loader": "^15.10.1",
@@ -918,15 +917,6 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
     },
-    "node_modules/aria-query": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-      "dev": true,
-      "dependencies": {
-        "dequal": "^2.0.3"
-      }
-    },
     "node_modules/autosize": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/autosize/-/autosize-4.0.4.tgz",
@@ -1281,15 +1271,6 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
-    "node_modules/dequal": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -1306,12 +1287,6 @@
       "version": "1.4.284",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
       "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==",
-      "dev": true
-    },
-    "node_modules/emoji-regex": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.2.1.tgz",
-      "integrity": "sha512-97g6QgOk8zlDRdgq1WxwgTMgEWGVAQvB5Fdpgc1MkNy56la5SKP9GsMXKDOdqwn90/41a8yPwIGk1Y6WVbeMQA==",
       "dev": true
     },
     "node_modules/emojis-list": {
@@ -1430,9 +1405,9 @@
       }
     },
     "node_modules/eslint-config-meedsio": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/eslint-config-meedsio/-/eslint-config-meedsio-1.0.5.tgz",
-      "integrity": "sha512-eSae9Ald7T7g4gIdomPGJ7/H+aVd9L+wLvDUICvc8vKfLeKoJSdOH1uoJ1beUytObQbzbJJJC+cHvf+8BxYDdg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/eslint-config-meedsio/-/eslint-config-meedsio-1.0.4.tgz",
+      "integrity": "sha512-hGHNO0ss7jqPgPMQUe+q8UmA4lrIUnaqeusGeiCPYq1z9APGWNrZEIqpY8NGi2at6vcQJ0yXl559RRUeuP3GUg==",
       "dev": true
     },
     "node_modules/eslint-plugin-vue": {
@@ -1483,77 +1458,6 @@
       }
     },
     "node_modules/eslint-plugin-vue/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
-    },
-    "node_modules/eslint-plugin-vuejs-accessibility": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-vuejs-accessibility/-/eslint-plugin-vuejs-accessibility-2.1.0.tgz",
-      "integrity": "sha512-TM0JWrpOUOmka3v83QkH5uYkwUUNWg2RPa6imnBU1El2kRv0Ws1e9N84VPW2HLLTW+Fo+XsdKmiKLXwtIhCqsg==",
-      "dev": true,
-      "dependencies": {
-        "aria-query": ">=5.0.0",
-        "emoji-regex": "^10.0.0",
-        "vue-eslint-parser": "^9.0.1"
-      },
-      "peerDependencies": {
-        "eslint": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-vuejs-accessibility/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/eslint-plugin-vuejs-accessibility/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/eslint-plugin-vuejs-accessibility/node_modules/vue-eslint-parser": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-9.3.1.tgz",
-      "integrity": "sha512-Clr85iD2XFZ3lJ52/ppmUDG/spxQu6+MAeHXjjyI4I1NUYZ9xmenQp4N0oaHJhrA8OOxltCVxMRfANGa70vU0g==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^4.3.4",
-        "eslint-scope": "^7.1.1",
-        "eslint-visitor-keys": "^3.3.0",
-        "espree": "^9.3.1",
-        "esquery": "^1.4.0",
-        "lodash": "^4.17.21",
-        "semver": "^7.3.6"
-      },
-      "engines": {
-        "node": "^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
-      },
-      "peerDependencies": {
-        "eslint": ">=6.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-vuejs-accessibility/node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
@@ -4620,15 +4524,6 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
     },
-    "aria-query": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-      "dev": true,
-      "requires": {
-        "dequal": "^2.0.3"
-      }
-    },
     "autosize": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/autosize/-/autosize-4.0.4.tgz",
@@ -4895,12 +4790,6 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
-    "dequal": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true
-    },
     "doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -4914,12 +4803,6 @@
       "version": "1.4.284",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
       "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==",
-      "dev": true
-    },
-    "emoji-regex": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.2.1.tgz",
-      "integrity": "sha512-97g6QgOk8zlDRdgq1WxwgTMgEWGVAQvB5Fdpgc1MkNy56la5SKP9GsMXKDOdqwn90/41a8yPwIGk1Y6WVbeMQA==",
       "dev": true
     },
     "emojis-list": {
@@ -5077,9 +4960,9 @@
       }
     },
     "eslint-config-meedsio": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/eslint-config-meedsio/-/eslint-config-meedsio-1.0.5.tgz",
-      "integrity": "sha512-eSae9Ald7T7g4gIdomPGJ7/H+aVd9L+wLvDUICvc8vKfLeKoJSdOH1uoJ1beUytObQbzbJJJC+cHvf+8BxYDdg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/eslint-config-meedsio/-/eslint-config-meedsio-1.0.4.tgz",
+      "integrity": "sha512-hGHNO0ss7jqPgPMQUe+q8UmA4lrIUnaqeusGeiCPYq1z9APGWNrZEIqpY8NGi2at6vcQJ0yXl559RRUeuP3GUg==",
       "dev": true
     },
     "eslint-plugin-vue": {
@@ -5112,58 +4995,6 @@
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
-          }
-        },
-        "yallist": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "dev": true
-        }
-      }
-    },
-    "eslint-plugin-vuejs-accessibility": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-vuejs-accessibility/-/eslint-plugin-vuejs-accessibility-2.1.0.tgz",
-      "integrity": "sha512-TM0JWrpOUOmka3v83QkH5uYkwUUNWg2RPa6imnBU1El2kRv0Ws1e9N84VPW2HLLTW+Fo+XsdKmiKLXwtIhCqsg==",
-      "dev": true,
-      "requires": {
-        "aria-query": ">=5.0.0",
-        "emoji-regex": "^10.0.0",
-        "vue-eslint-parser": "^9.0.1"
-      },
-      "dependencies": {
-        "lru-cache": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "dev": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "semver": {
-          "version": "7.5.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
-        "vue-eslint-parser": {
-          "version": "9.3.1",
-          "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-9.3.1.tgz",
-          "integrity": "sha512-Clr85iD2XFZ3lJ52/ppmUDG/spxQu6+MAeHXjjyI4I1NUYZ9xmenQp4N0oaHJhrA8OOxltCVxMRfANGa70vU0g==",
-          "dev": true,
-          "requires": {
-            "debug": "^4.3.4",
-            "eslint-scope": "^7.1.1",
-            "eslint-visitor-keys": "^3.3.0",
-            "espree": "^9.3.1",
-            "esquery": "^1.4.0",
-            "lodash": "^4.17.21",
-            "semver": "^7.3.6"
           }
         },
         "yallist": {

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -14,8 +14,9 @@
       "devDependencies": {
         "babel-loader": "^8.3.0",
         "eslint": "^8.12.0",
-        "eslint-config-meedsio": "^1.0.4",
+        "eslint-config-meedsio": "^1.0.5",
         "eslint-plugin-vue": "^8.6.0",
+        "eslint-plugin-vuejs-accessibility": "^2.1.0",
         "eslint-webpack-plugin": "^3.1.1",
         "vue": "^2.6.14",
         "vue-loader": "^15.10.1",
@@ -917,6 +918,15 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
     },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
     "node_modules/autosize": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/autosize/-/autosize-4.0.4.tgz",
@@ -1271,6 +1281,15 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -1287,6 +1306,12 @@
       "version": "1.4.284",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
       "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==",
+      "dev": true
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.2.1.tgz",
+      "integrity": "sha512-97g6QgOk8zlDRdgq1WxwgTMgEWGVAQvB5Fdpgc1MkNy56la5SKP9GsMXKDOdqwn90/41a8yPwIGk1Y6WVbeMQA==",
       "dev": true
     },
     "node_modules/emojis-list": {
@@ -1405,9 +1430,9 @@
       }
     },
     "node_modules/eslint-config-meedsio": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/eslint-config-meedsio/-/eslint-config-meedsio-1.0.4.tgz",
-      "integrity": "sha512-hGHNO0ss7jqPgPMQUe+q8UmA4lrIUnaqeusGeiCPYq1z9APGWNrZEIqpY8NGi2at6vcQJ0yXl559RRUeuP3GUg==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/eslint-config-meedsio/-/eslint-config-meedsio-1.0.5.tgz",
+      "integrity": "sha512-eSae9Ald7T7g4gIdomPGJ7/H+aVd9L+wLvDUICvc8vKfLeKoJSdOH1uoJ1beUytObQbzbJJJC+cHvf+8BxYDdg==",
       "dev": true
     },
     "node_modules/eslint-plugin-vue": {
@@ -1458,6 +1483,77 @@
       }
     },
     "node_modules/eslint-plugin-vue/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
+    "node_modules/eslint-plugin-vuejs-accessibility": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vuejs-accessibility/-/eslint-plugin-vuejs-accessibility-2.1.0.tgz",
+      "integrity": "sha512-TM0JWrpOUOmka3v83QkH5uYkwUUNWg2RPa6imnBU1El2kRv0Ws1e9N84VPW2HLLTW+Fo+XsdKmiKLXwtIhCqsg==",
+      "dev": true,
+      "dependencies": {
+        "aria-query": ">=5.0.0",
+        "emoji-regex": "^10.0.0",
+        "vue-eslint-parser": "^9.0.1"
+      },
+      "peerDependencies": {
+        "eslint": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-vuejs-accessibility/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/eslint-plugin-vuejs-accessibility/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/eslint-plugin-vuejs-accessibility/node_modules/vue-eslint-parser": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-9.3.1.tgz",
+      "integrity": "sha512-Clr85iD2XFZ3lJ52/ppmUDG/spxQu6+MAeHXjjyI4I1NUYZ9xmenQp4N0oaHJhrA8OOxltCVxMRfANGa70vU0g==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.3.4",
+        "eslint-scope": "^7.1.1",
+        "eslint-visitor-keys": "^3.3.0",
+        "espree": "^9.3.1",
+        "esquery": "^1.4.0",
+        "lodash": "^4.17.21",
+        "semver": "^7.3.6"
+      },
+      "engines": {
+        "node": "^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=6.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-vuejs-accessibility/node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
@@ -4524,6 +4620,15 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
     },
+    "aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "requires": {
+        "dequal": "^2.0.3"
+      }
+    },
     "autosize": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/autosize/-/autosize-4.0.4.tgz",
@@ -4790,6 +4895,12 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
+    "dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true
+    },
     "doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -4803,6 +4914,12 @@
       "version": "1.4.284",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
       "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==",
+      "dev": true
+    },
+    "emoji-regex": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.2.1.tgz",
+      "integrity": "sha512-97g6QgOk8zlDRdgq1WxwgTMgEWGVAQvB5Fdpgc1MkNy56la5SKP9GsMXKDOdqwn90/41a8yPwIGk1Y6WVbeMQA==",
       "dev": true
     },
     "emojis-list": {
@@ -4960,9 +5077,9 @@
       }
     },
     "eslint-config-meedsio": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/eslint-config-meedsio/-/eslint-config-meedsio-1.0.4.tgz",
-      "integrity": "sha512-hGHNO0ss7jqPgPMQUe+q8UmA4lrIUnaqeusGeiCPYq1z9APGWNrZEIqpY8NGi2at6vcQJ0yXl559RRUeuP3GUg==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/eslint-config-meedsio/-/eslint-config-meedsio-1.0.5.tgz",
+      "integrity": "sha512-eSae9Ald7T7g4gIdomPGJ7/H+aVd9L+wLvDUICvc8vKfLeKoJSdOH1uoJ1beUytObQbzbJJJC+cHvf+8BxYDdg==",
       "dev": true
     },
     "eslint-plugin-vue": {
@@ -4995,6 +5112,58 @@
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-plugin-vuejs-accessibility": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vuejs-accessibility/-/eslint-plugin-vuejs-accessibility-2.1.0.tgz",
+      "integrity": "sha512-TM0JWrpOUOmka3v83QkH5uYkwUUNWg2RPa6imnBU1El2kRv0Ws1e9N84VPW2HLLTW+Fo+XsdKmiKLXwtIhCqsg==",
+      "dev": true,
+      "requires": {
+        "aria-query": ">=5.0.0",
+        "emoji-regex": "^10.0.0",
+        "vue-eslint-parser": "^9.0.1"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "vue-eslint-parser": {
+          "version": "9.3.1",
+          "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-9.3.1.tgz",
+          "integrity": "sha512-Clr85iD2XFZ3lJ52/ppmUDG/spxQu6+MAeHXjjyI4I1NUYZ9xmenQp4N0oaHJhrA8OOxltCVxMRfANGa70vU0g==",
+          "dev": true,
+          "requires": {
+            "debug": "^4.3.4",
+            "eslint-scope": "^7.1.1",
+            "eslint-visitor-keys": "^3.3.0",
+            "espree": "^9.3.1",
+            "esquery": "^1.4.0",
+            "lodash": "^4.17.21",
+            "semver": "^7.3.6"
           }
         },
         "yallist": {

--- a/webapp/src/main/webapp/news-publish-targets-management/components/NewsPublishTargetsManagementDrawer.vue
+++ b/webapp/src/main/webapp/news-publish-targets-management/components/NewsPublishTargetsManagementDrawer.vue
@@ -108,6 +108,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
               :group-member="userGroup"
               :group-type="groupType"
               :all-groups-for-admin="allGroupsForAdmin"
+              :search-options="{filterType: 'all'}"
               include-spaces
               include-groups
               required />


### PR DESCRIPTION
When selecting a news target, members of space administrators group have just the spaces where they are members. the fix will show all the spaces for the space adminsistrators group by passing the serachOptions.filterType property with value equals to all