### PR TITLE
feat: Disable News Activity Notifications by plugin instead of props - Meeds-io/MIPs#50

### DIFF
--- a/webapp/src/main/webapp/WEB-INF/conf/news/notification/configuration.xml
+++ b/webapp/src/main/webapp/WEB-INF/conf/news/notification/configuration.xml
@@ -229,4 +229,24 @@
       </init-params>
     </component-plugin>
   </external-component-plugins>
+
+  <external-component-plugins>
+    <target-component>org.exoplatform.social.core.manager.ActivityManager</target-component>
+    <component-plugin>
+      <name>NewsActivityTypePlugin</name>
+      <set-method>addActivityTypePlugin</set-method>
+      <type>org.exoplatform.social.core.ActivityTypePlugin</type>
+      <init-params>
+        <value-param>
+          <name>type</name>
+          <value>news</value>
+        </value-param>
+        <value-param>
+          <name>enableNotification</name>
+          <value>false</value>
+        </value-param>
+      </init-params>
+    </component-plugin>
+  </external-component-plugins>
+
 </configuration>


### PR DESCRIPTION
Prior to this change, the 'news' generated activity notification was disabled using properties embedded in Meeds Package. A new enhancement was made on Activity Stream APIto allow disable activity notifications by type. This change will configure the plugin to disable the Activity Notifications in favor of specific News notifications.