### PR TITLE
 fix :Update btn disabled in Edit posting/ publishing drawer - EXO-65317

### DIFF
--- a/webapp/src/main/webapp/news-details/components/ExoNewsEditPublishingDrawer.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsEditPublishingDrawer.vue
@@ -136,15 +136,20 @@ export default {
         this.disabled = true;
       } else {
         this.disabled = false;
+      }     
+      if (this.publish && this.news.targets && this.selectedTargets !== this.news.targets) {
+        this.selectedTargets = this.news.targets;
+        this.disabled = false;
+        if (this.news.published) {
+          this.disabled = true;
+        }
       }
     },
     selectedTargets(newVal, oldVal) {
       if (this.publish && newVal.length === 0) {
         this.disabled = true;
-      } else if (newVal !== oldVal) {
+      } else if (this.publish && this.selectedTargets !== this.news.targets && newVal !== oldVal) {
         this.disabled = false;
-      } else {
-        this.disabled = true;
       }
     },
   },
@@ -211,9 +216,7 @@ export default {
       this.editingNews = true;
       this.news.published = this.publish;
       this.news.activityPosted = !this.isActivityPosted;
-      if (this.selectedTargets.length > 0) {
-        this.news.targets = this.selectedTargets;
-      }
+      this.news.targets = this.selectedTargets;
       if (this.publish) {
         this.news.audience = this.selectedAudience === this.$t('news.composer.stepper.audienceSection.allUsers') ? 'all' : 'space';
       }


### PR DESCRIPTION
Prior to this change, when open action menu of the news, click on , publish btn, disable publish toggle btn, reclick on action menu and enable publish toggle btn, the update btn is disabled. To fix this problem, when disabled the publish news and save it is also necessary to save the new targets of the news and add a condition in publish to change the state of btn update. After this change, as there is a state change the update btn should be enabled.