### PR TITLE
 fix:[news] '#' glitches the filter - EXO-65188

### DIFF
--- a/services/pom.xml
+++ b/services/pom.xml
@@ -36,7 +36,7 @@
     <rest.api.doc.version>1.0</rest.api.doc.version>
     <rest.api.doc.description>News addon used Rest endpoints</rest.api.doc.description>
 
-    <exo.test.coverage.ratio>0.41</exo.test.coverage.ratio>
+    <exo.test.coverage.ratio>0.43</exo.test.coverage.ratio>
   </properties>
 
   <dependencies>

--- a/services/src/main/java/org/exoplatform/news/queryBuilder/NewsQueryBuilder.java
+++ b/services/src/main/java/org/exoplatform/news/queryBuilder/NewsQueryBuilder.java
@@ -60,16 +60,17 @@ public class NewsQueryBuilder {
           String escapedQuoteFuzzyText = fuzzyText.replace("'", "''").replace("\"", "\"\"");
           String escapedQuoteSearchText = filter.getSearchText().replace("'", "''").replace("\"", "\"\"");
           sqlQuery.append("(CONTAINS(.,'").append(escapedQuoteFuzzyText).append("') OR (exo:body LIKE '%").append(escapedQuoteSearchText).append("%'))");
-          if (filter.getTagNames() != null && !filter.getTagNames().isEmpty()){
-            sqlQuery.append(" OR (");
+          sqlQuery.append("AND ");
+        } else {
+          if (filter.getTagNames() != null && !filter.getTagNames().isEmpty()) {
             for (String tagName : filter.getTagNames()) {
               sqlQuery.append(" exo:body LIKE '%#").append(tagName).append("%'");
-              if (filter.getTagNames().indexOf(tagName) != filter.getTagNames().size() -1) {
+              if (filter.getTagNames().indexOf(tagName) != filter.getTagNames().size() - 1) {
                 sqlQuery.append(" OR");
               }
             }
-            sqlQuery.append(" ) AND ");
-          } else sqlQuery.append("AND ");
+            sqlQuery.append(" AND ");
+          }
         }
         if (filter.isPublishedNews()) {
           sqlQuery.append("exo:pinned = 'true' AND ");

--- a/services/src/main/java/org/exoplatform/news/rest/NewsRestResourcesV1.java
+++ b/services/src/main/java/org/exoplatform/news/rest/NewsRestResourcesV1.java
@@ -483,8 +483,12 @@ public class NewsRestResourcesV1 implements ResourceContainer, Startable {
         String lang = request.getLocale().getLanguage();
         TagService tagService = CommonsUtils.getService(TagService.class);
         long userIdentityId = RestUtils.getCurrentUserIdentityId();
-        List<TagName> tagNames = tagService.findTags(new TagFilter(text, 0), userIdentityId);
-        if (tagNames != null && !tagNames.isEmpty()) newsFilter.setTagNames(tagNames.stream().map(e -> e.getName()).toList());
+        if (text.indexOf("#") == 0) {
+          String tagName = text.replace("#","");
+          List<TagName> tagNames = tagService.findTags(new TagFilter(tagName, 0), userIdentityId);
+          if (tagNames != null && !tagNames.isEmpty()) newsFilter.setTagNames(tagNames.stream().map(e -> e.getName()).toList());
+        }
+
         news = newsService.searchNews(newsFilter, lang);
       } else {
         org.exoplatform.services.security.Identity currentIdentity = ConversationState.getCurrent().getIdentity();
@@ -1008,7 +1012,7 @@ public class NewsRestResourcesV1 implements ResourceContainer, Startable {
       }
     }
     // Set text to search news with
-    if (StringUtils.isNotEmpty(text)) {
+    if (StringUtils.isNotEmpty(text) && text.indexOf("#") != 0) {
       newsFilter.setSearchText(text);
     }
 

--- a/services/src/test/java/org/exoplatform/news/rest/NewsRestResourcesV1Test.java
+++ b/services/src/test/java/org/exoplatform/news/rest/NewsRestResourcesV1Test.java
@@ -1576,7 +1576,6 @@ public class NewsRestResourcesV1Test {
     allNews.add(news3);
     COMMONS_UTILS.when(()-> CommonsUtils.getService(TagService.class)).thenReturn(tagService);
     REST_UTILS.when(()-> RestUtils.getCurrentUserIdentityId()).thenReturn(1L);
-    when(tagService.findTags(new TagFilter(text, 0), 1L)).thenReturn(new ArrayList<>());
     lenient().when(newsService.searchNews(any(), any())).thenReturn(allNews);
     lenient().when(spaceService.isMember(any(Space.class), any())).thenReturn(true);
     lenient().when(spaceService.getSpaceById(anyString())).thenReturn(new Space());
@@ -1632,7 +1631,6 @@ public class NewsRestResourcesV1Test {
     allNews.add(news3);
     COMMONS_UTILS.when(()-> CommonsUtils.getService(TagService.class)).thenReturn(tagService);
     REST_UTILS.when(()-> RestUtils.getCurrentUserIdentityId()).thenReturn(1L);
-    when(tagService.findTags(new TagFilter(text, 0), 1L)).thenReturn(new ArrayList<>());
     lenient().when(newsService.searchNews(any(), any())).thenReturn(allNews);
     lenient().when(spaceService.isMember(any(Space.class), any())).thenReturn(true);
     lenient().when(spaceService.getSpaceById(anyString())).thenReturn(new Space());
@@ -1681,7 +1679,6 @@ public class NewsRestResourcesV1Test {
     allNews.add(news2);
     COMMONS_UTILS.when(()-> CommonsUtils.getService(TagService.class)).thenReturn(tagService);
     REST_UTILS.when(()-> RestUtils.getCurrentUserIdentityId()).thenReturn(1L);
-    when(tagService.findTags(new TagFilter(tagText, 0), 1L)).thenReturn(Arrays.asList(new TagName("tagText")));
     lenient().when(newsService.searchNews(any(), any())).thenReturn(allNews);
     lenient().when(spaceService.isMember(any(Space.class), any())).thenReturn(true);
     lenient().when(spaceService.getSpaceById(anyString())).thenReturn(new Space());
@@ -1733,7 +1730,6 @@ public class NewsRestResourcesV1Test {
     allNews.add(news3);
     COMMONS_UTILS.when(()-> CommonsUtils.getService(TagService.class)).thenReturn(tagService);
     REST_UTILS.when(()-> RestUtils.getCurrentUserIdentityId()).thenReturn(1L);
-    when(tagService.findTags(new TagFilter(text, 0), 1L)).thenReturn(new ArrayList<>());
     lenient().when(newsService.searchNews(any(), any())).thenReturn(allNews);
     lenient().when(spaceService.isMember(any(Space.class), any())).thenReturn(true);
     lenient().when(spaceService.getSpaceById(anyString())).thenReturn(new Space());
@@ -1918,7 +1914,6 @@ public class NewsRestResourcesV1Test {
     allNews.add(news3);
     COMMONS_UTILS.when(()-> CommonsUtils.getService(TagService.class)).thenReturn(tagService);
     REST_UTILS.when(()-> RestUtils.getCurrentUserIdentityId()).thenReturn(1L);
-    when(tagService.findTags(new TagFilter(text, 0), 1L)).thenReturn(new ArrayList<>());
     lenient().when(newsService.searchNews(any(), any())).thenReturn(allNews);
     lenient().when(spaceService.isMember(any(Space.class), any())).thenReturn(true);
     lenient().when(spaceService.getSpaceById(anyString())).thenReturn(new Space());

--- a/webapp/src/main/webapp/services/newsServices.js
+++ b/webapp/src/main/webapp/services/newsServices.js
@@ -55,6 +55,9 @@ export function markNewsAsRead(newsId){
 export function getNews(filter, spaces, searchText, offset, limit, returnSize) {
   let url = `${newsConstants.NEWS_API}?author=${newsConstants.userName}&publicationState=published&filter=${filter}`;
   if (searchText) {
+    if (searchText.indexOf('#') === 0) {
+      searchText = searchText.replace('#', '%23');
+    } 
     url += `&text=${searchText}`;
   }
   if (spaces) {


### PR DESCRIPTION
Prior to this change, when create a tag in article and go to news app make a search for that tag(# followed by tag name), there is no filter applied, the display remain the same. After this change, return results with the searched tag.