### PR TITLE
 fix:[news] search - paste filtered url in a new tab glitches the dis…

### DIFF
--- a/webapp/src/main/webapp/news/components/NewsApp.vue
+++ b/webapp/src/main/webapp/news/components/NewsApp.vue
@@ -183,8 +183,8 @@ export default {
   created() {
     const filterQueryParam = this.getQueryParam('filter');
     const searchQueryParam = this.getQueryParam('search');
-    this.removeQueryParam('spaces');
-    if (filterQueryParam || searchQueryParam) {
+    const spacesFilterParam = this.getQueryParam('spaces')?.split('_');    
+    if (filterQueryParam || searchQueryParam || spacesFilterParam) {
       if (filterQueryParam) {
         // set filter value, which will trigger news fetching
         this.newsFilter = filterQueryParam;
@@ -193,6 +193,11 @@ export default {
         // set search value
         this.searchText = searchQueryParam;
       }
+      if (spacesFilterParam) {
+        // set search value
+        this.spacesFilter = spacesFilterParam;
+      }
+      
     } else if (filterQueryParam === null) {
       this.newsFilter = 'all';
     } else {

--- a/webapp/src/main/webapp/news/components/NewsFilterSpaceDrawer.vue
+++ b/webapp/src/main/webapp/news/components/NewsFilterSpaceDrawer.vue
@@ -36,10 +36,13 @@ export default {
   },
   created() {
     this.$root.$on('news-space-selector-drawer-open', this.open);
+    this.selectedOwnerIds = this.value;
   },
   methods: {
     applyFilters() {
-      this.value = this.selectedOwnerIds;
+      if (this.value !== this.selectedOwnerIds){
+        this.value = this.selectedOwnerIds;
+      }
       this.$emit('input', this.value);
     },
     close() {


### PR DESCRIPTION
Prior to this change, when create news in three different space, go to news app, open hamburger drawer besides posted articles un-select all spaces and select only one space , copy the URL and paste it in a new tab on notice the filter glitches, all news are displayed. After this change, the filter is already mentioned in the URL.

(cherry picked from commit e330fbc767ae6a331ccc76638703a654bf1f7873)