### PR TITLE
fix: '#' glitches the News filter - EXO-65188

### DIFF
--- a/services/pom.xml
+++ b/services/pom.xml
@@ -36,7 +36,7 @@
     <rest.api.doc.version>1.0</rest.api.doc.version>
     <rest.api.doc.description>News addon used Rest endpoints</rest.api.doc.description>
 
-    <exo.test.coverage.ratio>0.41</exo.test.coverage.ratio>
+    <exo.test.coverage.ratio>0.43</exo.test.coverage.ratio>
   </properties>
 
   <dependencies>

--- a/services/src/main/java/org/exoplatform/news/queryBuilder/NewsQueryBuilder.java
+++ b/services/src/main/java/org/exoplatform/news/queryBuilder/NewsQueryBuilder.java
@@ -60,16 +60,17 @@ public class NewsQueryBuilder {
           String escapedQuoteFuzzyText = fuzzyText.replace("'", "''").replace("\"", "\"\"");
           String escapedQuoteSearchText = filter.getSearchText().replace("'", "''").replace("\"", "\"\"");
           sqlQuery.append("(CONTAINS(.,'").append(escapedQuoteFuzzyText).append("') OR (exo:body LIKE '%").append(escapedQuoteSearchText).append("%'))");
-          if (filter.getTagNames() != null && !filter.getTagNames().isEmpty()){
-            sqlQuery.append(" OR (");
+          sqlQuery.append("AND ");
+        } else {
+          if (filter.getTagNames() != null && !filter.getTagNames().isEmpty()) {
             for (String tagName : filter.getTagNames()) {
               sqlQuery.append(" exo:body LIKE '%#").append(tagName).append("%'");
-              if (filter.getTagNames().indexOf(tagName) != filter.getTagNames().size() -1) {
+              if (filter.getTagNames().indexOf(tagName) != filter.getTagNames().size() - 1) {
                 sqlQuery.append(" OR");
               }
             }
-            sqlQuery.append(" ) AND ");
-          } else sqlQuery.append("AND ");
+            sqlQuery.append(" AND ");
+          }
         }
         if (filter.isPublishedNews()) {
           sqlQuery.append("exo:pinned = 'true' AND ");

--- a/services/src/test/java/org/exoplatform/news/queryBuilder/NewsQueryBuilderTest.java
+++ b/services/src/test/java/org/exoplatform/news/queryBuilder/NewsQueryBuilderTest.java
@@ -2,33 +2,41 @@ package org.exoplatform.news.queryBuilder;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 import org.exoplatform.commons.utils.CommonsUtils;
+
+import org.exoplatform.social.core.identity.model.Identity;
+import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;
+import org.exoplatform.social.core.manager.IdentityManager;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
 import org.exoplatform.news.filter.NewsFilter;
 import org.exoplatform.news.utils.NewsUtils;
 import org.exoplatform.services.security.ConversationState;
 import org.exoplatform.services.security.MembershipEntry;
 import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceService;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+
 import org.mockito.Mock;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+
 @RunWith(PowerMockRunner.class)
 @PowerMockIgnore({"com.sun.*", "org.w3c.*", "javax.naming.*", "javax.xml.*", "org.xml.*", "javax.management.*"})
-@PrepareForTest(CommonsUtils.class)
+@PrepareForTest({CommonsUtils.class, NewsUtils.class})
 public class NewsQueryBuilderTest {
   @Mock
   SpaceService               spaceService;
+
 
   @Test
   public void shouldCreateQueryWithPinnedStateAndSearchTextAndAuthorAndOneSpaceAndCurrentUserIsNoPublisher() throws Exception {
@@ -43,6 +51,16 @@ public class NewsQueryBuilderTest {
     List<String> spaces = new ArrayList<>();
     spaces.add("1");
     filter.setSpaces(spaces);
+    filter.setDraftNews(true);
+    Space space1 = new Space();
+    space1.setId("1");
+    List<Space> allowedDraftNewsSpaces = new ArrayList<>();
+    allowedDraftNewsSpaces.add(space1);
+    PowerMockito.mockStatic(NewsUtils.class);
+    PowerMockito.mockStatic(CommonsUtils.class);
+    when( NewsUtils.getAllowedDraftNewsSpaces(any())).thenReturn(allowedDraftNewsSpaces);
+    Identity identity = new Identity(OrganizationIdentityProvider.NAME, "jean");
+    identity.setRemoteId("jean");
     org.exoplatform.services.security.Identity currentIdentity = new org.exoplatform.services.security.Identity("john");
     MembershipEntry membershipentry = new MembershipEntry("/platform/web-contributors", "redactor");
     List<MembershipEntry> memberships = new ArrayList<MembershipEntry>();
@@ -50,13 +68,16 @@ public class NewsQueryBuilderTest {
     currentIdentity.setMemberships(memberships);
     ConversationState state = new ConversationState(currentIdentity);
     ConversationState.setCurrent(state);
+    IdentityManager identityMock = mock(IdentityManager.class);
+    when(CommonsUtils.getService(IdentityManager.class)).thenReturn(identityMock);
+    when(identityMock.getOrCreateIdentity(anyString(), anyString())).thenReturn(identity);
 
     // when
     StringBuilder query = queryBuilder.buildQuery(filter);
 
     // then
     assertNotNull(query);
-    assertEquals("SELECT * FROM exo:news WHERE ( exo:archived IS NULL OR exo:archived = 'false' OR ( exo:archived = 'true' AND  exo:author = 'john')) AND (CONTAINS(.,'text~0.6') OR (exo:body LIKE '%text%')) OR ( exo:body LIKE '%#text%' OR exo:body LIKE '%#tex%' ) AND exo:pinned = 'true' AND ( exo:spaceId = '1') AND exo:author = 'john' AND (publication:currentState = 'published' OR (publication:currentState = 'draft' AND exo:activities <> '' )) AND jcr:path LIKE '/Groups/spaces/%' ORDER BY jcr:score DESC",
+    assertEquals("SELECT * FROM exo:news WHERE ( exo:archived IS NULL OR exo:archived = 'false' OR ( exo:archived = 'true' AND  exo:author = 'john')) AND (CONTAINS(.,'text~0.6') OR (exo:body LIKE '%text%'))AND exo:pinned = 'true' AND ( exo:spaceId = '1') AND publication:currentState = 'draft' AND (('null' IN exo:newsModifiersIds AND exo:activities <> '') OR ( exo:author = 'john' AND exo:activities = '')OR (exo:spaceId = '1') AND exo:draftVisible = 'true') AND jcr:path LIKE '/Groups/spaces/%' ORDER BY jcr:score DESC",
                  query.toString());
   }
 
@@ -218,6 +239,27 @@ public class NewsQueryBuilderTest {
     assertNotNull(query);
     assertEquals("SELECT * FROM exo:news WHERE ", query.toString());
   }
+
+  @Test
+  public void testBuildQueryWithTagNames() throws Exception {
+    // Given
+    NewsQueryBuilder queryBuilder = new NewsQueryBuilder();
+    org.exoplatform.services.security.Identity currentIdentity = new org.exoplatform.services.security.Identity("john");
+    ConversationState state = new ConversationState(currentIdentity);
+    ConversationState.setCurrent(state);
+    NewsFilter filter = new NewsFilter();
+    filter.setAuthor("john");
+    filter.setTagNames(Arrays.asList(new String[]{"text"}));
+
+    // when
+    StringBuilder query = queryBuilder.buildQuery(filter);
+
+    // then
+    assertNotNull(query);
+    assertEquals("SELECT * FROM exo:news WHERE ( exo:archived IS NULL OR exo:archived = 'false' OR ( exo:archived = 'true' AND  exo:author = 'john')) AND  exo:body LIKE '%#text%' AND exo:author = 'john' AND (publication:currentState = 'published' OR (publication:currentState = 'draft' AND exo:activities <> '' )) AND jcr:path LIKE '/Groups/spaces/%' ORDER BY null DESC",
+            query.toString());
+  }
+
   @Test
   public void shouldAddFuzzySyntaxWhitQuotedWord() throws Exception {
     // Given
@@ -229,7 +271,7 @@ public class NewsQueryBuilderTest {
 
     // Then
     assertNotNull(result);
-    assertEquals(result, "\"quoted\"~0.6");
+    assertEquals("\"quoted\"~0.6", result);
   }
 
   @Test
@@ -243,7 +285,7 @@ public class NewsQueryBuilderTest {
 
     // Then
     assertNotNull(result);
-    assertEquals(result, "search~0.6 OR text~0.6");
+    assertEquals("search~0.6 OR text~0.6", result);
   }
 
   @Test
@@ -257,7 +299,7 @@ public class NewsQueryBuilderTest {
 
     // Then
     assertNotNull(result);
-    assertEquals(result, "\"search text\"~0.6");
+    assertEquals("\"search text\"~0.6", result);
   }
   @Test
   public void shouldAddFuzzySyntaxWhenTextContainsMultiWordsAndQuotedOne() throws Exception {
@@ -270,6 +312,19 @@ public class NewsQueryBuilderTest {
 
     // Then
     assertNotNull(result);
-    assertEquals(result, "this~0.6 OR is~0.6 OR a~0.6 OR \"search text\"~0.6");
+    assertEquals("this~0.6 OR is~0.6 OR a~0.6 OR \"search text\"~0.6", result);
+  }
+
+  @Test
+  public void testAddFuzzySyntaxAndORQuoteInsideQuote() {
+    // Given
+    NewsQueryBuilder queryBuilder = new NewsQueryBuilder();
+    String text = "This \"quoted\" text.";
+
+    // when
+    String result = queryBuilder.addFuzzySyntaxAndOR(text);
+
+    // then
+    assertEquals("This~0.6 OR \"quoted\"~0.6 OR  text.~0.6", result);
   }
 }

--- a/services/src/test/java/org/exoplatform/news/rest/NewsRestResourcesV1Test.java
+++ b/services/src/test/java/org/exoplatform/news/rest/NewsRestResourcesV1Test.java
@@ -14,6 +14,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 import javax.ws.rs.ext.RuntimeDelegate;
 
+import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.news.model.NewsAttachment;
 import org.exoplatform.news.service.NewsService;
 import org.exoplatform.news.storage.NewsAttachmentsStorage;
@@ -22,8 +23,7 @@ import org.exoplatform.services.cms.thumbnail.ThumbnailService;
 import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;
 import org.exoplatform.social.metadata.favorite.FavoriteService;
 import org.exoplatform.social.metadata.tag.TagService;
-import org.exoplatform.social.metadata.tag.model.TagFilter;
-import org.exoplatform.social.metadata.tag.model.TagName;
+import org.exoplatform.social.rest.api.RestUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -36,13 +36,17 @@ import org.exoplatform.news.model.News;
 import org.exoplatform.services.rest.impl.RuntimeDelegateImpl;
 import org.exoplatform.services.security.*;
 import org.exoplatform.services.wcm.publication.PublicationDefaultStates;
-import org.exoplatform.social.core.manager.ActivityManager;
 import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceService;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(PowerMockRunner.class)
+@PowerMockIgnore({"com.sun.*", "org.w3c.*", "javax.naming.*", "javax.xml.*", "org.xml.*", "javax.management.*"})
+@PrepareForTest({CommonsUtils.class, RestUtils.class})
 public class NewsRestResourcesV1Test {
 
   public static final String JOHN = "john";
@@ -59,9 +63,6 @@ public class NewsRestResourcesV1Test {
   IdentityManager        identityManager;
 
   @Mock
-  ActivityManager        activityManager;
-
-  @Mock
   PortalContainer        container;
 
   @Mock
@@ -74,7 +75,7 @@ public class NewsRestResourcesV1Test {
   TagService tagService;
 
   private NewsRestResourcesV1 newsRestResourcesV1;
-  
+
   @Before
   public void setup() {
     RuntimeDelegate.setInstance(new RuntimeDelegateImpl());
@@ -1556,8 +1557,10 @@ public class NewsRestResourcesV1Test {
     allNews.add(news1);
     allNews.add(news2);
     allNews.add(news3);
-    when(container.getComponentInstanceOfType(TagService.class)).thenReturn(tagService);
-    when(tagService.findTags(new TagFilter(text, 0), 1L)).thenReturn(new ArrayList<>());
+    PowerMockito.mockStatic(CommonsUtils.class);
+    PowerMockito.mockStatic(RestUtils.class);
+    when(CommonsUtils.getService(TagService.class)).thenReturn(tagService);
+    when(RestUtils.getCurrentUserIdentityId()).thenReturn(1L);
     lenient().when(newsService.searchNews(any(), any())).thenReturn(allNews);
     lenient().when(spaceService.isMember(any(Space.class), any())).thenReturn(true);
     lenient().when(spaceService.getSpaceById(anyString())).thenReturn(new Space());
@@ -1611,8 +1614,10 @@ public class NewsRestResourcesV1Test {
     allNews.add(news1);
     allNews.add(news2);
     allNews.add(news3);
-    when(container.getComponentInstanceOfType(TagService.class)).thenReturn(tagService);
-    when(tagService.findTags(new TagFilter(text, 0), 1L)).thenReturn(new ArrayList<>());
+    PowerMockito.mockStatic(CommonsUtils.class);
+    PowerMockito.mockStatic(RestUtils.class);
+    when(CommonsUtils.getService(TagService.class)).thenReturn(tagService);
+    when(RestUtils.getCurrentUserIdentityId()).thenReturn(1L);
     lenient().when(newsService.searchNews(any(), any())).thenReturn(allNews);
     lenient().when(spaceService.isMember(any(Space.class), any())).thenReturn(true);
     lenient().when(spaceService.getSpaceById(anyString())).thenReturn(new Space());
@@ -1659,8 +1664,10 @@ public class NewsRestResourcesV1Test {
     List<News> allNews = new ArrayList<>();
     allNews.add(news1);
     allNews.add(news2);
-    when(container.getComponentInstanceOfType(TagService.class)).thenReturn(tagService);
-    when(tagService.findTags(new TagFilter(tagText, 0), 1L)).thenReturn(Arrays.asList(new TagName("tagText")));
+    PowerMockito.mockStatic(CommonsUtils.class);
+    PowerMockito.mockStatic(RestUtils.class);
+    when(CommonsUtils.getService(TagService.class)).thenReturn(tagService);
+    when(RestUtils.getCurrentUserIdentityId()).thenReturn(1L);
     lenient().when(newsService.searchNews(any(), any())).thenReturn(allNews);
     lenient().when(spaceService.isMember(any(Space.class), any())).thenReturn(true);
     lenient().when(spaceService.getSpaceById(anyString())).thenReturn(new Space());
@@ -1710,8 +1717,10 @@ public class NewsRestResourcesV1Test {
     allNews.add(news1);
     allNews.add(news2);
     allNews.add(news3);
-    when(container.getComponentInstanceOfType(TagService.class)).thenReturn(tagService);
-    when(tagService.findTags(new TagFilter(text, 0), 1L)).thenReturn(new ArrayList<>());
+    PowerMockito.mockStatic(CommonsUtils.class);
+    PowerMockito.mockStatic(RestUtils.class);
+    when(CommonsUtils.getService(TagService.class)).thenReturn(tagService);
+    when(RestUtils.getCurrentUserIdentityId()).thenReturn(1L);
     lenient().when(newsService.searchNews(any(), any())).thenReturn(allNews);
     lenient().when(spaceService.isMember(any(Space.class), any())).thenReturn(true);
     lenient().when(spaceService.getSpaceById(anyString())).thenReturn(new Space());
@@ -1894,8 +1903,10 @@ public class NewsRestResourcesV1Test {
     allNews.add(news1);
     allNews.add(news2);
     allNews.add(news3);
-    when(container.getComponentInstanceOfType(TagService.class)).thenReturn(tagService);
-    when(tagService.findTags(new TagFilter(text, 0), 1L)).thenReturn(new ArrayList<>());
+    PowerMockito.mockStatic(CommonsUtils.class);
+    PowerMockito.mockStatic(RestUtils.class);
+    when(CommonsUtils.getService(TagService.class)).thenReturn(tagService);
+    when(RestUtils.getCurrentUserIdentityId()).thenReturn(1L);
     lenient().when(newsService.searchNews(any(), any())).thenReturn(allNews);
     lenient().when(spaceService.isMember(any(Space.class), any())).thenReturn(true);
     lenient().when(spaceService.getSpaceById(anyString())).thenReturn(new Space());

--- a/webapp/src/main/webapp/services/newsServices.js
+++ b/webapp/src/main/webapp/services/newsServices.js
@@ -55,6 +55,9 @@ export function markNewsAsRead(newsId){
 export function getNews(filter, spaces, searchText, offset, limit, returnSize) {
   let url = `${newsConstants.NEWS_API}?author=${newsConstants.userName}&publicationState=published&filter=${filter}`;
   if (searchText) {
+    if (searchText.indexOf('#') === 0) {
+      searchText = searchText.replace('#', '%23');
+    } 
     url += `&text=${searchText}`;
   }
   if (spaces) {


### PR DESCRIPTION
Prior to this change, when create a tag in article and go to news app make a search for that tag(# followed by tag name), there is no filter applied, the display remain the same. After this change, return results with the searched tag.

(cherry picked from commit https://github.com/exoplatform/news/commit/4992ade14c9cad02cffd5e08385c0d3c9a627cbd)