### PR TITLE
fix: Adjust the styling of the Error messages for the news header input -EXO-65316

### DIFF
--- a/webapp/src/main/webapp/skin/less/newsListView.less
+++ b/webapp/src/main/webapp/skin/less/newsListView.less
@@ -73,6 +73,10 @@
         cursor: pointer;
       }
 
+      .v-messages.theme--light.error--text {
+        padding-right: 15%;
+      }
+
       .v-counter.theme--light {
         position: absolute;
         top: 44px;


### PR DESCRIPTION
Prior to this change the error message superimposes the maximum number of characters of the Header.
This change is going to adjust the styling of the error message for the news header input.