### PR TITLE
fix: Fix News Rich Editor content display style - MEED-2534 - Meeds-io/meeds#1102

### DIFF
--- a/webapp/src/main/webapp/news-details/components/ExoNewsDetailsBody.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsDetailsBody.vue
@@ -115,7 +115,7 @@
             id="newsBody"
             :class="[!summary ? 'fullDetailsBodyNoSummary' : '']"
             class="fullDetailsBody clearfix">
-            <span v-sanitized-html="newsBody"></span>
+            <span v-sanitized-html="newsBody" class="rich-editor-content"></span>
           </div>
 
           <div v-show="attachments && attachments.length" class="newsAttachmentsTitle">


### PR DESCRIPTION
This change will apply Rich Editor Style on News content to ensure consistency with WYSIWYG Editor style.