### PR TITLE
fix : Adjust the styling of the news mosaic view on the extra-large screen - EXO-66168 (#926)

### DIFF
--- a/webapp/src/main/webapp/news-list-view/components/views/NewsMosaicView.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsMosaicView.vue
@@ -91,7 +91,7 @@ export default {
     this.getNewsList();
   },
   mounted() {
-    this.isSmallWidth =  this.$refs && this.$refs['top-news-mosaic'] && this.$refs['top-news-mosaic']?.clientWidth *100 / window.screen.width  < 33;
+    this.isSmallWidth =  this.$refs && this.$refs['top-news-mosaic'] && this.$refs['top-news-mosaic']?.clientWidth < this.isSmallBreakpoint;
   },
   computed: {
     isMobile() {


### PR DESCRIPTION

Prior to this change, the news mosaic view articles were displayed like the mobile view on the extra-large screen. This issue was due to the incorrect check of the width based on the screen width. This change will display the news articles in the correct viewing mode .