### PR TITLE
fix : Enable post button after inserting draged or pasted image on the news body - EXO-66290 

### DIFF
--- a/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
+++ b/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
@@ -666,12 +666,10 @@ export default {
             self.news.body = evt.editor.getData();
             self.autoSave();
           },
-          drop: function (evt) {
-            window.setTimeout(() => {
-              self.news.body = evt.editor.getData();
-              self.autoSave();
-            }, 1000);
-          }
+          afterInsertHtml: function (evt) {
+            self.news.body = evt.editor.getData();
+            self.autoSave();
+          },
         }
       });
     },


### PR DESCRIPTION
Before this change, after inserting an image by pasting it into the news content, the 'Post' button continued to display as disabled. This issue was due to the 'onchange' event listener, which updated the news body by setting it to an empty value because the inserted image hadn't been uploaded yet. The same situation occurred with dragged images, which were handled by the 'drag' event listener with a one-second timeout to wait for the upload to finish. However, this approach was not satisfactory when dealing with a slow network connection.

This change adds the 'afterInsertHtml' event listener, which is fired after data insertion. This ensures that the inserted image is uploaded and inserted into the editor, resolving the issue.