### PR TITLE
fix:[NEWS] pasted image not displayed after posting news - EXO-66378

### DIFF
--- a/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
+++ b/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
@@ -389,6 +389,7 @@ export default {
       spaceDisplayName: '',
       unAuthorizedAccess: false,
       endUplodingFileTimeout: 50,
+      newsBody: null
     };
   },
   computed: {
@@ -667,7 +668,10 @@ export default {
             self.autoSave();
           },
           afterInsertHtml: function (evt) {
-            self.news.body = evt.editor.getData();
+            self.newsBody = evt.editor.getData();
+          },
+          fileUploadResponse: function() {
+            self.news.body = self.newsBody;
             self.autoSave();
           },
         }


### PR DESCRIPTION
Prior to this change, when open news editor in its body, type some text then paste an image copied from web or from personal computer when the image is being uploaded (upload in pregress), type some text in title field and click on post, this image not displayed. To fix this problem, added the fileUploadResponse event in the ckeditor and ensured that the addition of body cef had in this event. After this change, this image is displayed.