### PR TITLE
 fix: update news configuration for image storage location - EXO-64344 

### DIFF
--- a/services/src/test/java/org/exoplatform/news/storage/jcr/JcrNewsStorageTest.java
+++ b/services/src/test/java/org/exoplatform/news/storage/jcr/JcrNewsStorageTest.java
@@ -162,7 +162,6 @@ public class JcrNewsStorageTest {
   public static void afterRunBare() throws Exception { // NOSONAR
     COMMONS_UTILS.close();
     PORTAL_CONTAINER.close();
-    REST_UTILS.close();
   }
 
   @Test

--- a/services/src/test/java/org/exoplatform/news/storage/jcr/JcrNewsStorageTest.java
+++ b/services/src/test/java/org/exoplatform/news/storage/jcr/JcrNewsStorageTest.java
@@ -162,6 +162,7 @@ public class JcrNewsStorageTest {
   public static void afterRunBare() throws Exception { // NOSONAR
     COMMONS_UTILS.close();
     PORTAL_CONTAINER.close();
+    REST_UTILS.close();
   }
 
   @Test

--- a/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
+++ b/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
@@ -624,7 +624,7 @@ export default {
         typeOfRelation: 'mention_activity_stream',
         spaceURL: self.spaceURL,
         spaceGroupId: self.spaceGroupId,
-        imagesDownloadFolder: 'news/images',
+        imagesDownloadFolder: 'DRIVE_ROOT_NODE/news/images',
         toolbarLocation: 'top',
         extraAllowedContent: 'img[style,class,src,referrerpolicy,alt,width,height]; span(*)[*]{*}; span[data-atwho-at-query,data-atwho-at-value,contenteditable]; a[*];i[*]',
         removeButtons: 'Subscript,Superscript,Cut,Copy,Paste,PasteText,PasteFromWord,Undo,Redo,Scayt,Unlink,Anchor,Table,HorizontalRule,SpecialChar,Maximize,Source,Strike,Outdent,Indent,BGColor,About',


### PR DESCRIPTION
This will set the default location of images uploaded to News articles under the root of the space instead of under the Documents folder.