### PR TITLE
fix: Add cancel button on Mobile view on article creation page to return to previous page - EXO-63301

### DIFF
--- a/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
+++ b/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
@@ -33,6 +33,14 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         @post-article="postNews" />
       <div class="newsComposerToolbar">
         <div id="composerToolbarInformation" class="d-flex flex-row py-2">
+          <v-btn 
+            v-if="isMobile"
+            icon
+            fab
+            class="my-auto"
+            @click="close()">
+            <v-icon> mdi-arrow-left </v-icon>
+          </v-btn>
           <v-avatar
             height="40"
             min-height="40"
@@ -40,7 +48,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
             min-width="40"
             max-width="40"
             size="40"
-            class="mx-3 my-auto">
+            :class="isMobile ? 'me-3' : 'mx-3'"
+            class="my-auto">
             <v-img src="/news/images/news.png" />
           </v-avatar>
           <div class="d-flex flex-grow-1 flex-column my-auto align-left">
@@ -1016,6 +1025,9 @@ export default {
         }
       }).then(() => this.$emit('draftUpdated'))
         .then(() => this.draftSavingStatus = this.$t('news.composer.draft.savedDraftStatus'));
+    },
+    close() {
+      window.close();
     },
     goBack() {
       if ( history.length > 1) {


### PR DESCRIPTION
Prior to this change, when click on write an article In space then the article edition page opens, there is no way to quit the edition page unless I post the article.To fix this, Add the cancel button so the user can return to the previous page to space as page.

(cherry picked from commit 42bd39de91544d4a83dd1cfeb7cb06c3b51aa6ca)