### PR TITLE
fix: Article drafts edition makes the article displayed on top of the news app - EXO-56012

### DIFF
--- a/services/src/main/java/org/exoplatform/news/rest/NewsRestResourcesV1.java
+++ b/services/src/main/java/org/exoplatform/news/rest/NewsRestResourcesV1.java
@@ -1017,13 +1017,16 @@ public class NewsRestResourcesV1 implements ResourceContainer, Startable {
           break;
         }
       }
+      if ("DRAFTS".equals(filterType.toString())) {
+        newsFilter.setOrder("exo:lastModifiedDate");
+      } else {
+        newsFilter.setOrder("exo:dateModified");
+      }
     }
     // Set text to search news with
     if (StringUtils.isNotEmpty(text) && text.indexOf("#") != 0) {
       newsFilter.setSearchText(text);
     }
-
-    newsFilter.setOrder("exo:dateModified");
     newsFilter.setLimit(limit);
     newsFilter.setOffset(offset);
 

--- a/services/src/main/java/org/exoplatform/news/storage/jcr/JcrNewsStorage.java
+++ b/services/src/main/java/org/exoplatform/news/storage/jcr/JcrNewsStorage.java
@@ -397,7 +397,7 @@ public class JcrNewsStorage implements NewsStorage {
     news.setUpdater(getLastUpdater(originalNode));
     news.setUpdateDate(getLastUpdatedDate(originalNode));
     news.setDraftUpdater(getStringProperty(originalNode, EXO_NEWS_LAST_MODIFIER));
-    news.setDraftUpdateDate(getDateProperty(node, "exo:dateModified"));
+    news.setDraftUpdateDate(getDateProperty(node, "exo:lastModifiedDate"));
     news.setPath(getPath(node));
     news.setAudience(audience);
     if (node.hasProperty(StageAndVersionPublicationConstant.CURRENT_STATE)) {
@@ -629,8 +629,12 @@ public class JcrNewsStorage implements NewsStorage {
       newsNode.setProperty("exo:name", news.getTitle());
       newsNode.setProperty("exo:summary", news.getSummary());
       newsNode.setProperty("exo:body", news.getBody());
-      newsNode.setProperty("exo:dateModified", Calendar.getInstance());
       newsNode.setProperty(EXO_NEWS_LAST_MODIFIER, updater);
+      if (PublicationDefaultStates.DRAFT.equals(news.getPublicationState())) {
+        newsNode.setProperty("exo:lastModifiedDate", Calendar.getInstance());
+      } else {
+        newsNode.setProperty("exo:dateModified", Calendar.getInstance());
+      }
       // illustration
       if (StringUtils.isNotEmpty(news.getUploadId())) {
         attachIllustration(newsNode, news.getUploadId());

--- a/services/src/test/java/org/exoplatform/news/rest/NewsRestResourcesV1Test.java
+++ b/services/src/test/java/org/exoplatform/news/rest/NewsRestResourcesV1Test.java
@@ -155,7 +155,6 @@ public class NewsRestResourcesV1Test {
     newsList.add(news);
     NewsFilter newsFilter = new NewsFilter();
     newsFilter.setLimit(10);
-    newsFilter.setOrder("exo:dateModified");
     lenient().when(newsService.getNewsByTargetName(newsFilter, "sliderNews", currentIdentity)).thenReturn(newsList);
 
     // When


### PR DESCRIPTION
Before this fix, when post several articles in a space and in news app, click on three dots>edit button for the last posted article then type some inputs then click on cancel, this article is displayed on the top of the posted articles list. in fact, it is that the draft which was created and the article existing in the same property of the date modified (dateModified) to fix this problem, during creation of draft in set another property (lastModifiedDate) and during get all the articles by modifying the tree property according to the filter of this list if it is drafted by using it as a property lastModifiedDate if not by using the same existing property. After this change, the routed list is sorted either by lastModifiedDate if the filter is the draft article list or by dateModified if the list has another filter.