### PR TITLE
fix: Article drafts edition makes the article displayed on top of the news app - EXO-56012

### DIFF
--- a/services/src/main/java/org/exoplatform/news/rest/NewsRestResourcesV1.java
+++ b/services/src/main/java/org/exoplatform/news/rest/NewsRestResourcesV1.java
@@ -1018,9 +1018,9 @@ public class NewsRestResourcesV1 implements ResourceContainer, Startable {
         }
       }
       if ("DRAFTS".equals(filterType.toString())) {
-        newsFilter.setOrder("exo:lastModifiedDate");
-      } else {
         newsFilter.setOrder("exo:dateModified");
+      } else {
+        newsFilter.setOrder("publication:liveDate");
       }
     }
     // Set text to search news with

--- a/services/src/main/java/org/exoplatform/news/storage/jcr/JcrNewsStorage.java
+++ b/services/src/main/java/org/exoplatform/news/storage/jcr/JcrNewsStorage.java
@@ -890,13 +890,17 @@ public class JcrNewsStorage implements NewsStorage {
    * @throws RepositoryException when error
    */
   private Date getPublicationDate(Node node) throws RepositoryException {
-    VersionNode versionNode = new VersionNode(node, node.getSession());
-    List<VersionNode> versions = versionNode.getChildren();
-    if (!versions.isEmpty()) {
-      versions.sort(Comparator.comparingInt(v -> Integer.parseInt(v.getName())));
-      return versions.get(0).getCreatedTime().getTime();
+    if (node.hasProperty("publication:liveDate")) {
+      Calendar nodeLiveDate = node.getProperty("publication:liveDate").getDate();
+      return nodeLiveDate.getTime();
+    } else {
+      VersionNode versionNode = new VersionNode(node, node.getSession());
+      List<VersionNode> versions = versionNode.getChildren();
+      if (!versions.isEmpty()) {
+        versions.sort(Comparator.comparingInt(v -> Integer.parseInt(v.getName())));
+        return versions.get(0).getCreatedTime().getTime();
+      }
     }
-
     return null;
   }
   

--- a/services/src/test/java/org/exoplatform/news/storage/jcr/JcrNewsStorageTest.java
+++ b/services/src/test/java/org/exoplatform/news/storage/jcr/JcrNewsStorageTest.java
@@ -160,6 +160,7 @@ public class JcrNewsStorageTest {
   public static void afterRunBare() throws Exception { // NOSONAR
     COMMONS_UTILS.close();
     PORTAL_CONTAINER.close();
+    REST_UTILS.close();
   }
 
   @Test

--- a/services/src/test/java/org/exoplatform/news/storage/jcr/JcrNewsStorageTest.java
+++ b/services/src/test/java/org/exoplatform/news/storage/jcr/JcrNewsStorageTest.java
@@ -160,7 +160,6 @@ public class JcrNewsStorageTest {
   public static void afterRunBare() throws Exception { // NOSONAR
     COMMONS_UTILS.close();
     PORTAL_CONTAINER.close();
-    REST_UTILS.close();
   }
 
   @Test

--- a/services/src/test/java/org/exoplatform/news/storage/jcr/JcrNewsStorageTest.java
+++ b/services/src/test/java/org/exoplatform/news/storage/jcr/JcrNewsStorageTest.java
@@ -289,7 +289,7 @@ public class JcrNewsStorageTest {
             .thenReturn(version1).thenReturn(version2);
     when(versionHistory.getAllVersions()).thenReturn(versionIterator);
     when(versionHistory.getRootVersion()).thenReturn(mock(Version.class));
-    when(property.getDate()).thenReturn(Calendar.getInstance());
+    when(property.getDate()).thenReturn(calendar1);
     when(property.getLong()).thenReturn((long) 10);
     Space space = mock(Space.class);
     when(spaceService.getSpaceById(nullable(String.class))).thenReturn(space);

--- a/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
+++ b/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
@@ -595,7 +595,7 @@ export default {
         typeOfRelation: 'mention_activity_stream',
         spaceURL: self.spaceURL,
         spaceGroupId: self.spaceGroupId,
-        imagesDownloadFolder: 'DRIVE_ROOT_NODE/News/images',
+        imagesDownloadFolder: 'DRIVE_ROOT_NODE/news/images',
         toolbarLocation: 'top',
         extraAllowedContent: 'table[summary];img[style,class,src,referrerpolicy,alt,width,height];span(*)[*]{*}; span[data-atwho-at-query,data-atwho-at-value,contenteditable]; a[*];i[*];',
         removeButtons: '',

--- a/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
+++ b/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
@@ -595,7 +595,7 @@ export default {
         typeOfRelation: 'mention_activity_stream',
         spaceURL: self.spaceURL,
         spaceGroupId: self.spaceGroupId,
-        imagesDownloadFolder: 'DRIVE_ROOT_NODE/news/images',
+        imagesDownloadFolder: 'DRIVE_ROOT_NODE/News/images',
         toolbarLocation: 'top',
         extraAllowedContent: 'table[summary];img[style,class,src,referrerpolicy,alt,width,height];span(*)[*]{*}; span[data-atwho-at-query,data-atwho-at-value,contenteditable]; a[*];i[*];',
         removeButtons: '',


### PR DESCRIPTION
Before this fix, when post several articles in a space and in news app, click on three dots>edit button for the last posted article then type some inputs then click on cancel, this article is displayed on the top of the posted articles list. in fact, it is that the draft which was created and the article existing in the same property of the date modified (dateModified) to fix this problem, during creation of article in set another property (publication:liveDate) and during get all the articles by modifying the tree property according to the filter of this list if it is drafted by using it as a property (exo:dateModified) otherwise using the previous property. After this change, the routed list is sorted either by (exo:dateModified) if the filter is the draft article list or by (publication:liveDate) if the list has another filter.