### PR TITLE
fix: News Card news template does not have a unique ID - EXO-62572 .

### DIFF
--- a/webapp/src/main/webapp/news-list-view/components/views/NewsCardsViewItem.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsCardsViewItem.vue
@@ -32,7 +32,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
       <div class="upper-row">
         <a
           class="space-link"
-          id="space-link"
+          :id="`space-link-${item.activityId}`"
           target="_self"
           v-if="!isHiddenSpace && showArticleSpace"
           :href="item.spaceUrl">


### PR DESCRIPTION
Before this change, when you add 2 news stories and post them to a news list on the snapshot page and configure the news list on the snapshot page to use the news card template, in search source code id=space-link. There are 2 tags with this ID. To resolve this issue, update id=space-link in newsCardsViewItem to id= space-link-(item.activityId). After this change, in the News Card template space link in each card to their ID.