### PR TITLE
fix: fix open embedded links - EXO-65753

### DIFF
--- a/webapp/src/main/webapp/news-details/components/ExoNewsDetails.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsDetails.vue
@@ -89,6 +89,7 @@ export default {
         hour: '2-digit',
         minute: '2-digit',
       },
+      iframelyOriginRegex: /^https?:\/\/if-cdn.com/
     };
   },
   computed: {
@@ -109,6 +110,14 @@ export default {
       }
       this.$root.$emit('application-loaded');
     }
+    window.addEventListener('message', (event) => {
+      if (this.iframelyOriginRegex.exec(event.origin)) {
+        const data = JSON.parse(event.data);
+        if (data.method === 'open-href') {
+          window.open(data.href, '_blank');
+        }
+      }
+    });
   },
   mounted() {
     this.markNewsAsRead(this.newsId);


### PR DESCRIPTION
prior to this.change, embedded links are not opened directly when click, this due to a security rule that prevents events from propagating directly to the parent window, thus iframely adds a script that use the postMessage to communicate with parent window about the open of the link. This PR uses the event message to handle the open of links triggered from the embedded iframes of iframely