### PR TITLE
fix: User and space avatar are not accessible - EXO-62527

### DIFF
--- a/services/src/main/resources/locale/portlet/news/News_en.properties
+++ b/services/src/main/resources/locale/portlet/news/News_en.properties
@@ -162,6 +162,12 @@ news.cards.readMore=Read more
 news.details.archive.action=Bookmark it to easily find it when searching
 news.details.unarchive.action=Remove from favorites
 news.details.menu.open=Open activity menu
+
+news.space.icon.title=Open space {0}
+news.space.icon.alt=Space {0} avatar
+news.avatar.author.title=Open {0} profile
+news.avatar.author.alt={0}'s avatar
+
 news.details.header.menu.share=Share
 news.details.header.menu.edit=Edit
 news.details.header.menu.resume=Resume

--- a/services/src/test/java/org/exoplatform/news/storage/jcr/JcrNewsStorageTest.java
+++ b/services/src/test/java/org/exoplatform/news/storage/jcr/JcrNewsStorageTest.java
@@ -160,6 +160,7 @@ public class JcrNewsStorageTest {
   public static void afterRunBare() throws Exception { // NOSONAR
     COMMONS_UTILS.close();
     PORTAL_CONTAINER.close();
+    REST_UTILS.close();
   }
 
   @Test

--- a/services/src/test/java/org/exoplatform/news/storage/jcr/JcrNewsStorageTest.java
+++ b/services/src/test/java/org/exoplatform/news/storage/jcr/JcrNewsStorageTest.java
@@ -160,7 +160,6 @@ public class JcrNewsStorageTest {
   public static void afterRunBare() throws Exception { // NOSONAR
     COMMONS_UTILS.close();
     PORTAL_CONTAINER.close();
-    REST_UTILS.close();
   }
 
   @Test

--- a/webapp/src/main/webapp/news-list-view/components/views/NewsCardsViewItem.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsCardsViewItem.vue
@@ -31,16 +31,17 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
     <div class="text-area">
       <div class="upper-row">
         <a
-          class="space-link"
-          :id="`space-link-${item.activityId}`"
-          target="_self"
           v-if="!isHiddenSpace && showArticleSpace"
-          :href="item.spaceUrl">
+          :id="`space-link-${item.activityId}`"
+          :href="item.spaceUrl"
+          class="space-link"
+          target="_self"
+          :arial-label="$t('news.space.icon.title',{ 0:item.spaceDisplayName })">
           <div class="article-space">
             <img
               class="space-icon"
               :src="item.spaceAvatarUrl"
-              alt="Space icon">
+              :alt="$t('news.space.icon.alt',{ 0:item.spaceDisplayName })">
             <div class="space-name">{{ item.spaceDisplayName }}</div>
           </div>
         </a>

--- a/webapp/src/main/webapp/news-list-view/components/views/NewsLatestViewItem.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsLatestViewItem.vue
@@ -18,7 +18,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
   <a
     class="articleLink"
     target="_self"
-    :href="item.url">
+    :href="item.url"
+    :arial-label="$t('news.space.icon.title',{ 0:item.spaceDisplayName })">
     <div class="articleImage" v-if="showImage">
       <img 
         :src="articleImg"
@@ -29,7 +30,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         <img
           class="spaceImage"
           :src="item.spaceAvatarUrl"
-          :alt="$t('news.latest.alt.spaceImage')">
+          :alt="$t('news.space.icon.alt',{ 0:item.spaceDisplayName })">
         <span class="spaceName">{{ item.spaceDisplayName }}</span>
       </div>
       <span v-if="showArticleTitle" class="articleTitle text-color text-body-1">{{ item.title }}</span>

--- a/webapp/src/main/webapp/news-list-view/components/views/NewsSliderViewItem.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsSliderViewItem.vue
@@ -21,7 +21,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         <v-img
           class="author-image"
           :src="authorAvatarUrl"
-          alt="Author image" />
+          :alt="$t('news.avatar.author.alt',{0:authorDisplayName})" />
       </v-avatar>
       <span class="text-capitalize text--white my-auto ml-2">{{ authorDisplayName }}</span>
     </div>
@@ -36,9 +36,12 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         <v-img
           class="spaceImage"
           :src="spaceAvatarUrl"
-          alt="Space icon" />
+          :alt="$t('news.space.icon.alt',{ 0:spaceDisplayName })" />
       </v-avatar>
-      <a :href="spaceUrl" class="my-auto">
+      <a 
+        :href="spaceUrl" 
+        class="my-auto"
+        :arial-label="$t('news.space.icon.title',{ 0:spaceDisplayName })">
         <span class="my-auto spaceName ml-2">{{ spaceDisplayName }}</span>
       </a>
     </div>

--- a/webapp/src/main/webapp/news-list-view/components/views/NewsStoriesViewItem.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsStoriesViewItem.vue
@@ -30,7 +30,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
           v-if="showArticleAuthor"
           class="author-photo"
           :src="item.authorAvatarUrl"
-          alt="Author image">
+          :alt="$t('news.avatar.author.alt',{0:item.authorDisplayName})">
         <div v-if="showArticleDate" class="author-date">
           <date-format
             :value="displayDate"


### PR DESCRIPTION
Before this change, when create an activity and refresh stream, the a tag of avatar have not a discernible name, the img tag for avatar have a role=presentation which is not the correct one and space and user avatar are concerned. To fix this, added:
  -the arial-label for this a tag of user avatar by the key news.avatar.author.title which returns a text Open {userFullname} profile.
  -the alt for this image tag by the key news.avatar.author.alt which returns a text{userFullname}'s avatar.
  -the arial-label for this a tag of space avatar by the key news.space.icon.title which returns a text Open {userFullname} profile.
  -the alt for this image tag by the key news.space.icon.alt which returns a text{userFullname}'s avatar.
After this change, user and space avatar are accessible.