### PR TITLE
fix: News list button see have a constrast problem - EXO-62421

### DIFF
--- a/webapp/src/main/webapp/news-list-view/components/settings/NewsSettings.vue
+++ b/webapp/src/main/webapp/news-list-view/components/settings/NewsSettings.vue
@@ -36,7 +36,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
       <v-btn
         depressed
         small
-        class="button-see-all-news caption text-uppercase grey--text my-auto me-2"
+        class="button-see-all-news caption text-uppercase text-light-color my-auto me-2"
         @click="seeAllNews">
         {{ $t('news.published.seeAll') }}
       </v-btn>


### PR DESCRIPTION
Before this change, a contrast issue due to the text color of the "See All " botton:  text color is 9e9e9e, background color is f5F5F5
after this change, changing the text color  to "#707070" resolve the contrast problem