### PR TITLE
fix: News illustration is not centered in news details - EXO-67803

### DIFF
--- a/webapp/src/main/webapp/news-details/components/ExoNewsDetailsBody.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsDetailsBody.vue
@@ -10,7 +10,7 @@
     </div>
     <div class="newsDetails-description">
       <div :class="[illustrationURL ? 'newsDetails-header' : '']" class="newsDetails-header">
-        <div v-if="illustrationURL" class="illustration">
+        <div v-if="illustrationURL" class="illustration center">
           <img
             :src="illustrationURL.concat('&size=0x400').toString()"
             class="newsDetailsImage illustrationPicture"


### PR DESCRIPTION
Prior to this change, when creating a new article with spatial illustration and opening the news article, the main illustration was not centered. To fix this, add class center in ExoNewsDetailsBody.vue in the illustrationURL div. After this change, the main illustration is kept as in edit mode: centered.