### PR TITLE
fix: News template accessibility problems - EXO-62419 (#990)

### DIFF
--- a/services/src/main/resources/locale/portlet/news/News_en.properties
+++ b/services/src/main/resources/locale/portlet/news/News_en.properties
@@ -263,5 +263,8 @@ news.latest.noSettings=No settings defined for this news list
 news.latest.openSettings=Open settings
 news.list.settings.drawer.createNewTarget=Create a new target
 
+news.alertView.leftArrowButtonTitle=Previous visual
+news.alertView.rightArrowButtonTitle=Next visual
+
 # For news page template
 UIWizardPageSelectLayoutForm.label.newsPage.newsLayout=News

--- a/webapp/src/main/webapp/news-list-view/components/settings/NewsSettings.vue
+++ b/webapp/src/main/webapp/news-list-view/components/settings/NewsSettings.vue
@@ -24,8 +24,9 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
     </div>
     <div :class="[showHeader && newsHeader ? 'd-flex flex-column me-2 mt-1' : 'd-flex flex-column me-2']">
       <v-icon
-        class="button-open-settings"
         v-if="canPublishNews && showSettingsIcon"
+        class="button-open-settings"
+        :aria-label="$t('news.latest.openSettings')"
         size="24"
         icon
         @click="openDrawer">

--- a/webapp/src/main/webapp/news-list-view/components/views/NewsAlertView.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsAlertView.vue
@@ -52,19 +52,22 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
       <div class="slider-buttons d-flex pe-2">
         <v-btn
-            @click="slider--"
-            icon>
+          :aria-label="$t('news.alertView.leftArrowButtonTitle')"
+          @click="slider--"
+          icon>
           <v-icon>chevron_left</v-icon>
         </v-btn>
         <v-btn
-            @click="slider++"
-            icon>
+          :aria-label="$t('news.alertView.rightArrowButtonTitle')"
+          @click="slider++"
+          icon>
           <v-icon>chevron_right</v-icon>
         </v-btn>
         <v-btn
-            v-if="canPublishNews && hover"
-            icon
-            @click="openDrawer">
+          v-if="canPublishNews && hover"
+          :aria-label="$t('news.latest.openSettings')"
+          icon
+          @click="openDrawer">
           <v-icon>mdi-cog</v-icon>
         </v-btn>
       </div>

--- a/webapp/src/main/webapp/news-list-view/components/views/NewsSliderView.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsSliderView.vue
@@ -38,10 +38,11 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
             <div class="flex flex-column carouselNewsInfo">
               <div class="flex flex-row">
                 <v-btn
-                    v-if="canPublishNews && hover"
-                    icon
-                    @click="openDrawer"
-                    class="float-right settingNewsButton">
+                  v-if="canPublishNews && hover"
+                  :aria-label="$t('news.latest.openSettings')"
+                  icon
+                  @click="openDrawer"
+                  class="float-right settingNewsButton">
                   <v-icon>mdi-cog</v-icon>
                 </v-btn>
               </div>


### PR DESCRIPTION
Before this change, Create news in a space and publish it to a news list then change news template then launch a lighthouse report related to accessibility, the settings button in news template and the left/right arrow buttons is reported as not accessible. To resolve this problem, add the title for this settings button by the already existing key news.latest.openSettings which returns a text Open settings, this left arrow button by the key news.alertView.leftArrowButtonTitle which returns a text Previous visual and this right arrow button with the key news.alertView.rightArrowButtonTitle which returns a text Next visual. After this change, this failing element is no longer displayed in the launch accessiblity of the Lighthouse tab.

(cherry picked from commit 4b7110baaceeeca6f08b91a6d26e93c3d0e40c56)