### PR TITLE
fix : unread activities is displayed for hidden activities - EXO-68198

### DIFF
--- a/services/src/main/java/org/exoplatform/news/notification/plugin/NewsSpaceWebNotificationPlugin.java
+++ b/services/src/main/java/org/exoplatform/news/notification/plugin/NewsSpaceWebNotificationPlugin.java
@@ -51,6 +51,9 @@ public class NewsSpaceWebNotificationPlugin extends SpaceWebNotificationPlugin {
         }
         ExoSocialActivity activity = activityManager.getActivity(activityId);
         MetadataObject metadataObject;
+        if (activity.isHidden()) {
+            return null;
+        }
         if (activity.isComment()) {
             ExoSocialActivity parentActivity = activityManager.getActivity(activity.getParentId());
             metadataObject = parentActivity.getMetadataObject();


### PR DESCRIPTION
When a news is published, but not visible in a stream, the activity is marked as hidden Before this fix, the activity generate a unread activity notification which is not readable as the activity is displayed in any stream This fix check if the activity is hidden before generating the unread notifications