### PR TITLE
fix: Apply border radius for the news target administration - EXO-67636

### DIFF
--- a/webapp/src/main/webapp/news-publish-targets-management/components/NewsPublishTargetsManagement.vue
+++ b/webapp/src/main/webapp/news-publish-targets-management/components/NewsPublishTargetsManagement.vue
@@ -16,10 +16,10 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 -->
 <template>
   <v-app class="newsTargetsAdminSettings">
-    <v-main class="white rounded-lg ma-5 px-7 pb-2">
+    <v-main class="white  card-border-radius pa-5">
       <div class="white">
         <div class="d-flex flex-row">
-          <h4 class="py-5 font-weight-bold">
+          <h4 class="pb-5 font-weight-bold">
             {{ $t('newsTargets.settings.title') }}
           </h4>
         </div>


### PR DESCRIPTION
Before this modification, no border radius was applied to the news target administration application. This change will now implement the border radius on the news target administration application 