### PR TITLE
fix: apply the border radius to the write news composer button - EXO-68053 

### DIFF
--- a/webapp/src/main/webapp/news-extensions/composer-action-extensions/components/activity/ActivityWriteNewsComposer.vue
+++ b/webapp/src/main/webapp/news-extensions/composer-action-extensions/components/activity/ActivityWriteNewsComposer.vue
@@ -17,7 +17,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 <template>
   <v-card
     id="writeNewsComposerButton"
-    class="mx-4 px-6 py-3"
+    class="mx-4 px-6 py-3 card-border-radius"
     outlined
     flat
     hover


### PR DESCRIPTION

Before this modification, no border radius was applied to write news composer button. This change will now implement the border radius on the write news composer button