### PR TITLE
fix: back arrow button on browser shouldn't be redirecting to news editor - EXO-67362 (#971)

### DIFF
--- a/services/src/main/java/org/exoplatform/news/rest/NewsRestResourcesV1.java
+++ b/services/src/main/java/org/exoplatform/news/rest/NewsRestResourcesV1.java
@@ -1017,13 +1017,16 @@ public class NewsRestResourcesV1 implements ResourceContainer, Startable {
           break;
         }
       }
+      if ("DRAFTS".equals(filterType.toString())) {
+        newsFilter.setOrder("exo:lastModifiedDate");
+      } else {
+        newsFilter.setOrder("exo:dateModified");
+      }
     }
     // Set text to search news with
     if (StringUtils.isNotEmpty(text) && text.indexOf("#") != 0) {
       newsFilter.setSearchText(text);
     }
-
-    newsFilter.setOrder("exo:dateModified");
     newsFilter.setLimit(limit);
     newsFilter.setOffset(offset);
 

--- a/services/src/main/java/org/exoplatform/news/storage/jcr/JcrNewsStorage.java
+++ b/services/src/main/java/org/exoplatform/news/storage/jcr/JcrNewsStorage.java
@@ -397,7 +397,7 @@ public class JcrNewsStorage implements NewsStorage {
     news.setUpdater(getLastUpdater(originalNode));
     news.setUpdateDate(getLastUpdatedDate(originalNode));
     news.setDraftUpdater(getStringProperty(originalNode, EXO_NEWS_LAST_MODIFIER));
-    news.setDraftUpdateDate(getDateProperty(node, "exo:dateModified"));
+    news.setDraftUpdateDate(getDateProperty(node, "exo:lastModifiedDate"));
     news.setPath(getPath(node));
     news.setAudience(audience);
     if (node.hasProperty(StageAndVersionPublicationConstant.CURRENT_STATE)) {
@@ -629,8 +629,12 @@ public class JcrNewsStorage implements NewsStorage {
       newsNode.setProperty("exo:name", news.getTitle());
       newsNode.setProperty("exo:summary", news.getSummary());
       newsNode.setProperty("exo:body", news.getBody());
-      newsNode.setProperty("exo:dateModified", Calendar.getInstance());
       newsNode.setProperty(EXO_NEWS_LAST_MODIFIER, updater);
+      if (PublicationDefaultStates.DRAFT.equals(news.getPublicationState())) {
+        newsNode.setProperty("exo:lastModifiedDate", Calendar.getInstance());
+      } else {
+        newsNode.setProperty("exo:dateModified", Calendar.getInstance());
+      }
       // illustration
       if (StringUtils.isNotEmpty(news.getUploadId())) {
         attachIllustration(newsNode, news.getUploadId());

--- a/services/src/main/resources/locale/portlet/news/News_en.properties
+++ b/services/src/main/resources/locale/portlet/news/News_en.properties
@@ -90,7 +90,6 @@ news.activity.clickToShowDetail=Click here for more news details
 news.archive.btn.confirm=Confirm
 news.archive.btn.cancel=Cancel
 news.archive.action=Archive article
-news.archive.confirm=This article will be archived and will no longer be available for users. You still can unarchive it from News application.
 news.archive.success=The article was successfully archived
 news.archive.error=An error occurred when trying to archive this article. Try again, if the error persists, please contact your administrator.
 news.archive.label=Archived
@@ -160,7 +159,9 @@ news.slider.yourArticleTitleGoesHere=Your article goes here
 news.slider.write=Write an Article
 
 news.cards.readMore=Read more
-
+news.details.archive.action=Bookmark it to easily find it when searching
+news.details.unarchive.action=Remove from favorites
+news.details.menu.open=Open activity menu
 news.details.header.menu.share=Share
 news.details.header.menu.edit=Edit
 news.details.header.menu.resume=Resume

--- a/services/src/test/java/org/exoplatform/news/rest/NewsRestResourcesV1Test.java
+++ b/services/src/test/java/org/exoplatform/news/rest/NewsRestResourcesV1Test.java
@@ -155,7 +155,6 @@ public class NewsRestResourcesV1Test {
     newsList.add(news);
     NewsFilter newsFilter = new NewsFilter();
     newsFilter.setLimit(10);
-    newsFilter.setOrder("exo:dateModified");
     lenient().when(newsService.getNewsByTargetName(newsFilter, "sliderNews", currentIdentity)).thenReturn(newsList);
 
     // When

--- a/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
+++ b/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
@@ -401,6 +401,7 @@ export default {
       newsBody: null,
       desktopToolbar: null,
       oembedMinWidth: 300,
+      spaceUrl: null,
     };
   },
   computed: {
@@ -566,6 +567,7 @@ export default {
       this.openApp();
     });
     this.$root.$on('update-visibility', this.updateVisibility);
+    this.$root.$on('news-space-url', (spaceUrl)=>this.spaceUrl = spaceUrl);
   },
   methods: {
     initCKEditor: function() {
@@ -830,6 +832,7 @@ export default {
       if (news.publicationState ==='staged') {
         this.$newsServices.scheduleNews(news).then((scheduleNews) => {
           if (scheduleNews) {
+            history.replaceState(null,'',scheduleNews.spaceUrl);
             window.location.href = scheduleNews.url;
           }
         });
@@ -843,6 +846,7 @@ export default {
             }
           }
           if (createdNewsActivity) {
+            history.replaceState(null,'',this.spaceUrl);
             window.location.href = `${eXo.env.portal.context}/${eXo.env.portal.portalName}/activity?id=${createdNewsActivity}`;
           } else {
             window.location.href = `${eXo.env.portal.context}/${eXo.env.portal.portalName}`;
@@ -956,6 +960,7 @@ export default {
     },
     updateNews: function (post) {
       this.confirmAndUpdateNews(post).then(() => {
+        history.replaceState(null,'',this.spaceUrl);
         window.location.href = `${eXo.env.portal.context}/${eXo.env.portal.portalName}/activity?id=${this.activityId}`;
       }).catch (function() {
         window.location.href = `${eXo.env.portal.context}/${eXo.env.portal.portalName}/activity?id=${this.activityId}`;
@@ -986,6 +991,7 @@ export default {
       }
 
       return this.$newsServices.updateNews(updatedNews, post).then((createdNews) => {
+        this.spaceUrl = createdNews.spaceUrl;
         if (this.news.body !== createdNews.body) {
           this.imagesURLs = this.extractImagesURLsDiffs(this.news.body, createdNews.body);
         }

--- a/webapp/src/main/webapp/news-details/components/ExoNewsArchive.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsArchive.vue
@@ -12,7 +12,7 @@
       </transition>
     </div>
     <a
-      :data-original-title="archiveLabel"
+      :title="newsArchiveLabel"
       class="btn newsArchiveButton"
       rel="tooltip"
       data-placement="bottom"
@@ -52,12 +52,15 @@ export default {
       messageArchive: '',
       successArchive: true,
       archiveLabel: '',
+      newsArchiveLabel: '',
     };
   },
   created() {
     if (!this.newsArchived) {
+      this.newsArchiveLabel = this.$t('news.details.archive.action');
       this.archiveLabel = this.$t('news.archive.action');
     } else {
+      this.newsArchiveLabel = this.$t('news.details.unarchive.action');
       this.archiveLabel = this.$t('news.unarchive.action');
     }
   },
@@ -105,11 +108,13 @@ export default {
         if (context.newsArchived === false) {
           context.messageArchive = context.$t('news.archive.success');
           context.archiveLabel = context.$t('news.unarchive.action');
+          context.newsArchiveLabel = context.$t('news.details.unarchive.action');
           // eslint-disable-next-line vue/no-mutating-props
           context.newsArchived = true;
         } else {
           context.messageArchive = context.$t('news.unarchive.success');
           context.archiveLabel = context.$t('news.archive.action');
+          context.newsArchiveLabel = context.$t('news.details.archive.action');
           // eslint-disable-next-line vue/no-mutating-props
           context.newsArchived = false;
         }

--- a/webapp/src/main/webapp/news/components/ExoNewsDetailsActionMenuApp.vue
+++ b/webapp/src/main/webapp/news/components/ExoNewsDetailsActionMenuApp.vue
@@ -11,6 +11,7 @@
     <template #activator="{ on, attrs }">
       <v-btn
         v-bind="attrs"
+        :title="$t('news.details.menu.open')"
         class="newsDetailsActionMenu pull-right"
         icon
         v-on="on">

--- a/webapp/src/main/webapp/schedule-news-drawer/components/ExoScheduleNewsDrawer.vue
+++ b/webapp/src/main/webapp/schedule-news-drawer/components/ExoScheduleNewsDrawer.vue
@@ -456,6 +456,7 @@ export default {
             this.schedulePostDate = news.schedulePostDate;
             this.selectedTargets = news.targets;
             this.audience = news.audience ? news.audience : 'all';
+            this.$root.$emit('news-space-url',news.spaceUrl);
           }
         });
     },


### PR DESCRIPTION
Prior to this change, when creating or editing an article and clicking posted then clicking the back arrow on your browser, the news page editor is reopened. To resolve this issue, when you click Posted, change the URL in the history of the current page (news editor page) to the URL of this article's space. After this change, redirected to the space flow in case of new creation or update.

(cherry picked from commit 360e2f994af7abb70db41442eb35b93471b40ca3)