### PR TITLE
fix: Fix Image Alignment Issue After Saving - EXO-68298

### DIFF
--- a/webapp/src/main/webapp/news-details/components/ExoNewsDetailsBody.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsDetailsBody.vue
@@ -121,8 +121,8 @@
             :class="[!summary ? 'fullDetailsBodyNoSummary' : '']"
             class="fullDetailsBody ms-13 me-13 clearfix">
             <div
-              class="reset-style-box rich-editor-content extended-rich-content"
-              v-html="newsBody" />
+              class="rich-editor-content extended-rich-content"
+              v-html="newsBody"></div>
           </div>
 
           <div v-show="attachments && attachments.length" class="newsAttachmentsTitle">

--- a/webapp/src/main/webapp/news-details/components/mobile/ExoNewsDetailsBodyMobile.vue
+++ b/webapp/src/main/webapp/news-details/components/mobile/ExoNewsDetailsBodyMobile.vue
@@ -35,8 +35,8 @@
     <v-divider class="mx-4" />
     <div class="d-flex flex-column pa-4 ms-2 me-2 newsBody">
       <div
-        class="reset-style-box rich-editor-content extended-rich-content"
-        v-html="newsBody" />
+        class="rich-editor-content extended-rich-content"
+        v-html="newsBody"></div>
     </div>
     <div v-show="attachments && attachments.length" class="d-flex flex-row pa-4 newsAttachmentsTitle subtitle-2">
       {{ $t('news.details.attachments.title') }} ({{ attachments ? attachments.length : 0 }})


### PR DESCRIPTION
Prior to this change, the image was correctly aligned by the middle in height with the text while in edit mode, but after saving, it would align by the bottom with the text.This commit ensures that the image maintains a consistent vertical alignment with the text after saving.