### PR TITLE
fix: button favorite and 3 dots menu in activity detail have no accessible name - EXO-62416 (#1001)

### DIFF
--- a/webapp/src/main/webapp/news-details/components/ExoNewsArchive.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsArchive.vue
@@ -12,7 +12,7 @@
       </transition>
     </div>
     <a
-      :title="newsArchiveLabel"
+      :arial-label="newsArchiveLabel"
       class="btn newsArchiveButton"
       rel="tooltip"
       data-placement="bottom"

--- a/webapp/src/main/webapp/news-details/components/ExoNewsDetailsActionMenu.vue
+++ b/webapp/src/main/webapp/news-details/components/ExoNewsDetailsActionMenu.vue
@@ -12,6 +12,7 @@
         <v-btn
           v-bind="attrs"
           class="newsDetailsActionMenu pull-right"
+          :aria-label="$t('news.details.menu.open')"
           icon
           v-on="on">
           <v-icon>mdi-dots-vertical</v-icon>

--- a/webapp/src/main/webapp/news/components/ExoNewsDetailsActionMenuApp.vue
+++ b/webapp/src/main/webapp/news/components/ExoNewsDetailsActionMenuApp.vue
@@ -11,7 +11,7 @@
     <template #activator="{ on, attrs }">
       <v-btn
         v-bind="attrs"
-        :title="$t('news.details.menu.open')"
+        :aria-label="$t('news.details.menu.open')"
         class="newsDetailsActionMenu pull-right"
         icon
         v-on="on">


### PR DESCRIPTION
Before this change, after creating an activity in a space when you open DevTools of your browser and in the flagship tab, run the accessibility check, the favorite button and the 3 dots menu button have no accessible name. To resolve this problem, in the News_eu.properties file, added the labels following find it easily when searching, Remove from favorites and Open activity menu to the Archive article, Unarchive article and menu 3 buttons points of the activity. After this change, these faulty elements are no longer displayed in the flagship tab, launch accessibility.