### PR TITLE
fix: Article drafts edition makes the article displayed on top of thenews app - EXO-56012 (#956)

### DIFF
--- a/services/src/main/java/org/exoplatform/news/rest/NewsRestResourcesV1.java
+++ b/services/src/main/java/org/exoplatform/news/rest/NewsRestResourcesV1.java
@@ -1018,9 +1018,9 @@ public class NewsRestResourcesV1 implements ResourceContainer, Startable {
         }
       }
       if ("DRAFTS".equals(filterType.toString())) {
-        newsFilter.setOrder("exo:lastModifiedDate");
-      } else {
         newsFilter.setOrder("exo:dateModified");
+      } else {
+        newsFilter.setOrder("publication:liveDate");
       }
     }
     // Set text to search news with

--- a/services/src/main/java/org/exoplatform/news/storage/jcr/JcrNewsStorage.java
+++ b/services/src/main/java/org/exoplatform/news/storage/jcr/JcrNewsStorage.java
@@ -890,13 +890,17 @@ public class JcrNewsStorage implements NewsStorage {
    * @throws RepositoryException when error
    */
   private Date getPublicationDate(Node node) throws RepositoryException {
-    VersionNode versionNode = new VersionNode(node, node.getSession());
-    List<VersionNode> versions = versionNode.getChildren();
-    if (!versions.isEmpty()) {
-      versions.sort(Comparator.comparingInt(v -> Integer.parseInt(v.getName())));
-      return versions.get(0).getCreatedTime().getTime();
+    if (node.hasProperty("publication:liveDate")) {
+      Calendar nodeLiveDate = node.getProperty("publication:liveDate").getDate();
+      return nodeLiveDate.getTime();
+    } else {
+      VersionNode versionNode = new VersionNode(node, node.getSession());
+      List<VersionNode> versions = versionNode.getChildren();
+      if (!versions.isEmpty()) {
+        versions.sort(Comparator.comparingInt(v -> Integer.parseInt(v.getName())));
+        return versions.get(0).getCreatedTime().getTime();
+      }
     }
-
     return null;
   }
   

--- a/services/src/test/java/org/exoplatform/news/storage/jcr/JcrNewsStorageTest.java
+++ b/services/src/test/java/org/exoplatform/news/storage/jcr/JcrNewsStorageTest.java
@@ -289,7 +289,7 @@ public class JcrNewsStorageTest {
             .thenReturn(version1).thenReturn(version2);
     when(versionHistory.getAllVersions()).thenReturn(versionIterator);
     when(versionHistory.getRootVersion()).thenReturn(mock(Version.class));
-    when(property.getDate()).thenReturn(Calendar.getInstance());
+    when(property.getDate()).thenReturn(calendar1);
     when(property.getLong()).thenReturn((long) 10);
     Space space = mock(Space.class);
     when(spaceService.getSpaceById(nullable(String.class))).thenReturn(space);


### PR DESCRIPTION
Before this fix, when post several articles in a space and in news app, click on three dots>edit button for the last posted article then type some inputs then click on cancel, this article is displayed on the top of the posted articles list. in fact, it is that the draft which was created and the article existing in the same property of the date modified (dateModified) to fix this problem, during creation of article in set another property (publication:liveDate) and during get all the articles by modifying the tree property according to the filter of this list if it is drafted by using it as a property (exo:dateModified) otherwise using the previous property. After this change, the routed list is sorted either by (exo:dateModified) if the filter is the draft article list or by (publication:liveDate) if the list has another filter.

(cherry picked from commit 4247d8374173a3aa1ee73f1987f2f64271178edf)