### PR TITLE
fix: news settings form grayed out and not editable - EXO-68547

### DIFF
--- a/webapp/src/main/webapp/news-list-view/components/NewsListView.vue
+++ b/webapp/src/main/webapp/news-list-view/components/NewsListView.vue
@@ -205,6 +205,9 @@ export default {
     this.retrieveNewsList().finally(() => this.$root.$applicationLoaded());
     document.addEventListener(`component-${this.extensionApp}-${this.extensionType}-updated`, this.refreshViewExtensions);
     this.refreshViewExtensions();
+
+    document.addEventListener('drawerOpened', () => this.$el.closest('#stickyBlockDesktop').style.position = 'static');
+    document.addEventListener('drawerClosed', () => this.$el.closest('#stickyBlockDesktop').style.position = 'sticky');
   },
   methods: {
     retrieveNewsList() {


### PR DESCRIPTION
Prior to this change, the News List View portlet's settings drawer appeared in gray and was non-editable. This commit fixes the problem by implementing event listeners to dynamically switch the position style of the #stickyBlockDesktop element between "sticky" and "static" based on drawer events.
(cherry picked from commit 1593c7a89cc020868cacbc8d7a9418741bdc8308)