### PR TITLE
fix: fix filtering unread activities articles' activities are not displayed - EXO-68634

### DIFF
--- a/services/src/main/java/org/exoplatform/news/notification/plugin/NewsSpaceWebNotificationPlugin.java
+++ b/services/src/main/java/org/exoplatform/news/notification/plugin/NewsSpaceWebNotificationPlugin.java
@@ -64,6 +64,7 @@ public class NewsSpaceWebNotificationPlugin extends SpaceWebNotificationPlugin {
                 metadataObject.getId(),
                 0,
                 metadataObject.getSpaceId());
+        spaceWebNotificationItem.setActivityId(activityId);
         if (activity.isComment()) {
             spaceWebNotificationItem.addApplicationSubItem(activity.getId());
         }


### PR DESCRIPTION
before this change, when saving news activity unread metadata the activity ID was not set causing when retrieving unread activity the activityId is not set so the activity is not displayed After this change, the activityId is set and the news unread activity are displayed