### PR TITLE
fix: Fix wrong displayed audience for edited published news

### DIFF
--- a/webapp/src/main/webapp/components/targetSelector/ExoNewsTargetsSelector.vue
+++ b/webapp/src/main/webapp/components/targetSelector/ExoNewsTargetsSelector.vue
@@ -138,7 +138,8 @@ export default {
   data: () =>({
     selectedAudience: null,
     selectedTargets: [],
-    disableAudienceChoice: false
+    disableAudienceChoice: false,
+    isDataInitialized: false
   }),
   computed: {
     selectedAudienceDescription() {
@@ -175,6 +176,9 @@ export default {
     }
   },
   created() {
+    if (!this.audience && this.news?.audience) {
+      this.audience = this.news.audience;
+    }
     this.selectedAudience = !this.audience || this.audience === 'all' ? this.$t('news.composer.stepper.audienceSection.allUsers') : this.$t('news.composer.stepper.audienceSection.onlySpaceMembers');
     $(document).click(() => {
       if (this.$refs.chooseTargets && this.$refs.chooseTargets.isMenuActive) {
@@ -185,18 +189,21 @@ export default {
       }
     });
     this.selectedTargets = this.news.targets;
+    this.$nextTick(() => this.isDataInitialized = true);
   },
   watch: {
     selectedTargets() {
-      const selectedTargetForCurrentUser = this.selectedTargets.filter(item => this.targets.some(e => {
-        return e.name === item;
-      }));
-      if (!selectedTargetForCurrentUser.length > 0) {
-        this.disableAudienceChoice = false;
-        this.selectedAudience = this.audiences[0];
-        this.addAudience();
-      } else {
-        this.selectAudience(selectedTargetForCurrentUser);
+      if (this.isDataInitialized) {
+        const selectedTargetForCurrentUser = this.selectedTargets.filter(item => this.targets.some(e => {
+          return e.name === item;
+        }));
+        if (!selectedTargetForCurrentUser.length > 0) {
+          this.disableAudienceChoice = false;
+          this.selectedAudience = this.audiences[0];
+          this.addAudience();
+        } else {
+          this.selectAudience(selectedTargetForCurrentUser);
+        }
       }
     },
   },


### PR DESCRIPTION
Prior to this change, after publishing news with a selected audience and attempting to edit it, the news audience would be incorrect. This issue was due to the uninitialized state of the news audience and its construction by the watch. This change ensures the initialization of the news audience and prevents the watch during data initialization.