### PR TITLE
fix: Fix news illustration link accessibility - EXO-68802

### DIFF
--- a/services/src/main/resources/locale/portlet/news/News_en.properties
+++ b/services/src/main/resources/locale/portlet/news/News_en.properties
@@ -191,6 +191,7 @@ news.title.confirmDeleteDraftNews=Delete draft?
 news.button.ok=OK
 news.button.cancel=Cancel
 news.share.message=The article has been shared in
+news.illustration.link.title=open the news
 
 search.connector.label.news=News
 search.news.card.author=Author

--- a/services/src/main/resources/locale/portlet/news/News_en.properties
+++ b/services/src/main/resources/locale/portlet/news/News_en.properties
@@ -191,7 +191,7 @@ news.title.confirmDeleteDraftNews=Delete draft?
 news.button.ok=OK
 news.button.cancel=Cancel
 news.share.message=The article has been shared in
-news.illustration.link.title=open the news
+news.illustration.link.title=Open the news {0}
 
 search.connector.label.news=News
 search.news.card.author=Author

--- a/services/src/main/resources/locale/portlet/news/News_fr.properties
+++ b/services/src/main/resources/locale/portlet/news/News_fr.properties
@@ -191,7 +191,7 @@ news.title.confirmDeleteDraftNews=Supprimer le brouillon?
 news.button.ok=Valider
 news.button.cancel=Annuler
 news.share.message=L'article a \u00E9t\u00E9 partag\u00E9 dans
-news.illustration.link.title=Ouvrir l'article
+news.illustration.link.title=Ouvrir l'article {0}
 
 search.connector.label.news=Articles
 search.news.card.author=Auteur

--- a/services/src/main/resources/locale/portlet/news/News_fr.properties
+++ b/services/src/main/resources/locale/portlet/news/News_fr.properties
@@ -191,6 +191,7 @@ news.title.confirmDeleteDraftNews=Supprimer le brouillon?
 news.button.ok=Valider
 news.button.cancel=Annuler
 news.share.message=L'article a \u00E9t\u00E9 partag\u00E9 dans
+news.illustration.link.title=Ouvrir l'article
 
 search.connector.label.news=Articles
 search.news.card.author=Auteur

--- a/webapp/src/main/webapp/news/components/NewsAppItem.vue
+++ b/webapp/src/main/webapp/news/components/NewsAppItem.vue
@@ -20,7 +20,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
       :href="news.url"
       :style="{ 'background-image': 'url(' + illustrationUrl + ')' }"
       class="newsSmallIllustration"
-      :target="news.target"></a>
+      :target="news.target"
+      :aria-label="$t('news.illustration.link.title')"></a>
     <div class="newsItemContent">
       <div class="newsItemContentHeader">
         <h3>

--- a/webapp/src/main/webapp/news/components/NewsAppItem.vue
+++ b/webapp/src/main/webapp/news/components/NewsAppItem.vue
@@ -21,7 +21,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
       :style="{ 'background-image': 'url(' + illustrationUrl + ')' }"
       class="newsSmallIllustration"
       :target="news.target"
-      :aria-label="$t('news.illustration.link.title')"></a>
+      :aria-label="$t('news.illustration.link.title', {0: news.title})"></a>
     <div class="newsItemContent">
       <div class="newsItemContentHeader">
         <h3>


### PR DESCRIPTION
This change is going to add an aria label to the news illustration link to avoid the accessibility issue.