### PR TITLE
fix: Fix greeting text for posted/published news - EXO-69145

### DIFF
--- a/services/src/main/resources/locale/portlet/news/News_de.properties
+++ b/services/src/main/resources/locale/portlet/news/News_de.properties
@@ -107,7 +107,7 @@ news.notification.description.publish.news={0} hat den Artikel "{1} " ver\u00F6f
 news.notification.title=Neuer Artikel wurde in {0} ver\u00F6ffentlicht
 news.notification.title.mention.in.news=Sie wurden im Artikel "{0} " erw\u00E4hnt
 news.notification.title.published.news=Neuer Artikel ver\u00F6ffentlicht
-news.notification.label.SayHello=Hello
+Notification.label.SayHello=Hallo
 news.notification.button.goToContent.label=Go to news
 news.notification.label.footer=Wenn Sie solche Benachrichtigungen nicht empfangen m\u00F6chten, <a target="_blank" class="notification_settings_url" href="{0}">hier klicken</a>, um Ihre Benachrichtigung-Einstellungen zu passen.
 

--- a/services/src/main/resources/locale/portlet/news/News_en.properties
+++ b/services/src/main/resources/locale/portlet/news/News_en.properties
@@ -107,7 +107,7 @@ news.notification.description.publish.news={0} has published the article:
 news.notification.title=New article posted in {0}
 news.notification.title.mention.in.news=You have been mentioned in the article "{0}"
 news.notification.title.published.news=New article published
-news.notification.label.SayHello=Hello
+Notification.label.SayHello=Hi
 news.notification.button.goToContent.label=Go to news
 news.notification.label.footer=If you do not want to receive such notifications, <a target="_blank" class="notification_settings_url" href="{0}">click here</a> to change your notification settings.
 

--- a/services/src/main/resources/locale/portlet/news/News_fr.properties
+++ b/services/src/main/resources/locale/portlet/news/News_fr.properties
@@ -107,7 +107,7 @@ news.notification.description.publish.news={0} a diffus\u00E9 l'article "{1}"
 news.notification.title=Un nouvel article est publi\u00E9 dans {0}
 news.notification.title.mention.in.news=Vous avez \u00E9t\u00E9 mentionn\u00E9 dans l'article "{0}"
 news.notification.title.published.news=Nouvel article diffus\u00E9
-news.notification.label.SayHello=Hello
+Notification.label.SayHello=Bonjour
 news.notification.button.goToContent.label=Go to news
 news.notification.label.footer=Si vous ne souhaitez pas recevoir de telles notifications, <a target="_blank" class="notification_settings_url" href="{0}">cliquez ici</a> pour modifier vos param\u00E8tres de notification.
 


### PR DESCRIPTION
prior to this change the greeting text for posted & published news was received in english even though the plf language of the receiver is set to another language.
after the change the greeting text would be in the adequate language