### PR TITLE
fix: news bloc disappear if header contains apostrophe -EXO-69247

### DIFF
--- a/webapp/src/main/webapp/WEB-INF/jsp/newsListView.jsp
+++ b/webapp/src/main/webapp/WEB-INF/jsp/newsListView.jsp
@@ -78,7 +78,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         saveSettingsURL: <%= "'" + saveSettingsURL + "'" %>,
         viewTemplate: <%= viewTemplate == null ? null : "'" + viewTemplate + "'" %>,
         newsTarget: <%= newsTarget == null ? null : "'" + newsTarget + "'" %>,
-        header: <%= header == null ? null : "'" + header + "'" %>,
+        header: <%= header == null ? null : "'" + header.replace("'", "\\'") + "'" %>,
         showHeader: <%= showHeader == null ? null : "'" + showHeader + "'" %>,
         limit: <%= limit == null ? null : "'" + limit + "'" %>,
         showSeeAll: <%= showSeeAll == null ? null : "'" + showSeeAll + "'" %>,


### PR DESCRIPTION
before this change, when the header contains an " ' " the news bloc disappears since a JS script error happened while converting string Java to string js
After this change, the " ' " is replaced by its encoder " \\' " and allowing the string conversion and the news is bloc is well displayed