### PR TITLE
fix: Article drafts deletion makes the article displayed on top of the news application - EXO-58132

### DIFF
--- a/services/src/main/java/org/exoplatform/news/storage/jcr/JcrNewsStorage.java
+++ b/services/src/main/java/org/exoplatform/news/storage/jcr/JcrNewsStorage.java
@@ -691,7 +691,7 @@ public class JcrNewsStorage implements NewsStorage {
             if (!node.isCheckedOut()) {
               node.checkout();
             }
-            publicationService.changeState(node, PublicationDefaultStates.PUBLISHED, new HashMap<>());
+            publicationService.changeState(node, PublicationDefaultStates.PUBLISHED, new HashMap<>(){{ put("context.action", "delete"); }});
             return;
           }
         }


### PR DESCRIPTION
Prior to this change, after deleting the draft article, the article was displayed at the top of the articles list. This issue arose due to the update of the publication:liveDate property during the change of the current revision state to hide the deleted activity. This modification is going to prevent the publication:liveDate from being updated for the delete action.