### PR TITLE
fix: fix deleted news figure in missed activities counter - EXO-69288

### DIFF
--- a/services/src/main/java/org/exoplatform/news/service/impl/NewsServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/service/impl/NewsServiceImpl.java
@@ -221,10 +221,7 @@ public class NewsServiceImpl implements NewsService {
     newsStorage.deleteNews(newsId, isDraft);
     indexingService.unindex(NewsIndexingServiceConnector.TYPE, String.valueOf(news.getId()));
     MetadataObject newsMetadataObject = new MetadataObject(NewsUtils.NEWS_METADATA_OBJECT_TYPE, newsId, null);
-    List<MetadataItem> metadataItems = metadataService.getMetadataItemsByObject(newsMetadataObject);
-    for (MetadataItem metadataItem : metadataItems) {
-      metadataService.deleteMetadataItem(metadataItem.getId(), true);
-    }
+    metadataService.deleteMetadataItemsByObject(newsMetadataObject);
     NewsUtils.broadcastEvent(NewsUtils.DELETE_NEWS, currentIdentity.getUserId(), news);
   }
   

--- a/services/src/main/java/org/exoplatform/news/service/impl/NewsServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/service/impl/NewsServiceImpl.java
@@ -218,11 +218,6 @@ public class NewsServiceImpl implements NewsService {
     if (!news.isCanDelete()) {
       throw new IllegalArgumentException("User " + currentIdentity.getUserId() + " is not authorized to delete news");
     }
-
-    List<String> newsTargets = newsTargetingService.getTargetsByNewsId(newsId);
-    if (newsTargets != null) {
-      newsTargetingService.deleteNewsTargets(newsId);
-    }
     newsStorage.deleteNews(newsId, isDraft);
     indexingService.unindex(NewsIndexingServiceConnector.TYPE, String.valueOf(news.getId()));
     MetadataObject newsMetadataObject = new MetadataObject(NewsUtils.NEWS_METADATA_OBJECT_TYPE, newsId, null);

--- a/services/src/main/java/org/exoplatform/news/service/impl/NewsServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/service/impl/NewsServiceImpl.java
@@ -220,7 +220,7 @@ public class NewsServiceImpl implements NewsService {
     }
     newsStorage.deleteNews(newsId, isDraft);
     indexingService.unindex(NewsIndexingServiceConnector.TYPE, String.valueOf(news.getId()));
-    MetadataObject newsMetadataObject = new MetadataObject(NewsUtils.NEWS_METADATA_OBJECT_TYPE, newsId, null);
+    MetadataObject newsMetadataObject = new MetadataObject(NewsUtils.NEWS_METADATA_OBJECT_TYPE, newsId);
     metadataService.deleteMetadataItemsByObject(newsMetadataObject);
     NewsUtils.broadcastEvent(NewsUtils.DELETE_NEWS, currentIdentity.getUserId(), news);
   }

--- a/services/src/test/java/org/exoplatform/news/service/impl/NewsServiceImplTest.java
+++ b/services/src/test/java/org/exoplatform/news/service/impl/NewsServiceImplTest.java
@@ -231,19 +231,12 @@ public class NewsServiceImplTest {
 
     assertThrows(IllegalArgumentException.class, () -> newsService.deleteNews(news.getId(), identity, false));
     verify(newsStorage, times(1)).getNewsById(anyString(), anyBoolean());
-    verify(metadataService, times(0)).getMetadataItemsByObject(any(MetadataObject.class));
-    verify(metadataService, times(0)).deleteMetadataItem(any(Long.class), anyBoolean());
+    verify(metadataService, times(0)).deleteMetadataItemsByObject(any(MetadataObject.class));
 
     news.setAuthor(identity.getUserId());
     when(newsStorage.getNewsById(news.getId(), false)).thenReturn(news);
-    MetadataItem metadataItem = new MetadataItem();
-    metadataItem.setId(1L);
-    List<MetadataItem> metadataItems = new ArrayList<>();
-    metadataItems.add(metadataItem);
-    when(metadataService.getMetadataItemsByObject(any(MetadataObject.class))).thenReturn(metadataItems);
     newsService.deleteNews(news.getId(), identity, false);
     verify(newsStorage, times(2)).getNewsById(anyString(), anyBoolean());
-    verify(metadataService, times(1)).getMetadataItemsByObject(any(MetadataObject.class));
-    verify(metadataService, times(1)).deleteMetadataItem(any(Long.class), anyBoolean());
+    verify(metadataService, times(1)).deleteMetadataItemsByObject(any(MetadataObject.class));
   }
 }

--- a/services/src/test/java/org/exoplatform/news/service/impl/NewsServiceImplTest.java
+++ b/services/src/test/java/org/exoplatform/news/service/impl/NewsServiceImplTest.java
@@ -15,7 +15,6 @@ import static org.mockito.Mockito.when;
 import java.util.*;
 
 import org.exoplatform.social.metadata.MetadataService;
-import org.exoplatform.social.metadata.model.MetadataItem;
 import org.exoplatform.social.metadata.model.MetadataObject;
 import org.exoplatform.social.notification.Utils;
 import org.junit.AfterClass;

--- a/services/src/test/java/org/exoplatform/news/service/impl/NewsServiceImplTest.java
+++ b/services/src/test/java/org/exoplatform/news/service/impl/NewsServiceImplTest.java
@@ -17,6 +17,7 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 
+import org.exoplatform.social.metadata.MetadataService;
 import org.exoplatform.social.notification.Utils;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -76,6 +77,9 @@ public class NewsServiceImplTest {
     @Mock
     private UploadService uploadService;
 
+    @Mock
+    private MetadataService metadataService;
+
     private NewsService newsService;
 
     @AfterClass
@@ -87,7 +91,7 @@ public class NewsServiceImplTest {
     @Before
     public void setUp() {
         this.newsService = new NewsServiceImpl(spaceService, activityManager, identityManager, uploadService,
-                newsESSearchConnector,indexingService, newsStorage, userACL, newsTargetingService);
+                newsESSearchConnector,indexingService, newsStorage, userACL, newsTargetingService, metadataService);
     }
 
     @Test

--- a/services/src/test/java/org/exoplatform/news/service/impl/NewsServiceImplTest.java
+++ b/services/src/test/java/org/exoplatform/news/service/impl/NewsServiceImplTest.java
@@ -12,12 +12,11 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.*;
 
 import org.exoplatform.social.metadata.MetadataService;
+import org.exoplatform.social.metadata.model.MetadataItem;
+import org.exoplatform.social.metadata.model.MetadataObject;
 import org.exoplatform.social.notification.Utils;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -208,4 +207,43 @@ public class NewsServiceImplTest {
         verify(newsTargetingService, times(3)).deleteNewsTargets(any(News.class), anyString());
         verify(newsTargetingService, times(2)).saveNewsTarget(any(News.class), anyBoolean(), anyList(), anyString());
     }
+
+  @Test
+  public void testDeleteNews() throws Exception {
+    News news = new News();
+    news.setId("id123");
+    news.setSpaceId("1");
+
+    org.exoplatform.services.security.Identity identity = new Identity("1");
+    org.exoplatform.social.core.identity.model.Identity rootIdentity =
+                                                                     new org.exoplatform.social.core.identity.model.Identity("1");
+    Profile currentProfile = new Profile();
+    currentProfile.setProperty(Profile.FULL_NAME, "root");
+    rootIdentity.setProfile(currentProfile);
+    when(identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "root")).thenReturn(rootIdentity);
+    NEWS_UTILS.when(() -> NewsUtils.getUserIdentity(anyString())).thenReturn(identity);
+    Space space = new Space();
+    space.setId(news.getSpaceId());
+    space.setGroupId("/spaces/test_space");
+    space.setPrettyName("space_test");
+    when(spaceService.getSpaceById(news.getSpaceId())).thenReturn(space);
+    when(newsStorage.getNewsById(news.getId(), false)).thenReturn(news);
+
+    assertThrows(IllegalArgumentException.class, () -> newsService.deleteNews(news.getId(), identity, false));
+    verify(newsStorage, times(1)).getNewsById(anyString(), anyBoolean());
+    verify(metadataService, times(0)).getMetadataItemsByObject(any(MetadataObject.class));
+    verify(metadataService, times(0)).deleteMetadataItem(any(Long.class), anyBoolean());
+
+    news.setAuthor(identity.getUserId());
+    when(newsStorage.getNewsById(news.getId(), false)).thenReturn(news);
+    MetadataItem metadataItem = new MetadataItem();
+    metadataItem.setId(1L);
+    List<MetadataItem> metadataItems = new ArrayList<>();
+    metadataItems.add(metadataItem);
+    when(metadataService.getMetadataItemsByObject(any(MetadataObject.class))).thenReturn(metadataItems);
+    newsService.deleteNews(news.getId(), identity, false);
+    verify(newsStorage, times(2)).getNewsById(anyString(), anyBoolean());
+    verify(metadataService, times(1)).getMetadataItemsByObject(any(MetadataObject.class));
+    verify(metadataService, times(1)).deleteMetadataItem(any(Long.class), anyBoolean());
+  }
 }


### PR DESCRIPTION
before this change, after deleting news, it appears in the missed activities counter since its metadata item still exists
After this change, when deleting news its unread metadata items are deleted and  the counter of missed activities is displayed correctly