### PR TITLE
fix: fix deleted news figure in missed activities counter - EXO-69288

### DIFF
--- a/services/src/main/java/org/exoplatform/news/service/impl/NewsServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/news/service/impl/NewsServiceImpl.java
@@ -45,7 +45,9 @@ import org.exoplatform.social.core.manager.ActivityManager;
 import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceService;
+import org.exoplatform.social.metadata.MetadataService;
 import org.exoplatform.social.metadata.model.MetadataItem;
+import org.exoplatform.social.metadata.model.MetadataObject;
 import org.exoplatform.social.notification.LinkProviderUtils;
 import org.exoplatform.upload.UploadService;
 
@@ -74,7 +76,9 @@ public class NewsServiceImpl implements NewsService {
 
   private UserACL               userACL;
 
-  private NewsTargetingService               newsTargetingService;
+  private NewsTargetingService  newsTargetingService;
+
+  private MetadataService       metadataService;
 
   private static final Log      LOG                             = ExoLogger.getLogger(NewsServiceImpl.class);
 
@@ -86,7 +90,8 @@ public class NewsServiceImpl implements NewsService {
                          IndexingService indexingService,
                          NewsStorage newsStorage,
                          UserACL userACL,
-                         NewsTargetingService newsTargetingService) {
+                         NewsTargetingService newsTargetingService,
+                         MetadataService metadataService) {
     this.spaceService = spaceService;
     this.activityManager = activityManager;
     this.identityManager = identityManager;
@@ -95,6 +100,7 @@ public class NewsServiceImpl implements NewsService {
     this.newsStorage = newsStorage;
     this.userACL = userACL;
     this.newsTargetingService = newsTargetingService;
+    this.metadataService = metadataService;
   }
 
   /**
@@ -212,13 +218,10 @@ public class NewsServiceImpl implements NewsService {
     if (!news.isCanDelete()) {
       throw new IllegalArgumentException("User " + currentIdentity.getUserId() + " is not authorized to delete news");
     }
-
-    List<String> newsTargets = newsTargetingService.getTargetsByNewsId(newsId);
-    if(newsTargets != null) {
-      newsTargetingService.deleteNewsTargets(newsId);
-    }
     newsStorage.deleteNews(newsId, isDraft);
     indexingService.unindex(NewsIndexingServiceConnector.TYPE, String.valueOf(news.getId()));
+    MetadataObject newsMetadataObject = new MetadataObject(NewsUtils.NEWS_METADATA_OBJECT_TYPE, newsId);
+    metadataService.deleteMetadataItemsByObject(newsMetadataObject);
     NewsUtils.broadcastEvent(NewsUtils.DELETE_NEWS, currentIdentity.getUserId(), news);
   }
   

--- a/services/src/test/java/org/exoplatform/news/service/impl/NewsServiceImplTest.java
+++ b/services/src/test/java/org/exoplatform/news/service/impl/NewsServiceImplTest.java
@@ -12,11 +12,10 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.*;
 
+import org.exoplatform.social.metadata.MetadataService;
+import org.exoplatform.social.metadata.model.MetadataObject;
 import org.exoplatform.social.notification.Utils;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -76,6 +75,9 @@ public class NewsServiceImplTest {
     @Mock
     private UploadService uploadService;
 
+    @Mock
+    private MetadataService metadataService;
+
     private NewsService newsService;
 
     @AfterClass
@@ -87,7 +89,7 @@ public class NewsServiceImplTest {
     @Before
     public void setUp() {
         this.newsService = new NewsServiceImpl(spaceService, activityManager, identityManager, uploadService,
-                newsESSearchConnector,indexingService, newsStorage, userACL, newsTargetingService);
+                newsESSearchConnector,indexingService, newsStorage, userACL, newsTargetingService, metadataService);
     }
 
     @Test
@@ -204,4 +206,36 @@ public class NewsServiceImplTest {
         verify(newsTargetingService, times(3)).deleteNewsTargets(any(News.class), anyString());
         verify(newsTargetingService, times(2)).saveNewsTarget(any(News.class), anyBoolean(), anyList(), anyString());
     }
+
+  @Test
+  public void testDeleteNews() throws Exception {
+    News news = new News();
+    news.setId("id123");
+    news.setSpaceId("1");
+
+    org.exoplatform.services.security.Identity identity = new Identity("1");
+    org.exoplatform.social.core.identity.model.Identity rootIdentity =
+                                                                     new org.exoplatform.social.core.identity.model.Identity("1");
+    Profile currentProfile = new Profile();
+    currentProfile.setProperty(Profile.FULL_NAME, "root");
+    rootIdentity.setProfile(currentProfile);
+    when(identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "root")).thenReturn(rootIdentity);
+    NEWS_UTILS.when(() -> NewsUtils.getUserIdentity(anyString())).thenReturn(identity);
+    Space space = new Space();
+    space.setId(news.getSpaceId());
+    space.setGroupId("/spaces/test_space");
+    space.setPrettyName("space_test");
+    when(spaceService.getSpaceById(news.getSpaceId())).thenReturn(space);
+    when(newsStorage.getNewsById(news.getId(), false)).thenReturn(news);
+
+    assertThrows(IllegalArgumentException.class, () -> newsService.deleteNews(news.getId(), identity, false));
+    verify(newsStorage, times(1)).getNewsById(anyString(), anyBoolean());
+    verify(metadataService, times(0)).deleteMetadataItemsByObject(any(MetadataObject.class));
+
+    news.setAuthor(identity.getUserId());
+    when(newsStorage.getNewsById(news.getId(), false)).thenReturn(news);
+    newsService.deleteNews(news.getId(), identity, false);
+    verify(newsStorage, times(2)).getNewsById(anyString(), anyBoolean());
+    verify(metadataService, times(1)).deleteMetadataItemsByObject(any(MetadataObject.class));
+  }
 }


### PR DESCRIPTION
before this change, after deleting news, it appears in the missed activities counter since its metadata item still exists After this change, when deleting news its unread metadata items and all related metaDataItems are deleted and the counter of missed activities is displayed correctly