### PR TITLE
fix: Can't access to published news through notification - EXO-69364

### DIFF
--- a/webapp/src/main/webapp/news-notifications/components/PostNewsNotificationPlugin.vue
+++ b/webapp/src/main/webapp/news-notifications/components/PostNewsNotificationPlugin.vue
@@ -40,7 +40,8 @@ export default {
   },
   computed: {
     url() {
-      return this.notification?.parameters?.ACTIVITY_LINK;
+      return this.notification?.space?.isMember ? this.notification?.parameters?.ACTIVITY_LINK
+        : `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/news/detail?newsId=${this.notification?.parameters?.NEWS_ID}`;
     },
     eventTitle() {
       return this.notification?.parameters?.CONTENT_TITLE;


### PR DESCRIPTION
Before this change, when user who is not member in spacex receive the notification has published the article: news1 in spacex and click on it, user redirected to activity id of the news. After this change, as the user is not a member in the space he is redirected to the news id (news details).

(cherry picked from commit 1bc7d05b11d6646169632f580cf34bfa891548bc)