### PR TITLE
fix: Fix the embedded media that is not displayed on the scheduled news details - EXO-69716 

### DIFF
--- a/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
+++ b/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
@@ -855,10 +855,12 @@ export default {
       }
     },
     saveNewsDraft: function () {
+      this.news.body = this.replaceImagesURLs(this.news.body);
+      const newsBody = this.replaceImagesURLs(this.getBody());
       const news = {
         title: this.news.title,
         summary: this.news.summary,
-        body: this.replaceImagesURLs(this.news.body),
+        body: this.getBody() ? newsBody : this.news.body,
         author: this.currentUser,
         attachments: [],
         published: false,


### PR DESCRIPTION
Prior to this change, after including embedded media in a scheduled news article, the media was not displayed in the news details, but it was displayed with the posted articles. This issue occurred because embedded media was only processed during the post news action, which updates the news article on the contrary of the schedule new action. This change will preserve the embedded media during draft saving, resolving this issue.