### PR TITLE
fix: Fix the news list slider wiew is missing on small sceens - EXO-69373

### DIFF
--- a/webapp/src/main/webapp/news-list-view/components/views/NewsSliderView.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsSliderView.vue
@@ -126,7 +126,7 @@ export default {
       return this.newsList && this.newsList.filter(news => !!news);
     },
     extraClass() {
-      return this.$vuetify.breakpoint.width > 550 && (!this.canPublishNews && 'mt-7' || ' ') ;
+      return this.$vuetify.breakpoint.width > 550 ? (!this.canPublishNews && 'mt-7' || '') : '' ;
     },
     articleUrl() {
       return (item) => {


### PR DESCRIPTION
Prior to this change the news list slider view was not displayed on small screens (less than 550px) this issue was arose due to the incorrect computation of the the extraClass value , this change is going to compute correctly this class resolving this issue .