### PR TITLE
fix:  Template list : see all option + URL - EXO-69855

### DIFF
--- a/webapp/src/main/webapp/news-list-view/components/settings/NewsAdvancedSettings.vue
+++ b/webapp/src/main/webapp/news-list-view/components/settings/NewsAdvancedSettings.vue
@@ -76,16 +76,19 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
     <v-list-item v-if="showSeeAll">
       <v-list-item-content class="py-0">
         <v-list-item-action>
-          <input
+          <v-text-field
             v-model="seeAllUrl"
             :placeholder="$t('news.list.settings.drawer.advancedSettings.enterUrl')"
+            :rules="[urlRules.required]"
             type="url"
             id="seeLink"
             name="seeLink"
             required
+            outlined
+            dense
             @keyup="$emit('see-all-url', seeAllUrl)"
             @change="$emit('see-all-url', seeAllUrl)"
-            class="seeLink input-block-level ignore-vuetify-classes my-0">
+            class="seeLink input-block-level ignore-vuetify-classes my-0" />
         </v-list-item-action>
       </v-list-item-content>
     </v-list-item>
@@ -235,7 +238,10 @@ export default {
     showArticleSpace: false,
     showArticleDate: false,
     showArticleReactions: false,
-    limit: null
+    limit: null,
+    urlRules: {
+      required: value => value == null || !!(value?.length),
+    },
   }),
   computed: {
     displaySliderButton() {
@@ -267,7 +273,7 @@ export default {
       this.newsHeader = this.$root.header;
       this.limit = this.$root.limit;
       this.showHeader = this.viewTemplate === 'NewsSlider' || this.viewTemplate === 'NewsMosaic' || this.viewTemplate === 'NewsStories' ? false : this.$root.showHeader;
-      this.showSeeAll = this.viewTemplate === 'NewsSlider' || this.viewTemplate === 'NewsAlert' ? false : this.$root.showSeeAll;
+      this.showSeeAll = this.$root.showSeeAll;
       this.showArticleTitle = this.$root.showArticleTitle;
       this.showArticleImage = this.viewTemplate === 'NewsAlert' ? false : this.$root.showArticleImage;
       this.showArticleSummary = this.viewTemplate === 'NewsLatest' || this.viewTemplate === 'NewsAlert' || this.viewTemplate === 'NewsMosaic' || this.viewTemplate === 'NewsStories' ? false : this.$root.showArticleSummary;

--- a/webapp/src/main/webapp/news-list-view/components/settings/NewsSettingsDrawer.vue
+++ b/webapp/src/main/webapp/news-list-view/components/settings/NewsSettingsDrawer.vue
@@ -145,7 +145,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
           :show-article-author="showArticleAuthor"
           :view-template="viewTemplate"
           @limit-value="limit = $event"
-          @see-all-url="seeAllUrl = $event"
+          @see-all-url="setSeeAllUrl"
           @selected-option="selectedOption" />
       </form>
       <div class="d-flex flex-row mt-4 mx-8 justify-end advancedSettings">
@@ -198,6 +198,7 @@ export default {
     showArticleReactions: false,
     showTooltip: false,
     seeAllUrl: '',
+    isValidSeeAllUrl: false,
     saveSettingsURL: '',
     canManageNewsPublishTargets: eXo.env.portal.canManageNewsPublishTargets
   }),
@@ -218,7 +219,7 @@ export default {
       return this.viewTemplates.filter(e=> !e.name.includes('EmptyTemplate'));
     },
     disabled() {
-      return !this.newsHeader.length || (this.showSeeAll && !this.seeAllUrl?.length);
+      return !this.newsHeader.length || !this.isValidSeeAllUrl;
     },
     previewTemplate() {
       if ( this.viewTemplate === 'NewsLatest') {
@@ -257,6 +258,9 @@ export default {
         this.$refs.newsSettingsDrawer.endLoading();
       }
     },
+    seeAllUrl(){
+      this.isValidSeeAllUrl = !!this.seeAllUrl?.length;
+    }
   },
   created() {
     this.disabled = true;
@@ -299,7 +303,7 @@ export default {
       this.newsHeader = this.$root.header;
       this.limit = this.$root.limit;
       this.showHeader = this.viewTemplate === 'NewsSlider' || this.viewTemplate === 'NewsMosaic' || this.viewTemplate === 'NewsStories' ? false : this.$root.showHeader;
-      this.showSeeAll = false;
+      this.showSeeAll = this.$root.showSeeAll;
       this.showArticleTitle = this.$root.showArticleTitle;
       this.showArticleImage = this.viewTemplate === 'NewsAlert' ? false : this.$root.showArticleImage;
       this.showArticleSummary = this.viewTemplate === 'NewsLatest' || this.viewTemplate === 'NewsAlert' || this.viewTemplate === 'NewsMosaic' || this.viewTemplate === 'NewsStories' ? false : this.$root.showArticleSummary;
@@ -463,6 +467,9 @@ export default {
     },
     createNewTarget() {
       this.$root.$emit('open-news-publish-targets-management-drawer');
+    },
+    setSeeAllUrl(newUrl) {
+      this.seeAllUrl = newUrl;
     }
   },
 };

--- a/webapp/src/main/webapp/news-list-view/main.js
+++ b/webapp/src/main/webapp/news-list-view/main.js
@@ -64,7 +64,7 @@ export function init(params) {
   const header = params.header;
   const limit = params.limit === '' ? '4' : params.limit;
   const showHeader = viewTemplate === 'NewsSlider' ? false: params.showHeader === 'true';
-  const showSeeAll = viewTemplate === 'NewsSlider' ? false: params.showSeeAll === 'true';
+  const showSeeAll = params.showSeeAll === 'true' && !!params.seeAllUrl?.length;
   const showArticleTitle = params.showArticleTitle === '' ? true : params.showArticleTitle === 'true';
   const showArticleSummary = viewTemplate === 'NewsLatest' ? false: params.showArticleSummary === 'true';
   const showArticleImage = params.showArticleImage === '' ? true : params.showArticleImage === 'true';


### PR DESCRIPTION
Before this change, when changing the news list template and settings the save button was disabled as see All URL is empty
After this change, When I choose a display template or change the display template. Then the "see all" option is disabled by default and the text field is not displayed 