### PR TITLE
fix: Fix translate go to news button in mail notifications - EXO-69145 

### DIFF
--- a/services/src/main/resources/locale/portlet/news/News_fr.properties
+++ b/services/src/main/resources/locale/portlet/news/News_fr.properties
@@ -108,7 +108,7 @@ news.notification.title=Un nouvel article est publi\u00E9 dans {0}
 news.notification.title.mention.in.news=Vous avez \u00E9t\u00E9 mentionn\u00E9 dans l'article "{0}"
 news.notification.title.published.news=Nouvel article diffus\u00E9
 Notification.label.SayHello=Bonjour
-news.notification.button.goToContent.label=Go to news
+news.notification.button.goToContent.label=Consulter l'article
 news.notification.label.footer=Si vous ne souhaitez pas recevoir de telles notifications, <a target="_blank" class="notification_settings_url" href="{0}">cliquez ici</a> pour modifier vos param\u00E8tres de notification.
 
 UINotification.label.postCreateNews=Nouvel article


### PR DESCRIPTION
prior to this change the "go to news" button wasn't translated