### PR TITLE
fix:  Template list : see all option + URL - EXO-69855

### DIFF
--- a/webapp/src/main/webapp/news-list-view/components/settings/NewsAdvancedSettings.vue
+++ b/webapp/src/main/webapp/news-list-view/components/settings/NewsAdvancedSettings.vue
@@ -80,6 +80,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
             v-model="seeAllUrl"
             :placeholder="$t('news.list.settings.drawer.advancedSettings.enterUrl')"
             :rules="[urlRules.required]"
+            autofocus
             type="url"
             id="seeLink"
             name="seeLink"

--- a/webapp/src/main/webapp/news-list-view/components/settings/NewsSettingsDrawer.vue
+++ b/webapp/src/main/webapp/news-list-view/components/settings/NewsSettingsDrawer.vue
@@ -219,7 +219,7 @@ export default {
       return this.viewTemplates.filter(e=> !e.name.includes('EmptyTemplate'));
     },
     disabled() {
-      return !this.newsHeader.length || !this.isValidSeeAllUrl;
+      return !this.newsHeader.length || (this.showSeeAll && !this.isValidSeeAllUrl);
     },
     previewTemplate() {
       if ( this.viewTemplate === 'NewsLatest') {


### PR DESCRIPTION
Before this change, when changing the news list template and settings the save button was disabled as see All URL is empty
After this change, When I choose a display template or change the display template. Then the "see all" option is disabled by default and the text field is not displayed