### PR TITLE
fix: see all url autofocus and highlight - EXO-69855

### DIFF
--- a/webapp/src/main/webapp/news-list-view/components/settings/NewsAdvancedSettings.vue
+++ b/webapp/src/main/webapp/news-list-view/components/settings/NewsAdvancedSettings.vue
@@ -76,20 +76,16 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
     <v-list-item v-if="showSeeAll">
       <v-list-item-content class="py-0">
         <v-list-item-action>
-          <v-text-field
+          <input
             v-model="seeAllUrl"
-            :placeholder="$t('news.list.settings.drawer.advancedSettings.enterUrl')"
-            :rules="[urlRules.required]"
-            autofocus
             type="url"
             id="seeLink"
             name="seeLink"
+            autofocus
             required
-            outlined
-            dense
             @keyup="$emit('see-all-url', seeAllUrl)"
             @change="$emit('see-all-url', seeAllUrl)"
-            class="seeLink input-block-level ignore-vuetify-classes my-0" />
+            class="seeLink input-block-level ignore-vuetify-classes">
         </v-list-item-action>
       </v-list-item-content>
     </v-list-item>


### PR DESCRIPTION
before this change, the see all input is highlighted in red only when clicking outside
After this change, it is highlighted in red automatically when the showSeeAll is true