### PR TITLE
fix: Disable the see all button for Slider and News alert templates - EXO-70156

### DIFF
--- a/webapp/src/main/webapp/news-list-view/components/settings/NewsAdvancedSettings.vue
+++ b/webapp/src/main/webapp/news-list-view/components/settings/NewsAdvancedSettings.vue
@@ -67,6 +67,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
       <v-list-item-action>
         <v-switch
           v-model="showSeeAll"
+          :disabled="disableSeeAll"
           dense
           @change="selectedOption('showSeeAll', showSeeAll)"
           class="displayHeaderTitle my-auto" />
@@ -255,6 +256,9 @@ export default {
     },
     displayStoriesButtons() {
       return this.viewTemplate === 'NewsStories';
+    },
+    disableSeeAll() {
+      return this.viewTemplate === 'NewsSlider' || this.viewTemplate === 'NewsAlert';
     },
   },
   created() {


### PR DESCRIPTION
Before this change, choose Slider template (the same thing for News alert) the showseeAll button is active and we can change its value
After this change, The option must be deactivated for the two templates Slider and News alert as the option "Show list header"