### PR TITLE
fix: News bloc : Title display issue - EXO-70313

### DIFF
--- a/webapp/src/main/webapp/news-list-view/components/settings/NewsSettings.vue
+++ b/webapp/src/main/webapp/news-list-view/components/settings/NewsSettings.vue
@@ -16,7 +16,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 -->
 <template>
   <div v-if="showSettingsContainer" class="settings-container d-flex flex-row px-2 pt-2 pb-1">
-    <div class="d-flex latestNewsTitleContainer flex-column flex-grow-1 my-1">
+    <div class="d-flex latestNewsTitleContainer flex-column flex-grow-1 my-1 text-truncate">
       <span
         v-if="showHeader"
         class="news-text-header text-truncate"


### PR DESCRIPTION
Before this change, The news template header exceeded the border and the settings button + see all are displayed out of the template boundary
After this change, the header is truncated and the settings button + see all are well displayed 