### PR TITLE
fix: Delete Useless Loading Effetct - Meeds-io/MIPs#120

### DIFF
--- a/webapp/src/main/webapp/news-publish-targets-management/main.js
+++ b/webapp/src/main/webapp/news-publish-targets-management/main.js
@@ -36,8 +36,6 @@ if (extensionRegistry) {
 Vue.use(Vuetify);
 const vuetify = new Vuetify(eXo.env.portal.vuetifyPreset);
 
-document.dispatchEvent(new CustomEvent('displayTopBarLoading'));
-
 const appId = 'newsPublishTargetsManagement';
 
 // getting language of the PLF


### PR DESCRIPTION
Prior to this change, a `displayTopBarLoading` is initiated by application without a corresponding `hideTopBarLoading` to stop loading effect. This change will delete the display of page global loading effect and rely instead of the internal loading effect added inside the application while loading the news list.