### PR TITLE
Task-70913 : publish news : email received displays truncated border and content

### DIFF
--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>news</artifactId>
     <groupId>org.exoplatform.addons.news</groupId>
-    <version>2.6.x-SNAPSHOT</version>
+    <version>2.6.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>news-packaging</artifactId>
   <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
   </parent>
   <groupId>org.exoplatform.addons.news</groupId>
   <artifactId>news</artifactId>
-  <version>2.6.x-SNAPSHOT</version>
+  <version>2.6.x-maintenance-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>eXo Add-on:: News</name>
   <description>News</description>
@@ -40,7 +40,7 @@
   </modules>
 
   <properties>
-    <addon.exo.ecms.version>6.6.x-SNAPSHOT</addon.exo.ecms.version>
+    <addon.exo.ecms.version>6.6.x-maintenance-SNAPSHOT</addon.exo.ecms.version>
     <pitest.version>1.4.10</pitest.version>
 
     <sonar.organization>exoplatform</sonar.organization>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>news</artifactId>
     <groupId>org.exoplatform.addons.news</groupId>
-    <version>2.6.x-SNAPSHOT</version>
+    <version>2.6.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>news-services</artifactId>
   <packaging>jar</packaging>

--- a/services/src/main/java/org/exoplatform/news/notification/provider/MailTemplateProvider.java
+++ b/services/src/main/java/org/exoplatform/news/notification/provider/MailTemplateProvider.java
@@ -125,6 +125,7 @@ public class MailTemplateProvider extends TemplateProvider {
       templateContext.put("FIRST_NAME", encoder.encode(receiver.getProfile().getProperty(Profile.FIRST_NAME).toString()));
       // Footer
       templateContext.put("FOOTER_LINK", LinkProviderUtils.getRedirectUrl("notification_settings", receiver.getRemoteId()));
+      templateContext.put("COMPANY_LINK", LinkProviderUtils.getBaseUrl());
       String subject = TemplateUtils.processSubject(templateContext);
       String body = TemplateUtils.processGroovy(templateContext);
       // binding the exception throws by processing template

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>news</artifactId>
     <groupId>org.exoplatform.addons.news</groupId>
-    <version>2.6.x-SNAPSHOT</version>
+    <version>2.6.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>news-webapp</artifactId>
   <packaging>war</packaging>


### PR DESCRIPTION
Prior to this fix, when a user publish an article in a space, notification mail content is  truncated : no name displayed, the bottom border isn't displayed,
This problem is caused by a missing company link attribute.
This fix add the missing information to render correctely the mail template.