### PR TITLE
Task-70913 : publish news : email received displays truncated border and content

### DIFF
--- a/services/src/main/java/org/exoplatform/news/notification/provider/MailTemplateProvider.java
+++ b/services/src/main/java/org/exoplatform/news/notification/provider/MailTemplateProvider.java
@@ -125,6 +125,7 @@ public class MailTemplateProvider extends TemplateProvider {
       templateContext.put("FIRST_NAME", encoder.encode(receiver.getProfile().getProperty(Profile.FIRST_NAME).toString()));
       // Footer
       templateContext.put("FOOTER_LINK", LinkProviderUtils.getRedirectUrl("notification_settings", receiver.getRemoteId()));
+      templateContext.put("COMPANY_LINK", LinkProviderUtils.getBaseUrl());
       String subject = TemplateUtils.processSubject(templateContext);
       String body = TemplateUtils.processGroovy(templateContext);
       // binding the exception throws by processing template


### PR DESCRIPTION
Prior to this fix, when a user publish an article in a space, notification mail content is truncated : no name displayed, the bottom border isn't displayed,
This problem is caused by a missing company link attribute.
This fix add the missing information to render correctely the mail template.