### PR TITLE
 fix: Newslist display on right block - EXO-71852

### DIFF
--- a/webapp/src/main/webapp/news-list-view/components/views/NewsListTemplateView.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsListTemplateView.vue
@@ -64,12 +64,13 @@ export default {
     showArticleDate: true,
     showArticleReactions: true,
     canPublishNews: false,
-    parentWidth: 0
+    parentWidth: 0,
+    widthItemNews: 270
   }),
   computed: {
     numberOfColumns(){
-      const thresholds = this.$vuetify.breakpoint?.thresholds;
-      return this.parentWidth < thresholds.sm ? 12 : this.parentWidth < thresholds.md ? 6 : this.parentWidth < thresholds.lg ? 4 : 3;
+      const nomberOfItem = Math.floor(this.parentWidth / this.widthItemNews);
+      return (nomberOfItem > 0) ? (12 / nomberOfItem) : 12;
     }
   },
   created() {


### PR DESCRIPTION
Before this change, when add on home page two columns, in the left one add the news list view application with display template News List set the column width to 70% and in the right column add news list view application and set the column width to 30% then publish some articles and check their display in new list view, articles are displayed one under the other in the left column. After this change, In left column articles is displayed in respect to the news list template in three columns and in the right column articles is displayed in respect to the news list template in one column.

(cherry picked from commit b12dc3fc79910221aede3af848f78e7e3eff3c33) (cherry picked from commit bb7cf83f010b0e9c546036cedf7e253997790fbc)