### PR TITLE
fix: News article's title isn't displayed in related email notification's content - EXO-72226

### DIFF
--- a/services/src/main/resources/locale/portlet/news/News_de.properties
+++ b/services/src/main/resources/locale/portlet/news/News_de.properties
@@ -101,7 +101,7 @@ news.unarchive.confirm=Dieser Artikel wird unarchiviert und verf\u00fcgbar f\u00
 news.unarchive.success=Der Artikel wurde erfolgreich dearchiviert
 news.unarchive.error=Ein Fehler beim Dearchivieren des Artikels ist aufgetreten. Bitte wiederholen, und wenn der Fehler trotzdem besteht, bitte kontaktieren Sie Ihren Administrator.
 
-news.notification.description={0} hat im {2} Raum einen Artikel gepostet:
+news.notification.description={0} hat im {2} Raum einen Artikel gepostet: "{1}"
 news.notification.description.mention.in.news=Sie wurden im Artikel "{0} " erw\u00e4hnt
 news.notification.description.publish.news={0} hat den Artikel "{1} " ver\u00f6ffentlicht
 news.notification.title=Neuer Artikel wurde in {0} ver\u00f6ffentlicht

--- a/services/src/main/resources/locale/portlet/news/News_en.properties
+++ b/services/src/main/resources/locale/portlet/news/News_en.properties
@@ -101,9 +101,9 @@ news.unarchive.confirm=This article will be unarchived and become available for 
 news.unarchive.success=The article was successfully unarchived
 news.unarchive.error=An error occurred when trying to unarchive this article. Try again, if the error persists, please contact your administrator.
 
-news.notification.description={0} has posted  in the {2} space an article:
+news.notification.description={0} has posted  in the {2} space an article: "{1}"
 news.notification.description.mention.in.news=You have been mentioned in the article:
-news.notification.description.publish.news={0} has published the article:
+news.notification.description.publish.news={0} has published the article "{1}"
 news.notification.title=New article posted in {0}
 news.notification.title.mention.in.news=You have been mentioned in the article "{0}"
 news.notification.title.published.news=New article published

--- a/services/src/main/resources/locale/portlet/news/News_fr.properties
+++ b/services/src/main/resources/locale/portlet/news/News_fr.properties
@@ -101,7 +101,7 @@ news.unarchive.confirm=Cet article ne sera plus archiv\u00e9 et il sera de nouve
 news.unarchive.success=Cet article est de nouveau visible
 news.unarchive.error=Une erreur est apparue lorsque vous avez essay\u00e9 de rendre \u00e0 nouveau visible l'article. Essayez encore et si l'erreur persiste, veuillez contacter votre administrateur.
 
-news.notification.description={0} a publi\u00e9 un article dans l'espace {2} : 
+news.notification.description={0} a publi\u00e9 un article dans l'espace {2} : "{1}"
 news.notification.description.mention.in.news=Vous avez \u00e9t\u00e9 mentionn\u00e9 dans l'article :
 news.notification.description.publish.news={0} a diffus\u00e9 l'article "{1}"
 news.notification.title=Un nouvel article est publi\u00e9 dans {0}


### PR DESCRIPTION
Before this fix, when a user posts OR/AND publishes a news article, related email notification's content received doesn't display the article title for the cases below: 

- Published article: email's content doesn't display article's title for English users 
- Posted article: email's content doesn't display article's title for all fr&en users 

This error comes from the missing news article title's variable in related translations keys.

After this fix, both fr&en users receive news article email notifications displaying article's title in content.