### PR TITLE
fix: Space publisher is able to choose all space members as target audience - EXO-71975 - Meeds-io/meeds#2199

### DIFF
--- a/webapp/src/main/webapp/components/targetSelector/ExoNewsTargetsSelector.vue
+++ b/webapp/src/main/webapp/components/targetSelector/ExoNewsTargetsSelector.vue
@@ -189,6 +189,9 @@ export default {
       }
     });
     this.selectedTargets = this.news.targets;
+    if (this.selectedTargets.length > 0) {
+          this.selectAudience(this.selectedTargets);
+    }
     this.$nextTick(() => this.isDataInitialized = true);
   },
   watch: {

--- a/webapp/src/main/webapp/components/targetSelector/ExoNewsTargetsSelector.vue
+++ b/webapp/src/main/webapp/components/targetSelector/ExoNewsTargetsSelector.vue
@@ -190,7 +190,7 @@ export default {
     });
     this.selectedTargets = this.news.targets;
     if (this.selectedTargets.length > 0) {
-          this.selectAudience(this.selectedTargets);
+      this.selectAudience(this.selectedTargets);
     }
     this.$nextTick(() => this.isDataInitialized = true);
   },


### PR DESCRIPTION
Before this change, when publish an article, as user is publisher in spacex, in newsTarget audience is preselected (only space members) and click on publish from menu action of the article, audience dropdown is enabled and publisher can choose all users. After this change, audience limitation is maintained.

(cherry picked from commit https://github.com/Meeds-io/content/commit/0e912a999447548c78f7bef03b119e369b7926c3)