### PR TITLE
fix: Search news by title or summary is not working - EXO-72721

### DIFF
--- a/services/src/main/java/org/exoplatform/news/search/NewsESSearchConnector.java
+++ b/services/src/main/java/org/exoplatform/news/search/NewsESSearchConnector.java
@@ -54,7 +54,7 @@ public class NewsESSearchConnector {
 
   public static final String           SEARCH_QUERY_TERM            = "\"must\":{" +
       "  \"query_string\":{" +
-      "    \"fields\": [\"body\", \"posterName\"]," +
+      "    \"fields\": [\"body\", \"posterName\", \"summary\",\"title\"]," +
       "    \"default_operator\": \"AND\"," +
       "    \"query\": \"@term@\"" +
       "  }" +


### PR DESCRIPTION
Before this fix, when searching a new with a term in the title or in the summary was not working This is because the ES search query search only in body and posterName This commit add the search in summary and title