### PR TITLE
fix: Resize of image in scheduled news lead to no display in news list - EXO-73978.

### DIFF
--- a/services/src/main/java/org/exoplatform/news/storage/jcr/JcrNewsStorage.java
+++ b/services/src/main/java/org/exoplatform/news/storage/jcr/JcrNewsStorage.java
@@ -1233,6 +1233,9 @@ public class JcrNewsStorage implements NewsStorage {
       ExtendedNode image = null;
       if (imageSrcRegex.equals(IMAGE_SRC_REGEX)) {
         String imageUUID = match.substring(match.lastIndexOf("/") + 1);
+        if (imageUUID.contains("width") || imageUUID.contains("height")) {
+          imageUUID = imageUUID.substring(0,imageUUID.lastIndexOf(" ")-1);
+        }
         image = (ExtendedNode) getNodeById(imageUUID, sessionProvider);
       } else {
         String imagePath = match.substring(match.indexOf("/Groups"));


### PR DESCRIPTION
Before this change, when start to create an article in spacex then insert an image in the body the resize it and schedule the publish of news1 in a news list then save once the time of publish is reached check your news list, news1 isn' t displayed. After this change, news1 is displayed in the related news list.