### PR TITLE
fix: News Slider - Mouse hover makes article content misplaced - EXO-75170 - Meeds-io/meeds#255

### DIFF
--- a/webapp/src/main/webapp/news-list-view/components/views/NewsSliderView.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsSliderView.vue
@@ -50,7 +50,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                   v-if="showArticleTitle"
                   :href="articleUrl(item)"
                   class="flex flex-row flex-grow-1 align-center justify-center headLinesTruncate"
-                  :class="extraClass.concat(canPublishNews && !hover ? 'mt-12' : '')">
+                  :class="extraClass.concat(canPublishNews ? 'mt-12' : '')">
               <span class="text-h4 font-weight-medium white--text text-truncate-2">
                 {{ item.title }}
               </span>


### PR DESCRIPTION
Before this change, when create news target targeta choosing slider template then publish some news articles in targeta and hover over the targeta sliding articles, article titles and displayed information position changes. To resolve this problem, remove the hover condition to apply class m-12. After this change, article titles keep centered.

(cherry picked from commit https://github.com/Meeds-io/content/commit/b03739d0867f815b252e6c726765097e5dc6cda7)