### PR TITLE
fix: Unexpected Notes/News bottom white line added on each update - EXO - 75342 - Meeds-io/meeds#2594

### DIFF
--- a/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
+++ b/webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsActivityComposer.vue
@@ -609,6 +609,7 @@ export default {
         colorButton_enableMore: true,
         enterMode: CKEDITOR.ENTER_P,
         shiftEnterMode: CKEDITOR.ENTER_BR,
+        autoParagraph: false,
         sharedSpaces: {
           top: 'newsTop'
         },


### PR DESCRIPTION
Before this change, when edit same notes/news by adding some content and save, on each update, an additional empty line is added. To resolve this problem, add an autoParagraph property of value false in the ckeditor. After this change, no additional empty line is added.

(cherry picked from commit https://github.com/Meeds-io/notes/commit/fa8814235c3b5d812c04ccc524bf8fa7775a4324)