### PR TITLE
fix: News Slider - Mouse hover makes article content misplaced - EXO-75170 - Meeds-io/meeds#255

### DIFF
--- a/webapp/src/main/webapp/news-list-view/components/views/NewsSliderView.vue
+++ b/webapp/src/main/webapp/news-list-view/components/views/NewsSliderView.vue
@@ -36,7 +36,9 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
               eager />
           <v-container class="slide-text-container d-flex text-center body-2">
             <div class="flex flex-column carouselNewsInfo">
-              <div class="flex flex-row">
+              <div
+                :class="$vuetify.rtl && 'l-0' || 'r-0'"
+                class="flex flex-row position-absolute">
                 <v-btn
                   v-if="canPublishNews && hover"
                   :aria-label="$t('news.latest.openSettings')"


### PR DESCRIPTION
Before this change, when create news target targeta choosing slider template then publish some news articles in target and hover over the target sliding articles, article titles and displayed information position changes. To resolve this problem, need to apply position absolute to the slider news info div. After this change, article titles keep centered.